### PR TITLE
No more scalar ops in NaN checker and NetCDF output writer

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -33,6 +33,7 @@ export
     FaceFieldZ,
     EdgeField,
     data,
+    ardata,
     underlying_data,
     set!,
     fill_halo_regions!,

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -30,7 +30,7 @@ end
 
 function run_diagnostic(model::Model, nc::NaNChecker)
     for (field, field_name) in zip(nc.fields, nc.field_names)
-        if any(isnan, field.data)  # This is also fast on CuArrays.
+        if any(isnan, field.data.parent)  # This is also fast on CuArrays.
             t, i = model.clock.time, model.clock.iteration
             println("time = $t, iteration = $i")
             println("NaN found in $field_name. Aborting simulation.")

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -112,6 +112,7 @@ FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
 @inline setindex!(f::Field, v, inds...) = setindex!(f.data, v, inds...)
 
 @inline data(f::Field) = view(f.data, 1:f.grid.Nx, 1:f.grid.Ny, 1:f.grid.Nz)
+@inline ardata(f::Field) = f.data.parent[1+f.grid.Hx:f.grid.Nx+f.grid.Hx, 1+f.grid.Hy:f.grid.Ny+f.grid.Hy, 1+f.grid.Hz:f.grid.Nz+f.grid.Hz]
 @inline underlying_data(f::Field) = f.data.parent
 
 show(io::IO, f::Field) = show(io, f.data)

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -147,11 +147,11 @@ function write_output(model::Model, fw::NetCDFOutputWriter)
         "xF" => collect(model.grid.xF),
         "yF" => collect(model.grid.yF),
         "zF" => collect(model.grid.zF),
-        "u" => Array(data(model.velocities.u)),
-        "v" => Array(data(model.velocities.v)),
-        "w" => Array(data(model.velocities.w)),
-        "T" => Array(data(model.tracers.T)),
-        "S" => Array(data(model.tracers.S))
+        "u" => Array(ardata(model.velocities.u)),
+        "v" => Array(ardata(model.velocities.v)),
+        "w" => Array(ardata(model.velocities.w)),
+        "T" => Array(ardata(model.tracers.T)),
+        "S" => Array(ardata(model.tracers.S))
     )
 
     if fw.async


### PR DESCRIPTION
cc @sandreza 

Model is back to normal speed. NaN checker and NetCDF output writer were the issues.

```
(base) alir_mit_edu@oceananigans-debug:~/Oceananigans.jl$ julia --project newscript.jl 
WARNING: Method definition overdub(Cassette.Context{N, M, T, P, B, H} where H<:Union{Cassette.DisableHooks, Nothing} where B<:Union{Nothing, Base.IdDict{Module, Base.Dict{Symbol, Cassette.BindingMeta}}} where P<:Cassette.AbstractPass where T<:Union{Nothing, Cassette.Tag{N, X, E} where E where X where N<:Cassette.AbstractContextName} where M where N<:Cassette.AbstractContextName, Any...) in module Cassette at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:508 overwritten in module GPUifyLoops at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:508.
WARNING: Method definition recurse(Cassette.Context{N, M, T, P, B, H} where H<:Union{Cassette.DisableHooks, Nothing} where B<:Union{Nothing, Base.IdDict{Module, Base.Dict{Symbol, Cassette.BindingMeta}}} where P<:Cassette.AbstractPass where T<:Union{Nothing, Cassette.Tag{N, X, E} where E where X where N<:Cassette.AbstractContextName} where M where N<:Cassette.AbstractContextName, Any...) in module Cassette at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:521 overwritten in module GPUifyLoops at /home/alir_mit_edu/.julia/packages/Cassette/xggAf/src/overdub.jl:521.
CUDA-enabled GPU(s) detected:
CuDevice(0): Tesla V100-SXM2-16GB
[000.00%] Time: 0.0 / 604800.0...   average wall clock time per iteration: 283.890 ms
[000.05%] Time: 300.0 / 604800.0...   average wall clock time per iteration: 39.199 ms
[000.10%] Time: 600.0 / 604800.0...   average wall clock time per iteration: 39.270 ms
[000.15%] Time: 900.0 / 604800.0...   average wall clock time per iteration: 39.172 ms
[000.20%] Time: 1200.0 / 604800.0...   average wall clock time per iteration: 39.167 ms
[000.25%] Time: 1500.0 / 604800.0...   average wall clock time per iteration: 39.245 ms
[000.30%] Time: 1800.0 / 604800.0...   average wall clock time per iteration: 39.119 ms
[000.35%] Time: 2100.0 / 604800.0...   average wall clock time per iteration: 39.181 ms
[000.40%] Time: 2400.0 / 604800.0...   average wall clock time per iteration: 39.246 ms
[000.45%] Time: 2700.0 / 604800.0...   average wall clock time per iteration: 45.696 ms
[000.50%] Time: 3000.0 / 604800.0...   average wall clock time per iteration: 40.170 ms
[000.55%] Time: 3300.0 / 604800.0...   average wall clock time per iteration: 39.193 ms
[000.60%] Time: 3600.0 / 604800.0...   average wall clock time per iteration: 39.091 ms
[000.64%] Time: 3900.0 / 604800.0...   average wall clock time per iteration: 39.124 ms
[000.69%] Time: 4200.0 / 604800.0...   average wall clock time per iteration: 39.230 ms
[000.74%] Time: 4500.0 / 604800.0...   average wall clock time per iteration: 39.090 ms
[000.79%] Time: 4800.0 / 604800.0...   average wall clock time per iteration: 39.110 ms
[000.84%] Time: 5100.0 / 604800.0...   average wall clock time per iteration: 39.208 ms
[000.89%] Time: 5400.0 / 604800.0...   average wall clock time per iteration: 39.086 ms
[000.94%] Time: 5700.0 / 604800.0...   average wall clock time per iteration: 45.165 ms
[000.99%] Time: 6000.0 / 604800.0...   average wall clock time per iteration: 40.586 ms
[001.04%] Time: 6300.0 / 604800.0...   average wall clock time per iteration: 39.119 ms
[001.09%] Time: 6600.0 / 604800.0...   average wall clock time per iteration: 39.115 ms
[001.14%] Time: 6900.0 / 604800.0...   average wall clock time per iteration: 39.198 ms
[001.19%] Time: 7200.0 / 604800.0...   average wall clock time per iteration: 39.083 ms
[001.24%] Time: 7500.0 / 604800.0...   average wall clock time per iteration: 39.110 ms
[001.29%] Time: 7800.0 / 604800.0...   average wall clock time per iteration: 39.205 ms
[001.34%] Time: 8100.0 / 604800.0...   average wall clock time per iteration: 39.099 ms
```