### PR TITLE
Disable scalar operations on CuArrays

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -113,6 +113,13 @@ macro hascuda(ex)
     return HAVE_CUDA ? :($(esc(ex))) : :(nothing)
 end
 
+@hascuda begin
+    println("CUDA-enabled GPU(s) detected:")
+    for (gpu, dev) in enumerate(CUDAnative.devices())
+        println(dev)
+    end
+end
+
 abstract type Metadata end
 abstract type ConstantsCollection end
 abstract type EquationOfState end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -120,6 +120,8 @@ end
     end
 end
 
+@hascuda CuArrays.allowscalar(false)
+
 abstract type Metadata end
 abstract type ConstantsCollection end
 abstract type EquationOfState end

--- a/src/models.jl
+++ b/src/models.jl
@@ -62,7 +62,9 @@ function Model(;
     output_writers = OutputWriter[],
        diagnostics = Diagnostic[]
 )
-
+    
+    arch == :GPU && !HAVE_CUDA && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
+    
     # Initialize model basics.
          metadata = ModelMetadata(arch, float_type)
     configuration = ModelConfiguration(νh, νv, κh, κv)


### PR DESCRIPTION
Also:
* Print available `CuDevice`s at startup
* Throw `ArgumentError` when attempting to construct a `Model{GPU}` when no CUDA-enabled GPU is detected.

Resolves #82 