### PR TITLE
Explicit default boundary conditions

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -54,9 +54,12 @@ export
     δρ,
 
     # Boundary conditions
-    BoundaryConditions,
     BoundaryCondition,
-    Default,
+    CoordinateBoundaryConditions,
+    FieldBoundaryConditions,
+    ModelBoundaryConditions,
+    Periodic,
+    FreeSlip,
     Flux,
     Gradient,
     Value,
@@ -65,16 +68,11 @@ export
 
     # Time stepping
     time_step!,
-    time_step_kernel!,
 
     # Poisson solver
     PoissonSolver,
     PoissonSolverGPU,
-    init_poisson_solver,
-    solve_poisson_3d_ppn,
-    solve_poisson_3d_ppn!,
     solve_poisson_3d_ppn_planned!,
-    solve_poisson_3d_ppn_gpu!,
     solve_poisson_3d_ppn_gpu_planned!,
 
     # Model helper structs, e.g. clock, etc.

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -59,7 +59,6 @@ export
     FieldBoundaryConditions,
     ModelBoundaryConditions,
     Periodic,
-    FreeSlip,
     Flux,
     Gradient,
     Value,

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -9,7 +9,6 @@ const nsolution = length(solution_fields)
 
 abstract type BCType end
 struct Periodic <: BCType end
-struct FreeSlip <: BCType end
 struct Flux <: BCType end
 struct Gradient <: BCType end
 struct Value <: BCType end
@@ -104,15 +103,15 @@ FieldBoundaryConditions() = FieldBoundaryConditions(
                                     BoundaryCondition(Periodic, nothing),
                                     BoundaryCondition(Periodic, nothing)),
                                 CoordinateBoundaryConditions(
-                                    BoundaryCondition(FreeSlip, nothing),
-                                    BoundaryCondition(FreeSlip, nothing)))
+                                    BoundaryCondition(Flux, 0),
+                                    BoundaryCondition(Flux, 0)))
 
 """
     ModelBoundaryConditions()
 
 Return a default set of model boundary conditions. For now, this corresponds to a
 doubly periodic domain, so `Periodic` boundary conditions along the x- and y-dimensions,
-with `FreeSlip` boundary conditions at the top and bottom.
+with no-flux boundary conditions at the top and bottom.
 """
 function ModelBoundaryConditions()
     bcs = (FieldBoundaryConditions() for i = 1:length(solution_fields))

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -96,24 +96,27 @@ struct ModelBoundaryConditions <: FieldVector{nsolution, FieldBoundaryConditions
     S :: FieldBoundaryConditions
 end
 
+FieldBoundaryConditions() = FieldBoundaryConditions(
+                                CoordinateBoundaryConditions(
+                                    BoundaryCondition(Periodic, nothing),
+                                    BoundaryCondition(Periodic, nothing)),
+                                CoordinateBoundaryConditions(
+                                    BoundaryCondition(Periodic, nothing),
+                                    BoundaryCondition(Periodic, nothing)),
+                                CoordinateBoundaryConditions(
+                                    BoundaryCondition(FreeSlip, nothing),
+                                    BoundaryCondition(FreeSlip, nothing)))
+
 """
     ModelBoundaryConditions()
 
 Return a default set of model boundary conditions. For now, this corresponds to a
 doubly periodic domain, so `Periodic` boundary conditions along the x- and y-dimensions,
-with free-slip (`FreeSlip`) boundary conditions at the top and bottom.
+with `FreeSlip` boundary conditions at the top and bottom.
 """
 function ModelBoundaryConditions()
-    periodic_bc = BoundaryCondition(Periodic, nothing)
-    free_slip_bc = BoundaryCondition(FreeSlip, nothing)
-
-    default_x_bc = CoordinateBoundaryConditions(periodic_bc, periodic_bc)
-    default_y_bc = CoordinateBoundaryConditions(periodic_bc, periodic_bc)
-    default_z_bc = CoordinateBoundaryConditions(free_slip_bc, free_slip_bc)
-
-    default_bc = FieldBoundaryConditions(default_x_bc, default_y_bc, default_z_bc)
-
-    return ModelBoundaryConditions(default_bc, default_bc, default_bc, default_bc, default_bc)
+    bcs = (FieldBoundaryConditions() for i = 1:length(solution_fields))
+    return ModelBoundaryConditions(bcs...)
 end
 
 #

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -354,20 +354,20 @@ function calculate_boundary_source_terms!(model::Model{A}) where A <: Architectu
     return nothing
 end
 
-# Do nothing if both boundary conditions are FreeSlip.
+# Do nothing if both left and right boundary conditions are periodic.
 apply_bcs!(::CPU, ::Val{:x}, Bx, By, Bz,
     left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::CPU, ::Val{:y}, Bx, By, Bz,
     left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::CPU, ::Val{:z}, Bx, By, Bz,
-    left_bc::BC{<:FreeSlip, T}, right_bc::BC{<:FreeSlip, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 
 apply_bcs!(::GPU, ::Val{:x}, Bx, By, Bz,
     left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::GPU, ::Val{:y}, Bx, By, Bz,
     left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::GPU, ::Val{:z}, Bx, By, Bz,
-    left_bc::BC{<:FreeSlip, T}, right_bc::BC{<:FreeSlip, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 
 # First, dispatch on coordinate.
 apply_bcs!(arch, ::Val{:x}, Bx, By, Bz, args...) =

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -354,20 +354,20 @@ function calculate_boundary_source_terms!(model::Model{A}) where A <: Architectu
     return nothing
 end
 
-# Do nothing if both boundary conditions are default.
+# Do nothing if both boundary conditions are FreeSlip.
 apply_bcs!(::CPU, ::Val{:x}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::CPU, ::Val{:y}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::CPU, ::Val{:z}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:FreeSlip, T}, right_bc::BC{<:FreeSlip, T}, args...) where {T} = nothing
 
 apply_bcs!(::GPU, ::Val{:x}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::GPU, ::Val{:y}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:Periodic, T}, right_bc::BC{<:Periodic, T}, args...) where {T} = nothing
 apply_bcs!(::GPU, ::Val{:z}, Bx, By, Bz,
-    left_bc::BC{<:Default, T}, right_bc::BC{<:Default, T}, args...) where {T} = nothing
+    left_bc::BC{<:FreeSlip, T}, right_bc::BC{<:FreeSlip, T}, args...) where {T} = nothing
 
 # First, dispatch on coordinate.
 apply_bcs!(arch, ::Val{:x}, Bx, By, Bz, args...) =


### PR DESCRIPTION
This PR gets rid of default and non-default boundary conditions. Default boundary conditions are now explicitly `Periodic` in x,y and `FreeSlip` in z.

This will make implementing multiple wall-bounded dimensions easier/cleaner.