### PR TITLE
Set up Slurm pipeline for performance regression testing.

### DIFF
--- a/.slurmci/gpu.slurm
+++ b/.slurmci/gpu.slurm
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00    # walltime
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=4G  # memory per CPU core
+#SBATCH --gres=gpu:1
+
+set -euo pipefail
+set -x  # echo on
+
+export PATH="${PATH}:${HOME}/julia-1.2/bin"
+export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/${SLURM_JOB_ID}/${HOSTNAME}:$(pwd)/.slurmdepot/common"
+export CUDA_PATH="/lib64"
+
+module load cuda/9.1
+
+julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"precompile"'
+julia --color=no --project $1

--- a/.slurmci/init.slurm
+++ b/.slurmci/init.slurm
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#SBATCH --time=1:00:00    # walltime
+#SBATCH --nodes=1         # number of nodes
+#SBATCH --mem-per-cpu=4G  # memory per CPU core
+
+set -euo pipefail
+set -x  # echo on
+
+export PATH="${PATH}:${HOME}/julia-1.2/bin"
+export JULIA_DEPOT_PATH="$(pwd)/.slurmdepot/common"
+
+julia --color=no --project -e 'using Pkg; pkg"instantiate"; pkg"build"; pkg"precompile"'

--- a/.slurmci/jobs.jl
+++ b/.slurmci/jobs.jl
@@ -1,0 +1,3 @@
+[SlurmJob(`.slurmci/init.slurm`) =>
+   [SlurmJob(`.slurmci/gpu.slurm benchmark/benchmarks.jl`)]
+]


### PR DESCRIPTION
Right now only 1 benchmark job is run to check for performance regression, which is important seeing as sometimes we introduce rogue bugs that kill performance.

cc @simonbyrne will this work with the Slurm CI/CliMA bot framework you've set up? Will be awesome to start using it. No MPI stuff yet but will probably add some soon.