### PR TITLE
Checkpointer revival

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -109,8 +109,10 @@ export
     BinaryOutputWriter,
     NetCDFOutputWriter,
     JLD2OutputWriter,
+    Checkpointer,
     write_output,
     read_output,
+    restore_from_checkpoint,
 
     # Model diagnostics
     Diagnostic,

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -35,11 +35,65 @@ function run_thermal_bubble_netcdf_tests()
     @test all(S .≈ data(model.tracers.S))
 end
 
+"""
+Run two coarse rising thermal bubble simulations and make sure that when
+restarting from a checkpoint, the restarted simulation matches the non-restarted
+simulation numerically.
+"""
+function run_thermal_bubble_checkpointer_tests(arch)
+    Nx, Ny, Nz = 16, 16, 16
+    Lx, Ly, Lz = 100, 100, 100
+    Δt = 6
+
+    true_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, arch=arch)
+
+    # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
+    # of the domain volume.
+    i1, i2 = round(Int, Nx/4), round(Int, 3Nx/4)
+    j1, j2 = round(Int, Ny/4), round(Int, 3Ny/4)
+    k1, k2 = round(Int, Nz/4), round(Int, 3Nz/4)
+    true_model.tracers.T.data[i1:i2, j1:j2, k1:k2] .+= 0.01
+
+    checkpointed_model = deepcopy(true_model)
+
+    time_step!(true_model, 9, Δt)
+
+    checkpointer = Checkpointer(output_frequency=5)
+    push!(checkpointed_model.output_writers, checkpointer)
+
+    # Checkpoint should be saved as "test_model_checkpoint_5.jld" after the 5th iteration.
+    time_step!(checkpointed_model, 5, Δt)
+
+    # Remove all knowledge of the checkpointed model.
+    checkpointed_model = nothing
+
+    restored_model = restore_from_checkpoint("checkpoint5.jld2")
+
+    time_step!(restored_model, 4, Δt; adams_bashforth_parameter = n->0.125)
+
+    # Now the true_model and restored_model should be identical.
+    @test all(restored_model.velocities.u.data .≈ true_model.velocities.u.data)
+    @test all(restored_model.velocities.v.data .≈ true_model.velocities.v.data)
+    @test all(restored_model.velocities.w.data .≈ true_model.velocities.w.data)
+    @test all(restored_model.tracers.T.data    .≈ true_model.tracers.T.data)
+    @test all(restored_model.tracers.S.data    .≈ true_model.tracers.S.data)
+    @test all(restored_model.G.Gu.data         .≈ true_model.G.Gu.data)
+    @test all(restored_model.G.Gv.data         .≈ true_model.G.Gv.data)
+    @test all(restored_model.G.Gw.data         .≈ true_model.G.Gw.data)
+    @test all(restored_model.G.GT.data         .≈ true_model.G.GT.data)
+    @test all(restored_model.G.GS.data         .≈ true_model.G.GS.data)
+end
+
 @testset "Output writers" begin
     println("Testing output writers...")
 
     @testset "NetCDF" begin
         println("  Testing NetCDF output writer...")
         run_thermal_bubble_netcdf_tests()
+    end
+
+    @testset "Checkpointer" begin
+        println("  Testing Checkpointer...")
+        run_thermal_bubble_checkpointer_tests(CPU())
     end
 end


### PR DESCRIPTION
This PR reintroduces checkpointing. This time the checkpointer saves the bare essentials to a JLD2 file.

Checkpointer will not save forcing functions as before (see #141).

Need to test GPU checkpointing, checkpointing with LES closures (I assumed `model.diffusivities` does not need to be checkpointed), and checkpointing with fancier boundary conditions.

A major issue with this checkpointer is that it can't restore the largest models because it creates a `Model` and then copies the data from the checkpoint file into the model fields. But if the model is using up all memory, then there's no room for reading data from disk to memory.

It should feed the data directly through the Model constructor, but this would require refactoring some of the model and field code.

This can be addressed in this PR or in a future PR, although it's kind of useless because checkpointing becomes more important the larger the model/simulation...

Resolves #324 