### PR TITLE
Only run Appveyor builds on x64.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,6 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 # Uncomment the following lines to allow failures on nightly julia


### PR DESCRIPTION
This should speed up Appveyor builds which currently take forever.

Also not sure how much we get out of testing x86/32-bit Windows...

Helps with #89 