### PR TITLE
More dynamic launch

### DIFF
--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -253,12 +253,11 @@ function calculate_interior_source_terms!(arch::Architecture, grid::Grid, consta
         end
     end
 
-    Bx, By, Bz = floor(Int, Nx/Tx), floor(Int, Ny/Ty), Nz  # Blocks in grid
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gu(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gv(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gw(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GT(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GS(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
+    @launch device(arch) config=launch_config(grid, 3) calculate_Gu(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
+    @launch device(arch) config=launch_config(grid, 3) calculate_Gv(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
+    @launch device(arch) config=launch_config(grid, 3) calculate_Gw(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
+    @launch device(arch) config=launch_config(grid, 3) calculate_GT(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
+    @launch device(arch) config=launch_config(grid, 3) calculate_GS(grid, constants, eos, closure, u, v, w, T, S, pHY′, Gu, Gv, Gw, GT, GS, F)
 end
 
 function adams_bashforth_update_source_terms!(grid::Grid{FT}, Gu, Gv, Gw, GT, GS, Gpu, Gpv, Gpw, GpT, GpS, χ) where FT


### PR DESCRIPTION
Forgot to use dynamic launch configs for the `calculate_G*` kernels.

But, hmmm, this actually slows things down a bit...

```
 ─────────────────────────────────────────────────────────────────────────────────────
 Oceananigans.jl static ocean bench...        Time                   Allocations      
                                      ──────────────────────   ───────────────────────
           Tot / % measured:                247s / 29.9%           14.9GiB / 0.56%    

 Section                      ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────────────
 256×256×256 (CPU, Float64)       10    34.0s  46.1%   3.40s    292KiB  0.34%  29.2KiB
 256×256×256 (CPU, Float32)       10    30.5s  41.4%   3.05s    227KiB  0.26%  22.7KiB
 128×128×128 (CPU, Float64)       10    3.94s  5.35%   394ms    292KiB  0.34%  29.2KiB
 128×128×128 (CPU, Float32)       10    3.54s  4.80%   354ms    227KiB  0.26%  22.7KiB
  64× 64× 64 (CPU, Float64)       10    417ms  0.57%  41.7ms    292KiB  0.34%  29.2KiB
  64× 64× 64 (CPU, Float32)       10    406ms  0.55%  40.6ms    227KiB  0.26%  22.7KiB
 256×256×256 (GPU, Float64)       10    337ms  0.46%  33.7ms   11.0MiB  13.0%  1.10MiB
 256×256×256 (GPU, Float32)       10    254ms  0.34%  25.4ms   9.62MiB  11.4%  0.96MiB
  32× 32× 32 (CPU, Float64)       10   52.6ms  0.07%  5.26ms    292KiB  0.34%  29.2KiB
 128×128×128 (GPU, Float64)       10   47.3ms  0.06%  4.73ms   11.0MiB  13.0%  1.10MiB
  32× 32× 32 (CPU, Float32)       10   46.9ms  0.06%  4.69ms    227KiB  0.26%  22.7KiB
 128×128×128 (GPU, Float32)       10   36.4ms  0.05%  3.64ms   9.62MiB  11.4%  0.96MiB
  32× 32× 32 (GPU, Float64)       10   26.6ms  0.04%  2.66ms   11.0MiB  13.0%  1.10MiB
  32× 32× 32 (GPU, Float32)       10   24.6ms  0.03%  2.46ms   9.61MiB  11.4%  0.96MiB
  64× 64× 64 (GPU, Float64)       10   24.6ms  0.03%  2.46ms   11.0MiB  13.0%  1.10MiB
  64× 64× 64 (GPU, Float32)       10   22.6ms  0.03%  2.26ms   9.62MiB  11.4%  0.96MiB
 ─────────────────────────────────────────────────────────────────────────────────────

CPU Float64 -> Float32 speedup:
 32× 32× 32: 1.122
 64× 64× 64: 1.027
128×128×128: 1.114
256×256×256: 1.114

GPU Float64 -> Float32 speedup:
 32× 32× 32: 1.081
 64× 64× 64: 1.086
128×128×128: 1.301
256×256×256: 1.326

CPU -> GPU speedup:
 32× 32× 32 (Float32): 1.903
 32× 32× 32 (Float64): 1.975
 64× 64× 64 (Float32): 17.951
 64× 64× 64 (Float64): 16.965
128×128×128 (Float32): 97.342
128×128×128 (Float64): 83.343
256×256×256 (Float32): 120.068
256×256×256 (Float64): 100.897
```