### PR TITLE
Bugfix in Model constructor

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -65,7 +65,7 @@ function Model(;
     arch == GPU() && !HAVE_CUDA && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
 
     # Initialize model basics.
-    configuration = ModelConfiguration(νh, νv, κh, κv)
+    configuration = ModelConfiguration(κh, κv, νh, νv)
              grid = RegularCartesianGrid(float_type, N, L)
             clock = Clock{float_type}(start_time, iteration)
 


### PR DESCRIPTION
This PR fixes a bug in the `Model` constructor that swapped the user-specified viscous and diffusive coefficients when constructing the `ModelConfiguration` object.