### PR TITLE
NaN checker diagnostic

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -86,6 +86,7 @@ export
     Diagnostic,
     run_diagnostic,
     FieldSummary,
+    NaNChecker,
     Nusselt_wT,
     Nusselt_Chi,
 


### PR DESCRIPTION
A NaN checker diagnostic that aborts the simulation when NaN values are detected.

We could have some shell script that look for this and sends an email or something. Julia could do this too but then we'd add a big dependency for a small diagnostic.

Resolves #38 