### PR TITLE
[WIP] Proposal threads-blocks layout abstraction

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -135,21 +135,21 @@ struct CPU <: Architecture end
 
 # A slightly complex (but fully-featured?) implementation:
 
-struct Layout{NT, NB}
+struct ThreadBlockLayout{NT, NB}
     threads :: NTuple{NT, Int}
      blocks :: NTuple{NB, Int}
 end
 
-XYZLayout(threads, grid) = Layout(threads, 
+XYZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
     (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny), grid.Nz) )
 
-XYLayout(threads, grid) = Layout(threads,
+XYThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
     (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny)) )
 
-XZLayout(threads, grid) = Layout(threads,
+XZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
     (floor(Int, threads[1]/grid.Nx), grid.Nz) )
 
-YZLayout(threads, grid) = Layout(threads, 
+YZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
     (floor(Int, threads[2]/grid.Ny), grid.Nz) )
 
 struct GPU{XYZ, XY, XZ, YZ} <: Architecture
@@ -160,8 +160,8 @@ struct GPU{XYZ, XY, XZ, YZ} <: Architecture
 end
 
 GPU(grid; threads=(16, 16)) = GPU(
-    XYZLayout(threads, grid), XYLayout(threads, grid),
-     XZLayout(threads, grid), YZLayout(threads, grid) )
+    XYZThreadBlockLayout(threads, grid), XYThreadBlockLayout(threads, grid),
+     XZThreadBlockLayout(threads, grid), YZThreadBlockLayout(threads, grid) )
 
 GPU() = GPU(nothing, nothing, nothing, nothing) # stopgap while code is unchanged.
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -9,6 +9,7 @@ export
     HAVE_CUDA,
     @hascuda,
 
+    # Architectures
     Architecture,
     CPU,
     GPU,
@@ -130,53 +131,6 @@ macro hascuda(ex)
     return HAVE_CUDA ? :($(esc(ex))) : :(nothing)
 end
 
-abstract type Architecture end
-struct CPU <: Architecture end
-
-# A slightly complex (but fully-featured?) implementation:
-
-struct ThreadBlockLayout{NT, NB}
-    threads :: NTuple{NT, Int}
-     blocks :: NTuple{NB, Int}
-end
-
-XYZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
-    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny), grid.Nz) )
-
-XYThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
-    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny)) )
-
-XZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
-    (floor(Int, threads[1]/grid.Nx), grid.Nz) )
-
-YZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
-    (floor(Int, threads[2]/grid.Ny), grid.Nz) )
-
-struct GPU{XYZ, XY, XZ, YZ} <: Architecture
-    xyz :: XYZ
-     xy :: XY
-     xz :: XZ
-     yz :: YZ
-end
-
-GPU(grid; threads=(16, 16)) = GPU(
-    XYZThreadBlockLayout(threads, grid), XYThreadBlockLayout(threads, grid),
-     XZThreadBlockLayout(threads, grid), YZThreadBlockLayout(threads, grid) )
-
-GPU() = GPU(nothing, nothing, nothing, nothing) # stopgap while code is unchanged.
-
-# Functions permitting generalization:
-threads(geom, arch) = nothing
- blocks(geom, arch) = nothing
-
-threads(geom, arch::GPU) = getproperty(getproperty(arch, geom), :threads)
- blocks(geom, arch::GPU) = getproperty(getproperty(arch, geom), :blocks)
-
-# @launch looks like xyz_kernel(args..., threads=threads(:xyz, arch), blocks=blocks(:xyz, arch))
-# etc.
-
-device(::CPU) = GPUifyLoops.CPU()
-device(::GPU) = GPUifyLoops.CUDA()
 
 @hascuda begin
     println("CUDA-enabled GPU(s) detected:")
@@ -187,6 +141,7 @@ end
 
 # @hascuda CuArrays.allowscalar(false)
 
+abstract type Architecture end
 abstract type Metadata end
 abstract type ConstantsCollection end
 abstract type EquationOfState end
@@ -198,6 +153,7 @@ abstract type OutputWriter end
 abstract type Diagnostic end
 abstract type AbstractPoissonSolver end
 
+include("architectures.jl")
 include("utils.jl")
 
 include("model_configuration.jl")

--- a/src/architectures.jl
+++ b/src/architectures.jl
@@ -1,0 +1,47 @@
+struct CPU <: Architecture end
+
+# A slightly complex (but fully-featured?) implementation:
+
+struct ThreadBlockLayout{NT, NB}
+    threads :: NTuple{NT, Int}
+     blocks :: NTuple{NB, Int}
+end
+
+XYZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
+    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny), grid.Nz) )
+
+XYThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
+    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny)) )
+
+XZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads,
+    (floor(Int, threads[1]/grid.Nx), grid.Nz) )
+
+YZThreadBlockLayout(threads, grid) = ThreadBlockLayout(threads, 
+    (floor(Int, threads[2]/grid.Ny), grid.Nz) )
+
+struct GPU{XYZ, XY, XZ, YZ} <: Architecture
+    xyz :: XYZ
+     xy :: XY
+     xz :: XZ
+     yz :: YZ
+end
+
+GPU(grid; threads=(16, 16)) = GPU(
+    XYZThreadBlockLayout(threads, grid), XYThreadBlockLayout(threads, grid),
+     XZThreadBlockLayout(threads, grid), YZThreadBlockLayout(threads, grid) )
+
+GPU() = GPU(nothing, nothing, nothing, nothing) # stopgap while code is unchanged.
+
+# Functions permitting generalization:
+threads(geom, arch) = nothing
+ blocks(geom, arch) = nothing
+
+threads(geom, arch::GPU) = getproperty(getproperty(arch, geom), :threads)
+ blocks(geom, arch::GPU) = getproperty(getproperty(arch, geom), :blocks)
+
+# @launch looks like xyz_kernel(args..., threads=threads(:xyz, arch), blocks=blocks(:xyz, arch))
+# etc.
+
+device(::CPU) = GPUifyLoops.CPU()
+device(::GPU) = GPUifyLoops.CUDA()
+


### PR DESCRIPTION
Check it out. The abstraction, pasted from `Oceananigans.jl` modified in this PR, is:


```julia
struct Layout{NT, NB} 
    threads :: NTuple{NT, Int}
     blocks :: NTuple{NB, Int}
end

XYZLayout(threads, grid) = Layout(threads, 
    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny), grid.Nz) )

XYLayout(threads, grid) = Layout(threads,
    (floor(Int, threads[1]/grid.Nx), floor(Int, threads[2]/grid.Ny)) )

XZLayout(threads, grid) = Layout(threads,
    (floor(Int, threads[1]/grid.Nx), grid.Nz) )

YZLayout(threads, grid) = Layout(threads, 
    (floor(Int, threads[2]/grid.Ny), grid.Nz) )

struct GPU{XYZ, XY, XZ, YZ} <: Architecture
    xyz :: XYZ 
     xy :: XY
     xz :: XZ
     yz :: YZ
end

GPU(grid; threads=(16, 16)) = GPU(
    XYZLayout(threads, grid), XYLayout(threads, grid),
     XZLayout(threads, grid), YZLayout(threads, grid) )

GPU() = GPU(nothing, nothing, nothing, nothing) # stopgap while code is unchanged.

# Functions permitting generalization:
threads(geom, arch) = nothing
 blocks(geom, arch) = nothing

threads(geom, arch::GPU) = getproperty(getproperty(arch, geom), :threads)
 blocks(geom, arch::GPU) = getproperty(getproperty(arch, geom), :blocks)

# @launch looks like xyz_kernel(args..., threads=threads(:xyz, arch), blocks=blocks(:xyz, arch))
# etc.
```

comments, criticism, modification, and rejection are all welcome.