### PR TITLE
Faster model with dynamic launch configuration by @maleadt

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -40,10 +40,10 @@ uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 version = "1.0.0"
 
 [[CMake]]
-deps = ["BinDeps", "Libdl", "Test"]
-git-tree-sha1 = "6e39bef3cbb8321e8a464b18a5c20d7cef813938"
+deps = ["BinDeps"]
+git-tree-sha1 = "c67a8689dc5444adc5eb2be7d837100340ecba11"
 uuid = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
-version = "1.1.1"
+version = "1.1.2"
 
 [[CMakeWrapper]]
 deps = ["BinDeps", "CMake", "Libdl", "Parameters", "Test"]
@@ -52,10 +52,10 @@ uuid = "d5fb7624-851a-54ee-a528-d3f3bac0b4a0"
 version = "0.2.3"
 
 [[CSTParser]]
-deps = ["LibGit2", "Test", "Tokenize"]
-git-tree-sha1 = "437c93bc191cd55957b3f8dee7794b6131997c56"
+deps = ["Tokenize"]
+git-tree-sha1 = "376a39f1862000442011390f1edf5e7f4dcc7142"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.5.2"
+version = "0.6.0"
 
 [[CUDAapi]]
 deps = ["Libdl", "Logging", "Test"]
@@ -65,15 +65,17 @@ version = "0.6.3"
 
 [[CUDAdrv]]
 deps = ["CUDAapi", "Libdl", "Printf"]
-git-tree-sha1 = "9b2d99981b984378799ec70dd005cb7e7b4e914c"
+git-tree-sha1 = "ee4e7f60365094ddb3fab653d7f5094b31690392"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaGPU/CUDAdrv.jl.git"
 uuid = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 version = "3.0.1"
 
 [[CUDAnative]]
-deps = ["Adapt", "CUDAapi", "CUDAdrv", "DataStructures", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Pkg", "Printf", "TimerOutputs"]
-git-tree-sha1 = "5cfc4cf4cbadd59f0465669fdf3ef7366bedaa7c"
+deps = ["Adapt", "CUDAapi", "CUDAdrv", "DataStructures", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Printf", "TimerOutputs"]
+git-tree-sha1 = "37bfdc22482ee0f21456f677c192faf77a755e0a"
 uuid = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
-version = "2.1.1"
+version = "2.2.0"
 
 [[Cassette]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Test"]
@@ -88,10 +90,10 @@ uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.1.0"
 
 [[Conda]]
-deps = ["Compat", "JSON", "VersionParsing"]
-git-tree-sha1 = "b625d802587c2150c279a40a646fba63f9bd8187"
+deps = ["JSON", "VersionParsing"]
+git-tree-sha1 = "9a11d428dcdc425072af4aea19ab1e8c3e01c032"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.2.0"
+version = "1.3.0"
 
 [[CondaBinDeps]]
 deps = ["BinDeps", "Compat", "Conda", "Libdl"]
@@ -136,10 +138,10 @@ uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 version = "0.2.4"
 
 [[FileIO]]
-deps = ["Pkg", "Random", "Test"]
-git-tree-sha1 = "da32159d4a2e526338506685e280e39ed2f18961"
+deps = ["Pkg"]
+git-tree-sha1 = "351f001a78aa1b7ad2696e386e110b5abd071c71"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.0.6"
+version = "1.0.7"
 
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
@@ -161,9 +163,11 @@ version = "0.7.1"
 
 [[GPUifyLoops]]
 deps = ["Cassette", "Requires", "StaticArrays"]
-git-tree-sha1 = "c8177843e45b3b81676cc95fe48ca218c1f649ed"
+git-tree-sha1 = "1b3608e6db0ec1e64058d70f570094115a88b3da"
+repo-rev = "ar/config-kwarg"
+repo-url = "https://github.com/vchuravy/GPUifyLoops.jl.git"
 uuid = "ba82f77b-6841-5d2e-bd9f-4daf811aec27"
-version = "0.2.4"
+version = "0.2.5"
 
 [[HDF5]]
 deps = ["BinDeps", "Blosc", "Homebrew", "Libdl", "Mmap", "WinRPM"]
@@ -355,10 +359,9 @@ uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.0"
 
 [[Tokenize]]
-deps = ["Printf", "Test"]
-git-tree-sha1 = "3e83f60b74911d3042d3550884ca2776386a02b8"
+git-tree-sha1 = "0de343efc07da00cd449d5b04e959ebaeeb3305d"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.3"
+version = "0.5.4"
 
 [[URIParser]]
 deps = ["Test", "Unicode"]

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -46,7 +46,7 @@ struct VelocityDivergenceChecker <: Diagnostic
 end
 
 function velocity_div!(grid::RegularCartesianGrid, u, v, w, div)
-    @loop for k in (1:grid.Nz; blockIdx().z)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
                 @inbounds div[i, j, k] = div_f2c(grid, u, v, w, i, j, k)

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -120,16 +120,19 @@ function launch_config(grid, dims)
         config = launch_configuration(fun)
 
         # adapt the suggested config from 1D to the requested grid dimensions
-        threads = floor(Int, sqrt(config.threads))
-        blocks = ceil.(Int, [grid.Nx,grid.Ny] ./ threads)
         if dims == 3
-            push!(blocks, grid.Nz)
+            threads = floor(Int, cbrt(config.threads))
+            blocks = ceil.(Int, [grid.Nx,grid.Ny,grid.Nz] ./ threads)
+            threads = [threads,threads,threads]
+        elseif dims == 2
+            threads = floor(Int, sqrt(config.threads))
+            blocks = ceil.(Int, [grid.Nx,grid.Ny] ./ threads)
+            threads = [threads,threads]
         else
-            @assert dims == 2
+            error("unsupported launch configuration")
         end
 
-        return (threads=(threads,threads),
-                blocks=Tuple(blocks))
+        return (threads=Tuple(threads), blocks=Tuple(blocks))
     end
 end
 

--- a/test/test_poisson_solvers.jl
+++ b/test/test_poisson_solvers.jl
@@ -9,7 +9,7 @@ using OffsetArrays
 using Oceananigans.Operators
 
 function ∇²!(grid::RegularCartesianGrid, f, ∇²f)
-    @loop for k in (1:grid.Nz; blockIdx().z)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
                 @inbounds ∇²f[i, j, k] = ∇²(grid, f, i, j, k)


### PR DESCRIPTION
This PR integrates Tim's changes from the GPU hackathon. By using dynamic launch configurations and splitting up the interior source term calculation kernel (+ https://github.com/JuliaGPU/CUDAnative.jl/pull/417) we get a pretty sweet ~25% overall speedup (so the most expensive kernel which was a bottleneck is sped up by ~40%).

Needs https://github.com/vchuravy/GPUifyLoops.jl/pull/90 to work for now.

cc @maleadt Sorry it took so long for me to merge these improvements.

Actually resolves #64 

```
──────────────────────────────────────────────────────────────────────────────────────
 Oceananigans.jl static ocean bench...        Time                   Allocations      
                                      ──────────────────────   ───────────────────────
           Tot / % measured:                409s / 28.8%           15.0GiB / 0.50%    

 Section                      ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────────
 256×256×256 (CPU, Float64)       10    56.0s  47.7%   5.60s    292KiB  0.37%  29.2KiB
 256×256×256 (CPU, Float32)       10    47.2s  40.2%   4.72s    227KiB  0.29%  22.7KiB
 128×128×128 (CPU, Float32)       10    5.91s  5.03%   591ms    227KiB  0.29%  22.7KiB
 128×128×128 (CPU, Float64)       10    5.87s  5.00%   587ms    292KiB  0.37%  29.2KiB
  64× 64× 64 (CPU, Float64)       10    803ms  0.68%  80.3ms    292KiB  0.37%  29.2KiB
  64× 64× 64 (CPU, Float32)       10    724ms  0.62%  72.4ms    227KiB  0.29%  22.7KiB
 256×256×256 (GPU, Float64)       10    309ms  0.26%  30.9ms   9.83MiB  12.9%  0.98MiB
 256×256×256 (GPU, Float32)       10    239ms  0.20%  23.9ms   8.70MiB  11.4%   891KiB
  32× 32× 32 (CPU, Float64)       10   86.6ms  0.07%  8.66ms    292KiB  0.37%  29.2KiB
  32× 32× 32 (CPU, Float32)       10   61.0ms  0.05%  6.10ms    227KiB  0.29%  22.7KiB
  32× 32× 32 (GPU, Float64)       10   50.7ms  0.04%  5.07ms   9.83MiB  12.9%  0.98MiB
  64× 64× 64 (GPU, Float64)       10   49.7ms  0.04%  4.97ms   9.83MiB  12.9%  0.98MiB
 128×128×128 (GPU, Float64)       10   46.9ms  0.04%  4.69ms   9.83MiB  12.9%  0.98MiB
  32× 32× 32 (GPU, Float32)       10   44.8ms  0.04%  4.48ms   8.70MiB  11.4%   891KiB
 128×128×128 (GPU, Float32)       10   40.6ms  0.03%  4.06ms   8.70MiB  11.4%   891KiB
  64× 64× 64 (GPU, Float32)       10   32.6ms  0.03%  3.26ms   8.70MiB  11.4%   891KiB
 ─────────────────────────────────────────────────────────────────────────────────────

CPU Float64 -> Float32 speedup:
 32× 32× 32: 1.419
 64× 64× 64: 1.110
128×128×128: 0.993
256×256×256: 1.186

GPU Float64 -> Float32 speedup:
 32× 32× 32: 1.132
 64× 64× 64: 1.524
128×128×128: 1.155
256×256×256: 1.294

CPU -> GPU speedup:
 32× 32× 32 (Float32): 1.363
 32× 32× 32 (Float64): 1.710
 64× 64× 64 (Float32): 22.178
 64× 64× 64 (Float64): 16.151
128×128×128 (Float32): 145.438
128×128×128 (Float64): 125.088
256×256×256 (Float32): 197.674
256×256×256 (Float64): 181.197
```