### PR TITLE
Test for GPU Poisson solver

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -55,6 +55,9 @@ export
     Default,
     Flux,
     Gradient,
+    Value,
+    getbc,
+    setbc!,
 
     # Time stepping
     time_step!,

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -153,41 +153,20 @@ Notes:
 @inline ∇κ∇ϕ_t(κ, ϕt, ϕt₋₁, flux, ΔzC, ΔzF) = (      -flux        - κ*(ϕt - ϕt₋₁)/ΔzC ) / ΔzF
 @inline ∇κ∇ϕ_b(κ, ϕb, ϕb₊₁, flux, ΔzC, ΔzF) = ( κ*(ϕb₊₁ - ϕb)/ΔzC +       flux        ) / ΔzF
 
+getbc(bc::BC{C, <:Function},      t, grid, u, v, w, T, S, iteration, i, j) where C = bc.condition(t, grid, u, v, w, T, S, iteration, i, j)
+getbc(bc::BC{C, <:Number},        t, grid, u, v, w, T, S, iteration, i, j) where C = bc.condition
+getbc(bc::BC{C, <:AbstractArray}, t, grid, u, v, w, T, S, iteration, i, j) where C = bc.condition[i, j]
+
 "Add flux divergence to ∂ϕ/∂t associated with a top boundary condition on ϕ."
-@inline apply_z_top_bc!(top_flux::BC{<:Flux, <:Function}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] -= top_flux.condition(t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
+@inline apply_z_top_bc!(top_flux::BC{<:Flux}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
+    Gϕ[i, j, 1] -= getbc(top_flux, t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
 
-@inline apply_z_top_bc!(top_flux::BC{<:Flux, <:Number}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] -= top_flux.condition / grid.Δz
-
-@inline apply_z_top_bc!(top_flux::BC{<:Flux, <:AbstractArray}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] -= top_flux.condition[i, j] / grid.Δz
-
-@inline apply_z_top_bc!(top_gradient::BC{<:Gradient, <:Function}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] += κ*top_gradient.condition(t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
-
-@inline apply_z_top_bc!(top_gradient::BC{<:Gradient, <:Number}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] += κ*top_gradient.condition / grid.Δz
-
-@inline apply_z_top_bc!(top_gradient::BC{<:Gradient, <:AbstractArray}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, 1] += κ*top_gradient.condition[i, j] / grid.Δz
+@inline apply_z_top_bc!(top_gradient::BC{<:Gradient}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
+    Gϕ[i, j, 1] += κ * getbc(top_gradient, t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
 
 "Add flux divergence to ∂ϕ/∂t associated with a bottom boundary condition on ϕ."
-@inline apply_z_bottom_bc!(bottom_flux::BC{<:Flux, <:Function}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] += bottom_flux.condition(t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
+@inline apply_z_bottom_bc!(bottom_flux::BC{<:Flux}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
+    Gϕ[i, j, grid.Nz] += getbc(bottom_flux, t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
 
-@inline apply_z_bottom_bc!(bottom_flux::BC{<:Flux, <:Number}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] += bottom_flux.condition / grid.Δz
-
-@inline apply_z_bottom_bc!(bottom_flux::BC{<:Flux, <:AbstractArray}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] += bottom_flux.condition[i, j] / grid.Δz
-
-@inline apply_z_bottom_bc!(bottom_gradient::BC{<:Gradient, <:Function}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] -= κ*bottom_gradient.condition(t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz
-
-@inline apply_z_bottom_bc!(bottom_gradient::BC{<:Gradient, <:Number}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] -= κ*bottom_gradient.condition / grid.Δz
-
-@inline apply_z_bottom_bc!(bottom_gradient::BC{<:Gradient, <:AbstractArray}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
-    Gϕ[i, j, grid.Nz] -= κ*bottom_gradient.condition[i, j] / grid.Δz
-
+@inline apply_z_bottom_bc!(bottom_gradient::BC{<:Gradient}, ϕ, Gϕ, κ, t, grid, u, v, w, T, S, iteration, i, j) =
+    Gϕ[i, j, grid.Nz] -= κ * getbc(bottom_gradient, t, grid, u, v, w, T, S, iteration, i, j) / grid.Δz

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -345,9 +345,9 @@ apply_bcs!(::GPU, ::Val{:z}, Bx, By, Bz,
 
 # First, dispatch on coordinate.
 apply_bcs!(arch, ::Val{:x}, Bx, By, Bz, args...) =
-    @launch device(arch) apply_x_bcs!(args..., threads=(Tx, Ty), blocks=(Bx, By, Bz))
+    @launch device(arch) apply_x_bcs!(args..., threads=(Tx, Ty), blocks=(By, Bz))
 apply_bcs!(arch, ::Val{:y}, Bx, By, Bz, args...) =
-    @launch device(arch) apply_y_bcs!(args..., threads=(Tx, Ty), blocks=(Bx, By, Bz))
+    @launch device(arch) apply_y_bcs!(args..., threads=(Tx, Ty), blocks=(Bx, Bz))
 apply_bcs!(arch, ::Val{:z}, Bx, By, Bz, args...) =
     @launch device(arch) apply_z_bcs!(args..., threads=(Tx, Ty), blocks=(Bx, By))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,14 +264,19 @@ float_types = (Float32, Float64)
         Nx, Ny, Nz = 3, 4, 5 # for simple test
         funbc(args...) = π
 
-        for fld in (:u, :v, :T, :S)
-            for bctype in (Gradient, Flux)
-                for bc in (0.6, rand(Nx, Ny), funbc)
-                    @test test_z_boundary_condition_simple(fld, bctype, bc, Nx, Ny, Nz)
+        for arch in archs
+            for TF in float_types
+                for fld in (:u, :v, :T, :S)
+                    for bctype in (Gradient, Flux, Value)
+                        for bc in (TF(0.6), rand(Nx, Ny), funbc)
+                            @test test_z_boundary_condition_simple(arch, TF, fld, bctype, bc, Nx, Ny, Nz)
+                        end
+                    end
+                    @test test_z_boundary_condition_top_bottom_alias(arch, TF, fld, Nx, Ny, Nz)
+                    @test test_z_boundary_condition_array(arch, TF, fld, Nx, Ny, Nz)
+                    @test test_flux_budget(arch, TF, fld)
                 end
             end
-
-            @test test_flux_budget(fld)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using
     Test,
+    Statistics,
     Oceananigans,
     Oceananigans.Operators,
     Oceananigans.TurbulenceClosures
@@ -8,6 +9,7 @@ import FFTW
 
 archs = (CPU(),)
 @hascuda archs = (CPU(), GPU())
+@hascuda using CuArrays
 
 float_types = (Float32, Float64)
 
@@ -261,19 +263,25 @@ float_types = (Float32, Float64)
         println("  Testing boundary conditions...")
         include("test_boundary_conditions.jl")
 
-        Nx, Ny, Nz = 3, 4, 5 # for simple test
         funbc(args...) = π
 
+        Nx = Ny = 16
         for arch in archs
             for TF in float_types
                 for fld in (:u, :v, :T, :S)
                     for bctype in (Gradient, Flux, Value)
-                        for bc in (TF(0.6), rand(Nx, Ny), funbc)
-                            @test test_z_boundary_condition_simple(arch, TF, fld, bctype, bc, Nx, Ny, Nz)
+
+                        arraybc = rand(TF, Nx, Ny)
+                        if arch == GPU()
+                            arraybc = CuArray(arraybc)
+                        end
+
+                        for bc in (TF(0.6), arraybc, funbc)
+                            @test test_z_boundary_condition_simple(arch, TF, fld, bctype, bc, Nx, Ny)
                         end
                     end
-                    @test test_z_boundary_condition_top_bottom_alias(arch, TF, fld, Nx, Ny, Nz)
-                    @test test_z_boundary_condition_array(arch, TF, fld, Nx, Ny, Nz)
+                    @test test_z_boundary_condition_top_bottom_alias(arch, TF, fld)
+                    @test test_z_boundary_condition_array(arch, TF, fld)
                     @test test_flux_budget(arch, TF, fld)
                 end
             end

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,23 +1,51 @@
-function test_z_boundary_condition_simple(field_name, bctype, bc, Nx, Ny, Nz)
+function test_z_boundary_condition_simple(arch, TF, field_name, bctype, bc, Nx, Ny, Nz)
     Lx, Ly, Lz = 0.1, 0.2, 0.3
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz))
+    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
 
     bc = BoundaryCondition(bctype, bc)
     bcs = getfield(model.boundary_conditions, field_name)
-    bcs.z.right = bc # just set a boundary condition somewhere
+    bcs.z.top = bc # just set a boundary condition somewhere
 
     time_step!(model, 1, 1e-16)
+
     typeof(model) <: Model
 end
 
+function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name, Nx, Ny, Nz)
+    Lx, Ly, Lz = 0.1, 0.2, 0.3
+    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
 
-function test_flux_budget(field_name)
+    bcval = 1.0
+    bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.top = BoundaryCondition(Value, bcval)
+    bcs.z.bottom = BoundaryCondition(Value, -bcval)
+
+    time_step!(model, 1, 1e-16)
+
+    getbc(bcs.z.top) == bcval && getbc(bcs.z.bottom) == -bcval
+end
+
+function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
+    Lx, Ly, Lz = 0.1, 0.2, 0.3
+    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
+
+    bcarray = rand(Nx, Ny)
+    bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.top = BoundaryCondition(Value, bcarray)
+
+    time_step!(model, 1, 1e-16)
+
+    getbc(bcs.z.top, 1, 2) == bcarray[1, 2]
+end
+
+function test_flux_budget(arch, TF, field_name)
     Nx, Ny, Nz = 1, 1, 16
     Lx, Ly, Lz = 1, 1, 0.7
     κ = 1
     eos = LinearEquationOfState(βS=0, βT=0)
 
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=κ, κ=κ, eos=eos)
+    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=κ, κ=κ, eos=eos,
+        arch=arch, float_type=TF)
 
     if field_name ∈ (:u, :v, :w)
         field = getfield(model.velocities, field_name)
@@ -27,10 +55,10 @@ function test_flux_budget(field_name)
 
     @. field.data = 0
 
-    bottom_flux = 0.3
+    bottom_flux = TF(0.3)
     flux_bc = BoundaryCondition(Flux, bottom_flux)
     bcs = getfield(model.boundary_conditions, field_name)
-    bcs.z.right = flux_bc # "right" = "bottom" in the convention where k=Nz is the bottom.
+    bcs.z.bottom = flux_bc # "right" = "bottom" in the convention where k=Nz is the bottom.
 
     mean_init = mean(field.data)
 

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,17 +1,19 @@
-function test_z_boundary_condition_simple(arch, TF, field_name, bctype, bc, Nx, Ny, Nz)
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
+function test_z_boundary_condition_simple(arch, T, field_name, bctype, bc, Nx, Ny)
+    Nz = 16 
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T)
 
     bc = BoundaryCondition(bctype, bc)
     bcs = getfield(model.boundary_conditions, field_name)
-    bcs.z.top = bc # just set a boundary condition somewhere
+    bcs.z.top = bc
 
     time_step!(model, 1, 1e-16)
 
     typeof(model) <: Model
 end
 
-function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name, Nx, Ny, Nz)
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
+function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name)
+    N = 16
+    model = Model(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
 
     bcval = 1.0
     bcs = getfield(model.boundary_conditions, field_name)
@@ -23,10 +25,15 @@ function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name, Nx, Ny
     getbc(bcs.z.top) == bcval && getbc(bcs.z.bottom) == -bcval
 end
 
-function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
+function test_z_boundary_condition_array(arch, T, field_name)
+    Nx = Ny = Nz = 16
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T)
 
-    bcarray = rand(Nx, Ny)
+    bcarray = rand(T, Nx, Ny)
+    if arch == GPU()
+        bcarray = CuArray(bcarray)
+    end
+
     bcs = getfield(model.boundary_conditions, field_name)
     bcs.z.top = BoundaryCondition(Value, bcarray)
 
@@ -36,8 +43,8 @@ function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
 end
 
 function test_flux_budget(arch, TF, field_name)
-    κ, Lz = 1, 0.7
-    model = Model(N=(1, 1, 16), L=(1, 1, Lz), ν=κ, κ=κ,
+    N, κ, Lz = 16, 1, 0.7
+    model = Model(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ,
         arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0))
 
     if field_name ∈ (:u, :v, :w)

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -32,12 +32,13 @@ function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
 
     time_step!(model, 1, 1e-16)
 
-    getbc(bcs.z.top, 1, 2) == bcarray[1, 2]
+    bcs.z.top[1, 2] == bcarray[1, 2]
 end
 
 function test_flux_budget(arch, TF, field_name)
-    model = Model(N=(1, 1, 16), L=(1, 1, 0.7), ν=1, κ=1,
-        arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0)
+    κ, Lz = 1, 0.7
+    model = Model(N=(1, 1, 16), L=(1, 1, Lz), ν=κ, κ=κ,
+        arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0))
 
     if field_name ∈ (:u, :v, :w)
         field = getfield(model.velocities, field_name)
@@ -62,5 +63,5 @@ function test_flux_budget(arch, TF, field_name)
 
     # budget is Lz * ∂<ϕ>/∂t = -Δflux = -top_flux/Lz (left) + bottom_flux/Lz (right);
     # therefore <ϕ> = bottom_flux * t / Lz
-    isapprox(mean(field.data) - mean_init, bottom_flux*model.clock.time/Lz)
+    isapprox(mean(field.data) - mean_init, bottom_flux * model.clock.time / Lz)
 end

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,6 +1,5 @@
 function test_z_boundary_condition_simple(arch, TF, field_name, bctype, bc, Nx, Ny, Nz)
-    Lx, Ly, Lz = 0.1, 0.2, 0.3
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
 
     bc = BoundaryCondition(bctype, bc)
     bcs = getfield(model.boundary_conditions, field_name)
@@ -12,8 +11,7 @@ function test_z_boundary_condition_simple(arch, TF, field_name, bctype, bc, Nx, 
 end
 
 function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name, Nx, Ny, Nz)
-    Lx, Ly, Lz = 0.1, 0.2, 0.3
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
 
     bcval = 1.0
     bcs = getfield(model.boundary_conditions, field_name)
@@ -26,8 +24,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name, Nx, Ny
 end
 
 function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
-    Lx, Ly, Lz = 0.1, 0.2, 0.3
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=TF)
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
 
     bcarray = rand(Nx, Ny)
     bcs = getfield(model.boundary_conditions, field_name)
@@ -39,13 +36,8 @@ function test_z_boundary_condition_array(arch, TF, field_name, Nx, Ny, Nz)
 end
 
 function test_flux_budget(arch, TF, field_name)
-    Nx, Ny, Nz = 1, 1, 16
-    Lx, Ly, Lz = 1, 1, 0.7
-    κ = 1
-    eos = LinearEquationOfState(βS=0, βT=0)
-
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=κ, κ=κ, eos=eos,
-        arch=arch, float_type=TF)
+    model = Model(N=(1, 1, 16), L=(1, 1, 0.7), ν=1, κ=1,
+        arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0)
 
     if field_name ∈ (:u, :v, :w)
         field = getfield(model.velocities, field_name)
@@ -58,7 +50,7 @@ function test_flux_budget(arch, TF, field_name)
     bottom_flux = TF(0.3)
     flux_bc = BoundaryCondition(Flux, bottom_flux)
     bcs = getfield(model.boundary_conditions, field_name)
-    bcs.z.bottom = flux_bc # "right" = "bottom" in the convention where k=Nz is the bottom.
+    bcs.z.bottom = flux_bc
 
     mean_init = mean(field.data)
 


### PR DESCRIPTION
This "PR" adapts one of the CPU Poisson solver tests to the GPU. The test fails. 

Hopefully there is a bug in the test. If so, it should be fixed so that we have a valid test for the GPU Poisson solver.

I suggest we use just one solver for both the CPU and the GPU --- unifying those could be in the scope of this PR.

It'll also be nice to have one function that returns the (real) solution to the Poisson equation, given complex input. 

Our algorithm (for Periodic-Periodic-Neumann --- this would not be the case for Periodic-Periodic-Periodic) requires one temporary storage variable (which stores a permuted, complex version of the solution) that should be part of the `PPNPoissonSolver` struct (see what I did there?)