### PR TITLE
Revert "Be more concrete"

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -54,11 +54,7 @@ export
 
     # Boundary conditions
     BoundaryConditions,
-    ZBoundaryConditions,
-    CoordinateBoundaryConditions,
-    FieldBoundaryConditions,
     BoundaryCondition,
-    DefaultBC,
     Default,
     Flux,
     Gradient,

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -46,30 +46,12 @@ Construct `CoordinateBoundaryCondition` to be applied along coordinate `c`, wher
 `left` and `right` that store boundary conditions on the 'left' (negative side)
 and 'right' (positive side) of a given coordinate.
 """
-mutable struct CoordinateBoundaryConditions{L, R}
-     left :: L
-    right :: R
+mutable struct CoordinateBoundaryConditions
+     left :: BoundaryCondition
+    right :: BoundaryCondition
 end
 
-function CoordinateBoundaryConditions(; 
-     left = DefaultBC(), 
-    right = DefaultBC()
-   )
-    return CoordinateBoundaryConditions(left, right)
-end
-
-"""
-    ZBoundaryConditions(top=DefaultBC(), bottom=DefaultBC())
-
-Returns `CoordinateBoundaryConditions` with specified `top`
-and `bottom` boundary conditions.
-"""
-function ZBoundaryConditions(; 
-       top = DefaultBC(), 
-    bottom = DefaultBC()
-   )
-    return CoordinateBoundaryConditions(top, bottom)
-end
+CoordinateBoundaryConditions() = CoordinateBoundaryConditions(DefaultBC(), DefaultBC())
 
 const CBC = CoordinateBoundaryConditions
 
@@ -98,18 +80,10 @@ Construct `FieldBoundaryConditions` for a field.
 A FieldBoundaryCondition has `CoordinateBoundaryConditions` in
 `x`, `y`, and `z`.
 """
-struct FieldBoundaryConditions{X, Y, Z}
-    x :: X 
-    y :: Y 
-    z :: Z 
-end
-
-function FieldBoundaryConditions(; 
-    x = CoordinateBoundaryConditions(),
-    y = CoordinateBoundaryConditions(),
-    z = CoordinateBoundaryConditions()
-    )
-    return FieldBoundaryConditions(x, y, z)
+struct FieldBoundaryConditions <: FieldVector{dims, CoordinateBoundaryConditions}
+    x :: CoordinateBoundaryConditions
+    y :: CoordinateBoundaryConditions
+    z :: CoordinateBoundaryConditions
 end
 
 """
@@ -118,50 +92,22 @@ end
 Construct a boundary condition type full of default
 `FieldBoundaryConditions` for u, v, w, T, S.
 """
-struct ModelBoundaryConditions{UBC, VBC, WBC, TBC, SBC}
-    u :: UBC
-    v :: VBC
-    w :: WBC
-    T :: TBC
-    S :: SBC
+struct ModelBoundaryConditions <: FieldVector{nsolution, FieldBoundaryConditions}
+    u :: FieldBoundaryConditions
+    v :: FieldBoundaryConditions
+    w :: FieldBoundaryConditions
+    T :: FieldBoundaryConditions
+    S :: FieldBoundaryConditions
 end
 
-function ModelBoundaryConditions(;
-    u = FieldBoundaryConditions(),
-    v = FieldBoundaryConditions(),
-    w = FieldBoundaryConditions(),
-    T = FieldBoundaryConditions(),
-    S = FieldBoundaryConditions()
-   )
-    return ModelBoundaryConditions(u, v, w, T, S)
+FieldBoundaryConditions() = FieldBoundaryConditions(CoordinateBoundaryConditions(),
+                                                    CoordinateBoundaryConditions(),
+                                                    CoordinateBoundaryConditions())
+
+function ModelBoundaryConditions()
+    bcs = (FieldBoundaryConditions() for i = 1:length(solution_fields))
+    return ModelBoundaryConditions(bcs...)
 end
-
-ModelBoundaryConditions(fld, coord, s::Symbol, bc) =
-    ModelBoundaryConditions(fld, coord, Val(s), bc)
-
-ModelBoundaryConditions(fld, coord, ::Val{:bottom}, bc) =
-    ModelBoundaryConditions(fld, coord, Val(:right), bc)
-
-ModelBoundaryConditions(fld, coord, ::Val{:top}, bc) =
-    ModelBoundaryConditions(fld, coord, Val(:left), bc)
-
-"""
-    BoundaryConditions(u=FieldBoundaryConditions(), ...)
-
-    BoundaryConditions(fld, coord, side, bc)
-
-Return an instance of `ModelBoundaryConditions` with one non-default
-boundary condition `bc` on `fld` along coordinate `coord` at `side`.
-"""
-function ModelBoundaryConditions(fld, coord, ::Val{S}, bc) where S
-    coordbcs = CoordinateBoundaryConditions(; Dict((S => bc))...)
-      fldbcs = FieldBoundaryConditions(; Dict((coord => coordbcs))...)
-    modelbcs = ModelBoundaryConditions(; Dict((fld => fldbcs))...)
-    return modelbcs
-end
-
-# sensible alias
-const BoundaryConditions = ModelBoundaryConditions
 
 #
 # User API

--- a/src/fieldsets.jl
+++ b/src/fieldsets.jl
@@ -1,25 +1,25 @@
-struct VelocityFields{U<:FaceFieldX, V<:FaceFieldY, W<:FaceFieldZ} <: FieldSet
-    u::U
-    v::V
-    w::W
+struct VelocityFields <: FieldSet
+    u::FaceFieldX
+    v::FaceFieldY
+    w::FaceFieldZ
 end
 
-struct TracerFields{CFT<:CellField, CFS<:CellField} <: FieldSet
-    T::CFT
-    S::CFS
+struct TracerFields <: FieldSet
+    T::CellField
+    S::CellField
 end
 
-struct PressureFields{CF1<:CellField, CF2<:CellField} <: FieldSet
-    pHY′::CF1
-    pNHS::CF2
+struct PressureFields <: FieldSet
+    pHY′::CellField
+    pNHS::CellField
 end
 
-struct SourceTerms{U<:FaceFieldX, V<:FaceFieldY, W<:FaceFieldZ, T<:CellField, S<:CellField} <: FieldSet
-    Gu::U
-    Gv::V
-    Gw::W
-    GT::T
-    GS::S
+struct SourceTerms <: FieldSet
+    Gu::FaceFieldX
+    Gv::FaceFieldY
+    Gw::FaceFieldZ
+    GT::CellField
+    GS::CellField
 end
 
 struct StepperTemporaryFields <: FieldSet

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,6 +1,6 @@
 using .TurbulenceClosures
 
-mutable struct Model{A<:Architecture, Grid, TC, BCS<:ModelBoundaryConditions, T, F,
+mutable struct Model{A<:Architecture, Grid, TC, T, F,
                     PC<:PlanetaryConstants, PS, VC<:VelocityFields,
                     EOS<:EquationOfState, TG, TGp,
                     Tracers<:TracerFields, PF<:PressureFields}
@@ -15,7 +15,7 @@ mutable struct Model{A<:Architecture, Grid, TC, BCS<:ModelBoundaryConditions, T,
          pressures :: PF                 # Container for hydrostatic and nonhydrostatic pressure.
            forcing :: F                  # Container for forcing functions defined by the user
            closure :: TC                 # Diffusive 'turbulence closure' for all model fields
-    boundary_conditions :: BCS           # Container for 3d bcs on all fields.
+    boundary_conditions :: ModelBoundaryConditions # Container for 3d bcs on all fields.
                  G :: TG        # Container for right-hand-side of PDE that governs `Model`
                 Gp :: TGp      # RHS at previous time-step (for Adams-Bashforth time integration)
     poisson_solver :: PS                 # ::PoissonSolver or ::PoissonSolverGPU
@@ -51,12 +51,11 @@ function Model(;
            eos = LinearEquationOfState(float_type),
     # Forcing and boundary conditions for (u, v, w, T, S)
        forcing = Forcing(nothing, nothing, nothing, nothing, nothing),
-           bcs = ModelBoundaryConditions(),
-    boundary_conditions = bcs,
+    boundary_conditions = ModelBoundaryConditions(),
     # Output and diagonstics
     output_writers = OutputWriter[],
        diagnostics = Diagnostic[]
-    )
+)
 
     arch == GPU() && !HAVE_CUDA && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,24 +1,21 @@
 using .TurbulenceClosures
 
-mutable struct Model{A<:Architecture, Grid, TC, T, F,
-                    PC<:PlanetaryConstants, PS, VC<:VelocityFields,
-                    EOS<:EquationOfState, TG, TGp,
-                    Tracers<:TracerFields, PF<:PressureFields}
+mutable struct Model{A<:Architecture, G, TC, T}
               arch :: A                  # Computer `Architecture` on which `Model` is run.
-              grid :: Grid               # Grid of physical points on which `Model` is solved.
+              grid :: G                  # Grid of physical points on which `Model` is solved.
              clock :: Clock{T}           # Tracks iteration number and simulation time of `Model`.
-               eos :: EOS                # Defines relationship between temperature,  salinity, and 
+               eos :: EquationOfState    # Defines relationship between temperature,  salinity, and 
                                          # buoyancy in the Boussinesq vertical momentum equation.
-         constants :: PC                 # Set of physical constants, inc. gravitational acceleration.
-        velocities :: VC                 # Container for velocity fields `u`, `v`, and `w`.
-           tracers :: Tracers            # Container for tracer fields.
-         pressures :: PF                 # Container for hydrostatic and nonhydrostatic pressure.
-           forcing :: F                  # Container for forcing functions defined by the user
+         constants :: PlanetaryConstants # Set of physical constants, inc. gravitational acceleration.
+        velocities :: VelocityFields     # Container for velocity fields `u`, `v`, and `w`.
+           tracers :: TracerFields       # Container for tracer fields.
+         pressures :: PressureFields     # Container for hydrostatic and nonhydrostatic pressure.
+           forcing                       # Container for forcing functions defined by the user
            closure :: TC                 # Diffusive 'turbulence closure' for all model fields
     boundary_conditions :: ModelBoundaryConditions # Container for 3d bcs on all fields.
-                 G :: TG        # Container for right-hand-side of PDE that governs `Model`
-                Gp :: TGp      # RHS at previous time-step (for Adams-Bashforth time integration)
-    poisson_solver :: PS                 # ::PoissonSolver or ::PoissonSolverGPU
+                 G :: SourceTerms        # Container for right-hand-side of PDE that governs `Model`
+                Gp :: SourceTerms        # RHS at previous time-step (for Adams-Bashforth time integration)
+    poisson_solver                       # ::PoissonSolver or ::PoissonSolverGPU
        stepper_tmp :: StepperTemporaryFields # Temporary fields used for the Poisson solver.
     output_writers :: Array{OutputWriter, 1} # Objects that write data to disk.
        diagnostics :: Array{Diagnostic, 1}   # Objects that calc diagnostics on-line during simulation.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -359,8 +359,8 @@ float_types = (Float32, Float64)
         include("test_output_writers.jl")
 
         @testset "Checkpointing" begin
-            # println("    Testing checkpointing...")
-            # run_thermal_bubble_checkpointer_tests()
+            println("    Testing checkpointing...")
+            run_thermal_bubble_checkpointer_tests()
         end
 
         @testset "NetCDF" begin

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,11 +1,10 @@
 function test_z_boundary_condition_simple(arch, T, field_name, bctype, bc, Nx, Ny)
     Nz = 16
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T)
 
     bc = BoundaryCondition(bctype, bc)
-    modelbcs = BoundaryConditions(field_name, :z, :top, bc)
-
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
-                  bcs=modelbcs)
+    bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.top = bc
 
     time_step!(model, 1, 1e-16)
 
@@ -14,18 +13,12 @@ end
 
 function test_z_boundary_condition_top_bottom_alias(arch, TF, field_name)
     N = 16
+    model = Model(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF)
+
     bcval = 1.0
-    top_bc = BoundaryCondition(Value, bcval)
-    bottom_bc = BoundaryCondition(Value, -bcval)
-
-    fieldbcs = FieldBoundaryConditions(z=ZBoundaryConditions(
-                    top=top_bc, bottom=bottom_bc))
-
-    modelbcs = BoundaryConditions(; Dict((field_name => fieldbcs))...)
-
-    model = Model(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=TF, bcs=modelbcs)
-
     bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.top = BoundaryCondition(Value, bcval)
+    bcs.z.bottom = BoundaryCondition(Value, -bcval)
 
     time_step!(model, 1, 1e-16)
 
@@ -34,19 +27,15 @@ end
 
 function test_z_boundary_condition_array(arch, T, field_name)
     Nx = Ny = Nz = 16
+    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T)
 
     bcarray = rand(T, Nx, Ny)
-
     if arch == GPU()
         bcarray = CuArray(bcarray)
     end
 
-    value_bc = BoundaryCondition(Value, bcarray)
-    modelbcs = BoundaryConditions(field_name, :z, :top, value_bc)
-
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T, bcs=modelbcs)
-
     bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.top = BoundaryCondition(Value, bcarray)
 
     time_step!(model, 1, 1e-16)
 
@@ -56,13 +45,8 @@ end
 function test_flux_budget(arch, TF, field_name)
     N, κ, Lz = 16, 1, 0.7
 
-    bottom_flux = TF(0.3)
-    flux_bc = BoundaryCondition(Flux, bottom_flux)
-    modelbcs = BoundaryConditions(field_name, :z, :bottom, flux_bc)
-
     model = Model(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ,
-                  arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0),
-                  bcs=modelbcs)
+                  arch=arch, float_type=TF, eos=LinearEquationOfState(βS=0, βT=0))
 
     if field_name ∈ (:u, :v, :w)
         field = getfield(model.velocities, field_name)
@@ -72,7 +56,11 @@ function test_flux_budget(arch, TF, field_name)
 
     @. field.data = 0
 
+    bottom_flux = TF(0.3)
+    flux_bc = BoundaryCondition(Flux, bottom_flux)
     bcs = getfield(model.boundary_conditions, field_name)
+    bcs.z.bottom = flux_bc
+
     mean_init = mean(data(field))
 
     τκ = Lz^2 / κ   # Diffusion time-scale

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -36,16 +36,16 @@ function run_thermal_bubble_checkpointer_tests()
     time_step!(restored_model, 5, Δt)
 
     # Now the true_model and restored_model should be identical.
-    @test_skip all(restored_model.velocities.u.data .≈ true_model.velocities.u.data)
-    @test_skip all(restored_model.velocities.v.data .≈ true_model.velocities.v.data)
-    @test_skip all(restored_model.velocities.w.data .≈ true_model.velocities.w.data)
-    @test_skip all(restored_model.tracers.T.data    .≈ true_model.tracers.T.data)
-    @test_skip all(restored_model.tracers.S.data    .≈ true_model.tracers.S.data)
-    @test_skip all(restored_model.G.Gu.data         .≈ true_model.G.Gu.data)
-    @test_skip all(restored_model.G.Gv.data         .≈ true_model.G.Gv.data)
-    @test_skip all(restored_model.G.Gw.data         .≈ true_model.G.Gw.data)
-    @test_skip all(restored_model.G.GT.data         .≈ true_model.G.GT.data)
-    @test_skip all(restored_model.G.GS.data         .≈ true_model.G.GS.data)
+    @test all(restored_model.velocities.u.data .≈ true_model.velocities.u.data)
+    @test all(restored_model.velocities.v.data .≈ true_model.velocities.v.data)
+    @test all(restored_model.velocities.w.data .≈ true_model.velocities.w.data)
+    @test all(restored_model.tracers.T.data    .≈ true_model.tracers.T.data)
+    @test all(restored_model.tracers.S.data    .≈ true_model.tracers.S.data)
+    @test all(restored_model.G.Gu.data         .≈ true_model.G.Gu.data)
+    @test all(restored_model.G.Gv.data         .≈ true_model.G.Gv.data)
+    @test all(restored_model.G.Gw.data         .≈ true_model.G.Gw.data)
+    @test all(restored_model.G.GT.data         .≈ true_model.G.GT.data)
+    @test all(restored_model.G.GS.data         .≈ true_model.G.GS.data)
 end
 
 """

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -18,10 +18,10 @@ function run_first_AB2_time_step_tests(arch, FT)
     Lx, Ly, Lz = 1, 2, 3
     Δt = 1
 
-    add_ones(args...) = 1.0
+    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=FT)
 
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=FT,
-                  forcing=Forcing(nothing, nothing, nothing, add_ones, nothing))
+    add_ones(args...) = 1.0
+    model.forcing = Forcing(nothing, nothing, nothing, add_ones, nothing)
 
     time_step!(model, 1, Δt)
 


### PR DESCRIPTION
Reverts climate-machine/Oceananigans.jl#263 because boundary conditions API broke. Seems that the tests did not catch this maybe?

```
(base) alir_mit_edu@oceananigans-debug:~/Oceananigans.jl$ julia --project newscript.jl 
WARNING: Method definition overdub(Cassette.Context{N, M, T, P, B, H} where H<:Union{Cassette.DisableHooks, Nothing} where B<:Union{Nothing, Base.IdDict{Module, Base.Dict{Symbol, Cassette.BindingMeta}}} where P<:Cassette.AbstractPass where T<:Union{Nothing, Cassette.Tag{N, X, E} where E where X where N<:Cassette.AbstractContextName} where M where N<:Cassette.AbstractContextName, Any...) in module Cassette at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:508 overwritten in module GPUifyLoops at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:508.
WARNING: Method definition recurse(Cassette.Context{N, M, T, P, B, H} where H<:Union{Cassette.DisableHooks, Nothing} where B<:Union{Nothing, Base.IdDict{Module, Base.Dict{Symbol, Cassette.BindingMeta}}} where P<:Cassette.AbstractPass where T<:Union{Nothing, Cassette.Tag{N, X, E} where E where X where N<:Cassette.AbstractContextName} where M where N<:Cassette.AbstractContextName, Any...) in module Cassette at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:521 overwritten in module GPUifyLoops at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:521.
CUDA-enabled GPU(s) detected:
CuDevice(0): Tesla V100-SXM2-16GB
ERROR: LoadError: TypeError: in setfield!, expected BoundaryCondition{Default,Nothing}, got BoundaryCondition{Flux,Float64}
Stacktrace:
 [1] setbc!(::Oceananigans.CoordinateBoundaryConditions{BoundaryCondition{Default,Nothing},BoundaryCondition{Default,Nothing}}, ::Val{:left}, ::BoundaryCondition{Flux,Float64}) at /home/alir_mit_edu/Oceananigans.jl/src/boundary_conditions.jl:85
 [2] setproperty!(::Oceananigans.CoordinateBoundaryConditions{BoundaryCondition{Default,Nothing},BoundaryCondition{Default,Nothing}}, ::Symbol, ::BoundaryCondition{Flux,Float64}) at /home/alir_mit_edu/Oceananigans.jl/src/boundary_conditions.jl:84
 [3] top-level scope at none:0
 [4] include at ./boot.jl:326 [inlined]
 [5] include_relative(::Module, ::String) at ./loading.jl:1038
 [6] include(::Module, ::String) at ./sysimg.jl:29
 [7] exec_options(::Base.JLOptions) at ./client.jl:267
 [8] _start() at ./client.jl:436
in expression starting at /home/alir_mit_edu/Oceananigans.jl/newscript.jl:53
```