### PR TITLE
Fix examples to account for halos

### DIFF
--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -17,7 +17,6 @@ function informative_message(model, u, w, ℕ)
 end
 
 function makeplot(axs, model, w)
-
     w_num = model.velocities.w
 
     w_ans = FaceFieldZ(w.(xnodes(w_num), ynodes(w_num), znodes(w_num),
@@ -27,9 +26,8 @@ function makeplot(axs, model, w)
 
     sca(axs[1, 1])
 
-    PyPlot.plot(w_ans[1, 1, :], view(znodes(w_num), 1, 1, :),
-        "-", linewidth=2, alpha=0.4)
-    PyPlot.plot(w_num[1, 1, :], view(znodes(w_num), 1, 1, :), "--", linewidth=1)
+    PyPlot.plot(data(w_ans)[1, 1, :], view(znodes(w_num), 1, 1, :),  "-", linewidth=2, alpha=0.4)
+    PyPlot.plot(data(w_num)[1, 1, :], view(znodes(w_num), 1, 1, :), "--", linewidth=1)
 
     xlim(-wmax, wmax)
 
@@ -40,7 +38,7 @@ function makeplot(axs, model, w)
     ylabel(L"z")
 
     sca(axs[2, 1])
-    PyPlot.plot(w_ans[1, 1, :] .- w_num[1, 1, :], view(znodes(w_num), 1, 1, :), "-")
+    PyPlot.plot(data(w_ans)[1, 1, :] .- data(w_num)[1, 1, :], view(znodes(w_num), 1, 1, :), "-")
 
     xlim(-wmax, wmax)
 

--- a/examples/rising_thermal_bubble_2d.jl
+++ b/examples/rising_thermal_bubble_2d.jl
@@ -21,7 +21,7 @@ xC, zC = reshape(xC, (Nx, 1, 1)), reshape(zC, (1, 1, Nz))
 # of the vertical slice. It roughly corresponds to a background temperature of
 # T = 282.99 K and a bubble temperature of T = 283.01 K.
 hot_bubble_perturbation = @. 0.01 * exp(-100 * ((xC - Lx/2)^2 + (zC + Lz/2)^2) / (Lx^2 + Lz^2))
-model.tracers.T.data .= 282.99 .+ 2 .* reshape(hot_bubble_perturbation, (Nx, Ny, Nz))
+data(model.tracers.T) .= 282.99 .+ 2 .* reshape(hot_bubble_perturbation, (Nx, Ny, Nz))
 
 # Add a NetCDF output writer that saves NetCDF files to the current directory
 # "." with a filename prefix of "thermal_bubble_2d_" every 10 iterations.

--- a/examples/rising_thermal_bubble_3d_gpu.jl
+++ b/examples/rising_thermal_bubble_3d_gpu.jl
@@ -21,7 +21,7 @@ xC, yC, zC = reshape(xC, (Nx, 1, 1)), reshape(yC, (Ny, 1, 1)), reshape(zC, (1, 1
 # of the vertical slice. It roughly corresponds to a background temperature of
 # T = 282.99 K and a bubble temperature of T = 283.01 K.
 hot_bubble_perturbation = @. 0.01 * exp(-100 * ((xC - Lx/2)^2 + (yC - Ly/2)^2 + (zC + Lz/2)^2) / (Lx^2 + Ly^2 + Lz^2))
-model.tracers.T.data .= 282.99 .+ 2 .* CuArray(hot_bubble_perturbation)
+data(model.tracers.T) .= 282.99 .+ 2 .* CuArray(hot_bubble_perturbation)
 
 # Add a NetCDF output writer that saves NetCDF files to the current directory
 # "." with a filename prefix of "thermal_bubble_3d_" every 10 iterations.

--- a/examples/utils.jl
+++ b/examples/utils.jl
@@ -14,38 +14,39 @@ znodes(ϕ::FaceFieldZ) = repeat(reshape(ϕ.grid.zF[1:end-1], 1, 1, ϕ.grid.Nz), 
 zerofunk(args...) = 0
 
 function set_ic!(model; u=zerofunk, v=zerofunk, w=zerofunk, T=zerofunk, S=zerofunk)
-    model.velocities.u.data .= u.(xnodes(model.velocities.u), ynodes(model.velocities.u), znodes(model.velocities.u))
-    model.velocities.v.data .= v.(xnodes(model.velocities.v), ynodes(model.velocities.v), znodes(model.velocities.v))
-    model.velocities.w.data .= w.(xnodes(model.velocities.w), ynodes(model.velocities.w), znodes(model.velocities.w))
-    model.tracers.T.data    .= T.(xnodes(model.tracers.T),    ynodes(model.tracers.T),    znodes(model.tracers.T))
-    model.tracers.S.data    .= S.(xnodes(model.tracers.S),    ynodes(model.tracers.S),    znodes(model.tracers.S))
+    Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
+    data(model.velocities.u) .= u.(xnodes(model.velocities.u), ynodes(model.velocities.u), znodes(model.velocities.u))
+    data(model.velocities.v) .= v.(xnodes(model.velocities.v), ynodes(model.velocities.v), znodes(model.velocities.v))
+    data(model.velocities.w) .= w.(xnodes(model.velocities.w), ynodes(model.velocities.w), znodes(model.velocities.w))
+    data(model.tracers.T)    .= T.(xnodes(model.tracers.T),    ynodes(model.tracers.T),    znodes(model.tracers.T))
+    data(model.tracers.S)    .= S.(xnodes(model.tracers.S),    ynodes(model.tracers.S),    znodes(model.tracers.S))
     return nothing
 end
 
 plotxzslice(ϕ, slice=1, args...; kwargs...) = pcolormesh(
-    view(xnodes(ϕ), :, slice, :), view(znodes(ϕ), :, slice, :), view(ϕ.data, :, slice, :), args...; kwargs...)
+    view(xnodes(ϕ), :, slice, :), view(znodes(ϕ), :, slice, :), view(data(ϕ), :, slice, :), args...; kwargs...)
 
 plotxyslice(ϕ, slice=1, args...; kwargs...) = pcolormesh(
-    view(xnodes(ϕ), :, :, slice), view(ynodes(ϕ), :, :, slice), view(ϕ.data, :, :, slice), args...; kwargs...)
+    view(xnodes(ϕ), :, :, slice), view(ynodes(ϕ), :, :, slice), view(data(ϕ), :, :, slice), args...; kwargs...)
 
 function total_kinetic_energy(model)
     return 0.5 * (
-          sum(model.velocities.u.data.^2)
-        + sum(model.velocities.v.data.^2)
-        + sum(model.velocities.w.data.^2)
+          sum(data(model.velocities.u).^2)
+        + sum(data(model.velocities.v).^2)
+        + sum(data(model.velocities.w).^2)
         )
 end
 
 function total_kinetic_energy(u, v, w)
-    return 0.5 * (sum(u.data.^2) + sum(v.data.^2) + sum(w.data.^2))
+    return 0.5 * (sum(data(u).^2) + sum(data(v).^2) + sum(data(w).^2))
 end
 
 function total_energy(model, N)
-    b = model.tracers.T.data .- mean(model.tracers.T.data, dims=(1, 2))
+    b = data(model.tracers.T) .- mean(data(model.tracers.T), dims=(1, 2))
     return 0.5 * (
-          sum(model.velocities.u.data.^2)
-        + sum(model.velocities.v.data.^2)
-        + sum(model.velocities.w.data.^2)
+          sum(data(model.velocities.u).^2)
+        + sum(data(model.velocities.v).^2)
+        + sum(data(model.velocities.w).^2)
         + sum(b.^2) / N^2
         )
 end
@@ -59,7 +60,7 @@ function w_relative_error(model, w)
         model.clock.time), model.grid)
 
     return mean(
-        (model.velocities.w.data .- w_ans.data).^2) / mean(w_ans.data.^2)
+        (data(model.velocities.w) .- data(w_ans)).^2) / mean(data(w_ans).^2)
 
 end
 
@@ -71,7 +72,7 @@ function u_relative_error(model, u)
         model.clock.time), model.grid)
 
     return mean(
-        (model.velocities.u.data .- u_ans.data).^2 ) / mean(u_ans.data.^2)
+        (data(model.velocities.u) .- data(u_ans)).^2 ) / mean(data(u_ans).^2)
 end
 
 function T_relative_error(model, T)
@@ -82,7 +83,7 @@ function T_relative_error(model, T)
         model.clock.time), model.grid)
 
     return mean(
-        (model.tracers.T.data .- T_ans.data).^2 ) / mean(T_ans.data.^2)
+        (data(model.tracers.T) .- data(T_ans)).^2 ) / mean(data(T_ans).^2)
 end
 
 """


### PR DESCRIPTION
This PR updates the examples to account for the fact that `field.data` returns the full offset array including all halos so you need to use `data(field)` which returns a view into the interior of the field with no halos.

cc @navidcy internal wave example works for me now. Can you try on this branch?

In hindsight, maybe a more sophisticated fields API would avoid issues like this where we're so reliant on the `data(::Field)` function. Maybe things should "just work" for the user.

Resolves #254 