### PR TITLE
Can use set_ic! with arrays

### DIFF
--- a/src/fields.jl
+++ b/src/fields.jl
@@ -177,6 +177,11 @@ function set_ic!(model; ics...)
     end
 end
 
+"""
+Looks like a ridiculously simple kernel lol but it means you just supply an Nx*Ny*Nz sized array
+and not have to worry about halos, or broadcasting over views of non-contiguous views (which
+results in slow CuArray scalar operations).
+"""
 function set_initial_condition!(grid, ϕ, ic::AbstractArray, args...)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -177,7 +177,17 @@ function set_ic!(model; ics...)
     end
 end
 
-function set_initial_condition!(grid, ϕ, ic, xN, yN, zN)
+function set_initial_condition!(grid, ϕ, ic::AbstractArray, args...)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                ϕ[i, j, k] = ic[i, j, k]
+            end
+        end
+    end
+end
+
+function set_initial_condition!(grid, ϕ, ic::Function, xN, yN, zN)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)


### PR DESCRIPTION
This PR follows up on PR #337 

Should help with adding noise to initial conditions as `rand` and `randn` aren't available in CUDAnative.jl. So we can use arrays to initialize with noise.

@glwagner you had issues with generating random numbers on the GPU in the past?

Looks like a ridiculously simple kernel lol but it means you just supply an` Nx*Ny*Nz` sized array and not have to worry about halos, or broadcasting over views of non-contiguous views (which results is slow CuArray scalar operations).