### PR TITLE
Test that the GPU Poisson solver solution is numerically divergence-free

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,6 +211,13 @@ float_types = (Float32, Float64)
             for Nx in Ns, Ny in Ns, Nz in Ns, ft in float_types
                 @test poisson_ppn_planned_div_free_cpu(ft, Nx, Ny, Nz, FFTW.ESTIMATE)
             end
+
+            @hascuda begin
+                for ft in float_types
+                    @test poisson_ppn_planned_div_free_gpu(ft, 16, 16, 16)
+                    @test poisson_ppn_planned_div_free_gpu(ft, 32, 32, 32)
+                end
+            end
         end
 
         @testset "Analytic solution reconstruction" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,6 +216,8 @@ float_types = (Float32, Float64)
                 for ft in float_types
                     @test poisson_ppn_planned_div_free_gpu(ft, 16, 16, 16)
                     @test poisson_ppn_planned_div_free_gpu(ft, 32, 32, 32)
+                    @test poisson_ppn_planned_div_free_gpu(ft, 32, 32, 16)
+                    @test poisson_ppn_planned_div_free_gpu(ft, 16, 32, 24)
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,10 @@ float_types = (Float32, Float64)
             for Nx in Ns, Ny in Ns, Nz in Ns, ft in float_types
                 @test poisson_ppn_planned_div_free_cpu(ft, Nx, Ny, Nz, FFTW.ESTIMATE)
             end
+        end
 
+        @testset "Divergence-free solution [GPU]" begin
+            println("    Testing divergence-free solution [GPU]...")
             @hascuda begin
                 for ft in float_types
                     @test poisson_ppn_planned_div_free_gpu(ft, 16, 16, 16)

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -3,6 +3,7 @@ using Statistics: mean
 using LinearAlgebra: norm
 
 import GPUifyLoops: @launch, @loop, @unroll, @synchronize
+@hascuda using CuArrays
 
 using Oceananigans.Operators
 
@@ -90,7 +91,7 @@ function poisson_ppn_planned_div_free_gpu(ft, Nx, Ny, Nz)
     solve_poisson_3d_ppn_gpu_planned!(Tx, Ty, Bx, By, Bz, solver, grid, RHS, ϕ)
 
     # Undoing the permutation made above to complete the IDCT.
-    ϕ.data .= CuArray{eltype(ϕ.data)}(reshape(permutedims(cat(ϕ.data[:, :, 1:Int(Nz/2)], f[:, :, end:-1:Int(Nz/2)+1]; dims=4), (1, 2, 4, 3)), Nx, Ny, Nz))
+    ϕ.data .= CuArray{eltype(ϕ.data)}(reshape(permutedims(cat(ϕ.data[:, :, 1:Int(Nz/2)], ϕ.data[:, :, end:-1:Int(Nz/2)+1]; dims=4), (1, 2, 4, 3)), Nx, Ny, Nz))
     @. ϕ.data = real(ϕ.data)
 
     ∇²_ppn!(grid, ϕ, ∇²ϕ)

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -96,7 +96,7 @@ function poisson_ppn_planned_div_free_gpu(ft, Nx, Ny, Nz)
 
     ∇²_ppn!(grid, ϕ, ∇²ϕ)
 
-    ∇²ϕ.data ≈ RHS_orig.data
+    Array(∇²ϕ.data) ≈ Array(RHS_orig.data)
 end
 
 """


### PR DESCRIPTION
Until the CPU and GPU Poisson solvers are unified this should give us confidence that the GPU Poisson solver is doing its job.

Found it easier to write the test independently so this supersedes PR #238 

Resolves #200