### PR TITLE
Dockerfile for Oceananigans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM julia:1.1
+LABEL maintainer="alir@mit.edu"
+
 RUN apt-get install -y git hdf5-tools
 RUN git clone https://github.com/climate-machine/Oceananigans.jl.git /Oceananigans.jl/
+
 WORKDIR /Oceananigans.jl/
 RUN julia --project -e "using Pkg; Pkg.instantiate();"
 RUN julia --project -e "using Oceananigans"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM julia:1.1
+RUN apt-get update && apt-get install -y git hdf5-tools
+RUN git clone https://github.com/climate-machine/Oceananigans.jl.git /Oceananigans.jl/
+WORKDIR /Oceananigans.jl/
+RUN julia --project -e "using Pkg; Pkg.instantiate();"
+RUN julia --project -e "using Oceananigans"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM julia:1.1
-RUN apt-get update && apt-get install -y git hdf5-tools
+RUN apt-get install -y git hdf5-tools
 RUN git clone https://github.com/climate-machine/Oceananigans.jl.git /Oceananigans.jl/
 WORKDIR /Oceananigans.jl/
 RUN julia --project -e "using Pkg; Pkg.instantiate();"


### PR DESCRIPTION
Simple Dockerfile to build a Docker image with Oceananigans installed, precompiled, and with dependencies built.

Should be useful for debugging and maybe speeding up CI. Image can be built then just downloaded by CI server, but usually testing is done before Docker image is built...

We also have a Dockerhub repository where images will be published: https://cloud.docker.com/repository/docker/aliramadhan/oceananigans

We can look into automated builds: https://docs.docker.com/docker-hub/builds/

For GPU-accelerated container we can look into: https://github.com/NVIDIA/nvidia-docker

cc @christophernhill we're finally in the 21st century!

Resolves #151 