### PR TITLE
No more scalar operations on CuArrays.

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -150,7 +150,7 @@ device(::GPU) = GPUifyLoops.CUDA()
     end
 end
 
-# @hascuda CuArrays.allowscalar(false)
+@hascuda CuArrays.allowscalar(false)
 
 abstract type Metadata end
 abstract type ConstantsCollection end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -33,6 +33,7 @@ export
     FaceFieldZ,
     EdgeField,
     data,
+    underlying_data,
     set!,
 
     # FieldSets (collections of related fields)
@@ -94,8 +95,6 @@ export
     FieldSummary,
     NaNChecker,
     VelocityDivergenceChecker,
-    Nusselt_wT,
-    Nusselt_Chi,
 
     # Package utilities
     prettytime,

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -110,6 +110,7 @@ FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
 @inline setindex!(f::Field, v, inds...) = setindex!(f.data, v, inds...)
 
 @inline data(f::Field) = view(f.data, 1:f.grid.Nx, 1:f.grid.Ny, 1:f.grid.Nz)
+@inline underlying_data(f::Field) = f.data.parent
 
 show(io::IO, f::Field) = show(io, f.data)
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -80,18 +80,15 @@ float_type(m::Model) = eltype(model.grid)
 add_bcs!(model::Model; kwargs...) = add_bcs(model.boundary_conditions; kwargs...)
 
 function initialize_with_defaults!(eos, tracers, sets...)
-
     # Default tracer initial condition is deteremined by eos.
-    tracers.S.data.parent    .= eos.S₀
-    tracers.T.data.parent    .= eos.T₀
+    underlying_data(tracers.S) .= eos.S₀
+    underlying_data(tracers.T) .= eos.T₀
 
     # Set all further fields to 0
     for set in sets
         for fldname in propertynames(set)
             fld = getproperty(set, fldname)
-            fld.data.parent .= 0 # promotes to eltype of fld.data
+            underlying_data(fld) .= 0 # promotes to eltype of fld.data
         end
     end
-    
-    return nothing
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -82,14 +82,14 @@ add_bcs!(model::Model; kwargs...) = add_bcs(model.boundary_conditions; kwargs...
 function initialize_with_defaults!(eos, tracers, sets...)
 
     # Default tracer initial condition is deteremined by eos.
-    tracers.S.data    .= eos.S₀
-    tracers.T.data    .= eos.T₀
+    tracers.S.data.parent    .= eos.S₀
+    tracers.T.data.parent    .= eos.T₀
 
     # Set all further fields to 0
     for set in sets
         for fldname in propertynames(set)
             fld = getproperty(set, fldname)
-            fld.data .= 0 # promotes to eltype of fld.data
+            fld.data.parent .= 0 # promotes to eltype of fld.data
         end
     end
     


### PR DESCRIPTION
This PR fixes a recent regression in `Model` construction time due to broadcasting over an `OffsetArray{CuArray}` getting converted to a scalar operation. Constructing models should be fast again.

I've also completely disabled scalar operations on CuArrays so this shouldn't happen again.

cc @sandreza 

Actually fixes #82 