### PR TITLE
Robust setting of fields

### DIFF
--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -22,10 +22,9 @@ parameters = Dict(:free_convection => Dict(:Fb=>3.39e-8, :Fu=>0.0,     :f=>1e-4,
 
 # Simulation parameters
 case = :free_convection
-verbose = false
- N = 32                   # Resolution    
+ N = 16                   # Resolution    
  Δ = 0.5                  # Grid spacing
-tf = hour/4               # Final simulation time
+tf = hour/2               # Final simulation time
 
 N², Fb, Fu, f = (parameters[case][p] for p in (:N², :Fb, :Fu, :f))
 βT, g = 2e-4, 9.81
@@ -36,7 +35,7 @@ ubcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fu))
 Tbcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fθ), bottom=BoundaryCondition(Gradient, dTdz))
 
 # Instantiate the model
-model = Model(      arch = HAVE_CUDA ? GPU() : CPU(),
+model = Model(      arch = CPU(), #HAVE_CUDA ? GPU() : CPU(), # this example will run on the GPU if cuda is available.
                        N = (N, N, N),
                        L = (N*Δ, N*Δ, N*Δ),
                      eos = LinearEquationOfState(βT=βT, βS=0.0),
@@ -86,8 +85,8 @@ wizard = TimeStepWizard(cfl=0.2, Δt=1.0, max_change=1.1, max_Δt=90.0)
 # Run the model
 while model.clock.time < tf
     update_Δt!(wizard, model)
-    walltime = @elapsed time_step!(model, 100, wizard.Δt)
-    verbose && @printf("%s", terse_message(model, walltime, wizard.Δt))
+    walltime = @elapsed time_step!(model, 10, wizard.Δt)
+    @printf "%s" terse_message(model, walltime, wizard.Δt)
     
     @haspyplot begin
         sca(axs); cla()

--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -1,129 +1,97 @@
 using Oceananigans, Random, Printf
 
-# Set `true` to use PyPlot to show the evolution of vertical velocity
-makeplot = true
+# Set `makeplot=false` to disable plotting even when PyPlot is available.
+makeplot = try
+    using PyPlot
+    true
+catch
+    false
+end
+
+macro haspyplot(ex)
+    makeplot ? :($(esc(ex))) : :(nothing)
+end
 
 # 
 # Model set-up
 #
 
 # Two cases from Van Roekel et al (JAMES, 2018)
-parameters = Dict(
-    :free_convection => Dict(:Fb=>3.39e-8, :Fu=>0.0,     :f=>1e-4, :N²=>1.96e-5),
-    :wind_stress     => Dict(:Fb=>0.0,     :Fu=>9.66e-5, :f=>0.0,  :N²=>9.81e-5)
-   )
+parameters = Dict(:free_convection => Dict(:Fb=>3.39e-8, :Fu=>0.0,     :f=>1e-4, :N²=>1.96e-5),
+                  :wind_stress     => Dict(:Fb=>0.0,     :Fu=>9.66e-5, :f=>0.0,  :N²=>9.81e-5))
 
 # Simulation parameters
-case = :wind_stress
-  DT = Float64                  # Data type
-   N = 32                       # Resolution    
-   Δ = 0.5                      # Grid spacing
-  tf = 8day                     # Final simulation time
-  N² = parameters[case][:N²]
-  Fb = parameters[case][:Fb]
-  Fu = parameters[case][:Fu]
-   f = parameters[case][:f]
+case = :free_convection
+verbose = false
+ N = 32                   # Resolution    
+ Δ = 0.5                  # Grid spacing
+tf = hour/2               # Final simulation time
 
-# Physical constants
-  βT = 2e-4                     # Thermal expansion coefficient
-   g = 9.81                     # Gravitational acceleration
-  Fθ = Fb / (g*βT)              # Temperature flux
-dTdz = N² / (g*βT)              # Initial temperature gradient
+N², Fb, Fu, f = (parameters[case][p] for p in (:N², :Fb, :Fu, :f))
+βT, g = 2e-4, 9.81
+Fθ, dTdz = Fb / (g*βT), N² / (g*βT)
 
-# Create boundary conditions
-ubcs = HorizontallyPeriodicBCs(    top = BoundaryCondition(Flux, Fu))
-Tbcs = HorizontallyPeriodicBCs(    top = BoundaryCondition(Flux, Fθ),
-                                bottom = BoundaryCondition(Gradient, dTdz))
+# Create boundary conditions. Note that temperature = buoyancy because βT=g=1.
+ubcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fu))
+Tbcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fθ), bottom=BoundaryCondition(Gradient, dTdz))
 
 # Instantiate the model
-model = Model(float_type = DT, 
-                    arch = HAVE_CUDA ? GPU() : CPU(),
-                       N = (N, N, 2N),
+model = Model(      arch = HAVE_CUDA ? GPU() : CPU(),
+                       N = (N, N, N),
                        L = (N*Δ, N*Δ, N*Δ),
-                     eos = LinearEquationOfState(DT, βT=βT, βS=0.0),
-               constants = PlanetaryConstants(DT, f=f, g=g),
-                 closure = AnisotropicMinimumDissipation(DT), # closure = ConstantSmagorinsky(DT),
+                     eos = LinearEquationOfState(βT=βT, βS=0.0),
+               constants = PlanetaryConstants(f=f, g=g),
+                 closure = AnisotropicMinimumDissipation(), # closure = ConstantSmagorinsky(),
                      bcs = BoundaryConditions(u=ubcs, T=Tbcs))
 
 # Set initial condition. Initial velocity and salinity fluctuations needed for AMD.
 Ξ(z) = randn() * z / model.grid.Lz * (1 + z / model.grid.Lz) # noise
-T₀(x, y, z) = 20 + dTdz * z + dTdz * model.grid.Lz * 1e-3 * Ξ(z)
-u₀(x, y, z) = 1e-3 * Ξ(z)
-w₀(x, y, z) = 1e-3 * Ξ(z)
-S₀(x, y, z) = 1e-9 * Ξ(z)
+T₀(x, y, z) = 20 + dTdz * z + dTdz * model.grid.Lz * 1e-6 * Ξ(z)
+ϵ₀(x, y, z) = 1e-4 * Ξ(z)
 
-set_ic!(model, u=u₀, w=w₀, T=T₀, S=S₀)
+set!(model, u=ϵ₀, w=ϵ₀, T=T₀, S=ϵ₀)
 
 #
 # Set up output
 #
 
-function init_savebcs(file, model)
-    file["boundary_conditions/top/FT"] = Fθ
-    file["boundary_conditions/top/Fb"] = Fb
-    file["boundary_conditions/top/Fu"] = Fu
-    file["boundary_conditions/bottom/dTdz"] = dTdz
-    file["boundary_conditions/bottom/dbdz"] = dTdz * g * βT
-    return nothing
-end
-
-filename = @sprintf("simple_flux_Fb%.0e_Fu%.0e_Nsq%.0e_Lz%d_Nz%d",
-                    Fb, Fu, N², model.grid.Lz, model.grid.Nz)
-
 u(model) = Array{Float32}(model.velocities.u.data.parent)
 v(model) = Array{Float32}(model.velocities.v.data.parent)
 w(model) = Array{Float32}(model.velocities.w.data.parent)
-θ(model) = Array{Float32}(model.tracers.T.data.parent)
+T(model) = Array{Float32}(model.tracers.T.data.parent)
 
-fields = Dict(:u=>u, :v=>v, :w=>w, :θ=>θ)
+fields = Dict(:u=>u, :v=>v, :w=>w, :T=>T)
+filename = @sprintf("%s_n%d", case, N)
+field_writer = JLD2OutputWriter(model, fields; dir="data", prefix=filename, interval=hour/4, force=true)
 
-field_writer = JLD2OutputWriter(model, fields; dir="data", prefix=filename,
-                                init=init_savebcs, interval=1hour, force=true)
-
-push!(model.output_writers, field_writer)
+# Uncomment to save output.
+#push!(model.output_writers, field_writer)
 
 # 
 # Run the simulation
 #
 
-if makeplot
-    using PyPlot
-    close("all")
-    fig, axs = subplots()
-end
+@haspyplot fig, axs = subplots()
 
 function terse_message(model, walltime, Δt)
     wmax = maximum(abs, model.velocities.w.data.parent)
     cfl = Δt / Oceananigans.cell_advection_timescale(model)
-
-    return @sprintf(
-        "i: %d, t: %.4f hours, Δt: %.1f s, wmax: %.6f ms⁻¹, cfl: %.3f, wall time: %s\n",
-        model.clock.iteration, model.clock.time/3600, Δt, wmax, cfl, prettytime(1e9*walltime),
-       )
+    return @sprintf("i: %d, t: %.4f hours, Δt: %.1f s, wmax: %.6f ms⁻¹, cfl: %.3f, wall time: %s\n",
+                    model.clock.iteration, model.clock.time/3600, Δt, wmax, cfl, prettytime(1e9*walltime))
 end
 
-# Spin up
-wizard = TimeStepWizard(cfl=0.01, Δt=1.0, max_change=1.1, max_Δt=90.0)
-
-for i = 1:100
-    update_Δt!(wizard, model)
-    walltime = @elapsed time_step!(model, 10, wizard.Δt)
-    @printf "%s" terse_message(model, walltime, wizard.Δt)
-end
-
-# Reset CFL condition values
-wizard.cfl = 0.2
-wizard.max_change = 1.5
+# A wizard for managing the simulation time-step.
+wizard = TimeStepWizard(cfl=0.2, Δt=1.0, max_change=1.1, max_Δt=90.0)
 
 # Run the model
 while model.clock.time < tf
     update_Δt!(wizard, model)
     walltime = @elapsed time_step!(model, 100, wizard.Δt)
-    @printf "%s" terse_message(model, walltime, wizard.Δt)
+    verbose && @printf("%s", terse_message(model, walltime, wizard.Δt))
     
-    if makeplot
+    @haspyplot begin
         sca(axs); cla()
         imshow(rotr90(view(data(model.velocities.w), :, 2, :)))
-        show()
+        gcf(); pause(0.01)
     end
 end

--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -25,7 +25,7 @@ case = :free_convection
 verbose = false
  N = 32                   # Resolution    
  Δ = 0.5                  # Grid spacing
-tf = hour/2               # Final simulation time
+tf = hour/4               # Final simulation time
 
 N², Fb, Fu, f = (parameters[case][p] for p in (:N², :Fb, :Fu, :f))
 βT, g = 2e-4, 9.81

--- a/examples/utils.jl
+++ b/examples/utils.jl
@@ -3,26 +3,6 @@ using Oceananigans
 
 using Statistics
 
-xnodes(ϕ) = repeat(reshape(ϕ.grid.xC, ϕ.grid.Nx, 1, 1), 1, ϕ.grid.Ny, ϕ.grid.Nz)
-ynodes(ϕ) = repeat(reshape(ϕ.grid.yC, 1, ϕ.grid.Ny, 1), ϕ.grid.Nx, 1, ϕ.grid.Nz)
-znodes(ϕ) = repeat(reshape(ϕ.grid.zC, 1, 1, ϕ.grid.Nz), ϕ.grid.Nx, ϕ.grid.Ny, 1)
-
-xnodes(ϕ::FaceFieldX) = repeat(reshape(ϕ.grid.xF[1:end-1], ϕ.grid.Nx, 1, 1), 1, ϕ.grid.Ny, ϕ.grid.Nz)
-ynodes(ϕ::FaceFieldY) = repeat(reshape(ϕ.grid.yF[1:end-1], 1, ϕ.grid.Ny, 1), ϕ.grid.Nx, 1, ϕ.grid.Nz)
-znodes(ϕ::FaceFieldZ) = repeat(reshape(ϕ.grid.zF[1:end-1], 1, 1, ϕ.grid.Nz), ϕ.grid.Nx, ϕ.grid.Ny, 1)
-
-zerofunk(args...) = 0
-
-function set_ic!(model; u=zerofunk, v=zerofunk, w=zerofunk, T=zerofunk, S=zerofunk)
-    Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
-    data(model.velocities.u) .= u.(xnodes(model.velocities.u), ynodes(model.velocities.u), znodes(model.velocities.u))
-    data(model.velocities.v) .= v.(xnodes(model.velocities.v), ynodes(model.velocities.v), znodes(model.velocities.v))
-    data(model.velocities.w) .= w.(xnodes(model.velocities.w), ynodes(model.velocities.w), znodes(model.velocities.w))
-    data(model.tracers.T)    .= T.(xnodes(model.tracers.T),    ynodes(model.tracers.T),    znodes(model.tracers.T))
-    data(model.tracers.S)    .= S.(xnodes(model.tracers.S),    ynodes(model.tracers.S),    znodes(model.tracers.S))
-    return nothing
-end
-
 plotxzslice(ϕ, slice=1, args...; kwargs...) = pcolormesh(
     view(xnodes(ϕ), :, slice, :), view(znodes(ϕ), :, slice, :), view(data(ϕ), :, slice, :), args...; kwargs...)
 

--- a/sandbox/eddying_channel.jl
+++ b/sandbox/eddying_channel.jl
@@ -2,30 +2,6 @@ using Statistics, Printf
 using CuArrays, JLD2, FileIO
 using Oceananigans
 
-include("src/time_step_utils.jl")
-
-xnodes(ϕ) = repeat(reshape(ϕ.grid.xC, ϕ.grid.Nx, 1, 1), 1, ϕ.grid.Ny, ϕ.grid.Nz) |> CuArray
-ynodes(ϕ) = repeat(reshape(ϕ.grid.yC, 1, ϕ.grid.Ny, 1), ϕ.grid.Nx, 1, ϕ.grid.Nz) |> CuArray
-znodes(ϕ) = repeat(reshape(ϕ.grid.zC, 1, 1, ϕ.grid.Nz), ϕ.grid.Nx, ϕ.grid.Ny, 1) |> CuArray
-
-xnodes(ϕ::FaceFieldX) = repeat(reshape(ϕ.grid.xF[1:end-1], ϕ.grid.Nx, 1, 1), 1, ϕ.grid.Ny, ϕ.grid.Nz) |> CuArray
-ynodes(ϕ::FaceFieldY) = repeat(reshape(ϕ.grid.yF[1:end-1], 1, ϕ.grid.Ny, 1), ϕ.grid.Nx, 1, ϕ.grid.Nz) |> CuArray
-znodes(ϕ::FaceFieldZ) = repeat(reshape(ϕ.grid.zF[1:end-1], 1, 1, ϕ.grid.Nz), ϕ.grid.Nx, ϕ.grid.Ny, 1) |> CuArray
-
-zerofunk(args...) = 0
-
-@inline ardata_view(f::Field) = view(f.data.parent, 1+f.grid.Hx:f.grid.Nx+f.grid.Hx, 1+f.grid.Hy:f.grid.Ny+f.grid.Hy, 1+f.grid.Hz:f.grid.Nz+f.grid.Hz)
-
-function set_ic!(model; u=zerofunk, v=zerofunk, w=zerofunk, T=zerofunk, S=zerofunk)
-    Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
-    ardata_view(model.velocities.u) .= u.(xnodes(model.velocities.u), ynodes(model.velocities.u), znodes(model.velocities.u))
-    ardata_view(model.velocities.v) .= v.(xnodes(model.velocities.v), ynodes(model.velocities.v), znodes(model.velocities.v))
-    ardata_view(model.velocities.w) .= w.(xnodes(model.velocities.w), ynodes(model.velocities.w), znodes(model.velocities.w))
-    ardata_view(model.tracers.T)    .= T.(xnodes(model.tracers.T),    ynodes(model.tracers.T),    znodes(model.tracers.T))
-    ardata_view(model.tracers.S)    .= S.(xnodes(model.tracers.S),    ynodes(model.tracers.S),    znodes(model.tracers.S))
-    return nothing
-end
-
 Lx, Ly, Lz = 250e3, 500e3, 1000  # 160×512×1 km
 Nx, Ny, Nz = 256, 512, 128
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -186,13 +186,12 @@ struct GPU <: Architecture end
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()
 
-abstract type Metadata end
 abstract type ConstantsCollection end
 abstract type EquationOfState end
 abstract type Grid{T} end
-abstract type Field end
-abstract type FaceField <: Field end
-abstract type FieldSet end
+abstract type AbstractModel end
+abstract type Field{A, G} end
+abstract type FaceField{A, G} <: Field{A, G} end
 abstract type OutputWriter end
 abstract type Diagnostic end
 abstract type PoissonSolver end

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,11 +1,9 @@
- import GPUifyLoops: @launch, @loop
-
 """
     CellField{A<:AbstractArray, G<:Grid} <: Field
 
 A cell-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct CellField{A<:AbstractArray, G<:Grid} <: Field
+struct CellField{A<:AbstractArray, G<:Grid} <: Field{A, G}
     data::A
     grid::G
 end
@@ -15,7 +13,7 @@ end
 
 An x-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldX{A<:AbstractArray, G<:Grid} <: FaceField
+struct FaceFieldX{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
     data::A
     grid::G
 end
@@ -25,7 +23,7 @@ end
 
 A y-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldY{A<:AbstractArray, G<:Grid} <: FaceField
+struct FaceFieldY{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
     data::A
     grid::G
 end
@@ -35,17 +33,7 @@ end
 
 A z-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldZ{A<:AbstractArray, G<:Grid} <: FaceField
-    data::A
-    grid::G
-end
-
-"""
-    EdgeField{A<:AbstractArray, G<:Grid} <: Field
-
-An edge-centered field defined on a grid `G` whose values are stored in an `A`.
-"""
-struct EdgeField{A<:AbstractArray, G<:Grid} <: Field
+struct FaceFieldZ{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
     data::A
     grid::G
 end
@@ -84,19 +72,15 @@ Return a `FaceFieldZ` with element type `T` on `arch` and `grid`.
 """
 FaceFieldZ(T, arch, grid) = FaceFieldZ(zeros(T, arch, grid), grid)
 
-"""
-    EdgeField([T=eltype(grid)], arch, grid)
-
-Return an `EdgeField` with element type `T` on `arch` and `grid`.
-`T` defaults to the element type of `grid`.
-"""
- EdgeField(T, arch, grid) =  EdgeField(zeros(T, arch, grid), grid)
-
  CellField(arch, grid) =  CellField(zeros(arch, grid), grid)
 FaceFieldX(arch, grid) = FaceFieldX(zeros(arch, grid), grid)
 FaceFieldY(arch, grid) = FaceFieldY(zeros(arch, grid), grid)
 FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
- EdgeField(arch, grid) =  EdgeField(zeros(arch, grid), grid)
+
+fieldtype(::CellField) = CellField
+fieldtype(::FaceFieldX) = FaceFieldX
+fieldtype(::FaceFieldY) = FaceFieldY
+fieldtype(::FaceFieldZ) = FaceFieldZ
 
 @inline size(f::Field) = size(f.grid)
 @inline length(f::Field) = length(f.data)
@@ -121,15 +105,12 @@ FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
 show(io::IO, f::Field) = show(io, f.data)
 iterate(f::Field, state=1) = iterate(f.data, state)
 
-set!(u::Field, v) = u.data.parent .= convert(eltype(u.grid), v)
-set!(u::Field, v::Field) = @. u.data = v.data
-
 # Define +, -, and * on fields as element-wise calculations on their data. This
 # is only true for fields of the same type, e.g. when adding a FaceFieldY to
 # another FaceFieldY, otherwise some interpolation or averaging must be done so
 # that the two fields are defined at the same point, so the operation which
 # will not be commutative anymore.
-for ft in (:CellField, :FaceFieldX, :FaceFieldY, :FaceFieldZ, :EdgeField)
+for ft in (:CellField, :FaceFieldX, :FaceFieldY, :FaceFieldZ)
     for op in (:+, :-, :*)
         @eval begin
             # +, -, * a Field by a Number on the left.
@@ -164,37 +145,125 @@ nodes(ϕ) = (xnodes(ϕ), ynodes(ϕ), znodes(ϕ))
 
 zerofunk(args...) = 0
 
-set_ic!(model; vals..) = set!(mode; vals...)  # legacy wrapper
+set!(u::Field, v::Number) = @. u.data = v
+set!(u::Field{A}, v::Field{A}) where A = @. u.data.parent = v.data.parent
 
-function set!(model; ics...)
-    for (fld, ic) in ics
-        if fld ∈ (:u, :v, :w)
-            ϕ = getproperty(model.velocities, fld)
+"Set the CPU field `u` to the array `v`."
+function set!(u::Field{A}, v::Array) where {
+    A <: OffsetArray{T, D, <:Array} where {T, D}}
+    for k in 1:u.grid.Nz, j in 1:u.grid.Ny, i in 1:u.grid.Nx
+        u[i, j, k] = v[i, j, k]
+    end
+    return nothing
+end
+
+"Set the GPU field `u` to the array `v`."
+@hascuda function set!(u::Field{A}, v::Array) where {
+    A <: OffsetArray{T, D, <:CuArray} where {T, D}}
+
+    FieldType = fieldtype(u)
+    v_field = FieldType(CPU(), u.grid)
+    set!(v_field, v)
+    set!(u, v_field)
+    return nothing
+end
+
+"Set the GPU field `u` to the CuArray `v`."
+@hascuda function set!(u::Field{A}, v::CuArray) where {
+    A <: OffsetArray{T, D, <:CuArray} where {T, D}}
+    @launch device(GPU()) config=launch_config(u.grid, 3) _set_gpu!(u.data, v, u.grid)
+end
+
+function _set_gpu!(u, v, grid)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+	            u[i, j, k] = v[i, j, k]
+	        end
+	    end
+    end
+    return nothing
+end
+
+"Set the GPU field `u` data to the CPU field data of `v`."
+@hascuda function set!(u::Field{Au}, v::Field{Av}) where {
+    Au<:OffsetArray{T1, D, <:CuArray}, Av<:OffsetArray{T2, D, <:Array} where {
+    T1, T2, D}}
+
+    copyto!(u.data.parent, v.data.parent)
+    return nothing
+end
+
+"Set the CPU field `u` data to the GPU field data of `v`."
+@hascuda function set!(u::Field{Au}, v::Field{Av}) where {
+    Au<:OffsetArray{T1, D, <:Array}, Av<:OffsetArray{T2, D, <:CuArray} where {
+    T1, T2, D}}
+
+    u.data.parent .= Array(v.data.parent)
+    return nothing
+end
+
+"Set the CPU field `u` data to the function `f(x, y, z)`."
+set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
+
+"Set the GPU field `u` data to the function `f(x, y, z)`."
+@hascuda function set!(u::Field{A1}, f::Function) where {
+    A1 <: OffsetArray{T, D, <:CuArray} where {T, D}}
+                                                                 
+    u_cpu = CellField(CPU(), u.grid)
+    set!(u_cpu, f)
+    set!(u, u_cpu)
+    return nothing
+end
+
+"""
+    set!(model; kwargs...)
+
+Set velocity and tracer fields of `model`. The keyword arguments 
+`kwargs...` take the form `name=data`, where `name` refers to one of the
+fields of `model.velocities` or `model.tracers`, and the `data` may be an array, 
+a function with arguments `(x, y, z)`, or any data type for which a 
+`set!(ϕ::Field, data)` function exists.
+
+Example
+=======
+
+model = Model(grid=RegularCartesianGrid(N=(32, 32, 32), L=(1, 1, 1))
+
+# Set u to a parabolic function of z, v to random numbers damped
+# at top and bottom, and T to some silly array of half zeros, 
+# half random numbers.
+
+u₀(x, y, z) = z/model.grid.Lz * (1 + z/model.grid.Lz)
+v₀(x, y, z) = 1e-3 * rand() * u₀(x, y, z)
+
+T₀ = rand(size(model.grid)...)
+T₀[T₀ .< 0.5] .= 0
+
+set!(model, u=u₀, v=v₀, T=T₀)
+"""
+function set!(model::AbstractModel; kwargs...)
+    for (fldname, value) in kwargs
+        if fldname ∈ propertynames(model.velocities)
+            ϕ = getproperty(model.velocities, fldname)
+        elseif fldname ∈ propertynames(model.tracers)
+            ϕ = getproperty(model.tracers, fldname)
         else
-            ϕ = getproperty(model.tracers, fld)
+            error("Name $fldname not found in model.velocities or model.tracers.")
         end
-
-        arch, grid = model.arch, model.grid
-        @launch device(arch) config=launch_config(grid, 3) set!(grid, ϕ.data, ic, nodes(ϕ)...)
+        @show data(ϕ) value
+        set!(ϕ, value)
+        @show data(ϕ)
     end
+    return nothing
 end
 
-function set!(grid, ϕ, ic::AbstractArray, args...)
-    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                ϕ[i, j, k] = ic[i, j, k]
-            end
-        end
+function set!(Φ::NamedTuple; kwargs...)
+    for (fldname, value) in kwargs
+        ϕ = getproperty(Φ, fldname)
+        set!(ϕ, value)
     end
+    return nothing
 end
 
-function set!(grid, ϕ, ic::Function, xN, yN, zN)
-    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                ϕ[i, j, k] = ic(xN[i], yN[j], zN[k])
-            end
-        end
-    end
-end
+set_ic!(model; kwargs...) = set!(model; kwargs...)  # legacy wrapper

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -175,7 +175,17 @@ function set_ic!(model; ics...)
     end
 end
 
-function set_initial_condition!(grid, ϕ, ic, xN, yN, zN)
+function set_initial_condition!(grid, ϕ, ic::AbstractArray, args...)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                ϕ[i, j, k] = ic[i, j, k]
+            end
+        end
+    end
+end
+
+function set_initial_condition!(grid, ϕ, ic::Function, xN, yN, zN)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -207,6 +207,7 @@ set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
 
     FieldType = fieldtype(u)
     u_cpu = field_type(CPU(), u.grid)
+    u_cpu = FieldType(CPU(), u.grid)
 
     set!(u_cpu, f)
     set!(u, u_cpu)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -206,7 +206,6 @@ set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
     A1 <: OffsetArray{T, D, <:CuArray} where {T, D}}
 
     FieldType = fieldtype(u)
-    u_cpu = field_type(CPU(), u.grid)
     u_cpu = FieldType(CPU(), u.grid)
 
     set!(u_cpu, f)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -249,11 +249,9 @@ function set!(model::AbstractModel; kwargs...)
         elseif fldname ∈ propertynames(model.tracers)
             ϕ = getproperty(model.tracers, fldname)
         else
-            error("Name $fldname not found in model.velocities or model.tracers.")
+            throw(ArgumentError("name $fldname not found in model.velocities or model.tracers."))
         end
-        @show data(ϕ) value
         set!(ϕ, value)
-        @show data(ϕ)
     end
     return nothing
 end

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -173,9 +173,9 @@ function set!(model; ics...)
         else
             ϕ = getproperty(model.tracers, fld)
         end
-        
+
         arch, grid = model.arch, model.grid
-        @launch device(arch) config=launch_config(grid, 3) set_initial_condition!(grid, ϕ.data, ic, nodes(ϕ)...)
+        @launch device(arch) config=launch_config(grid, 3) set!(grid, ϕ.data, ic, nodes(ϕ)...)
     end
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -173,7 +173,9 @@ function set!(model; ics...)
         else
             ϕ = getproperty(model.tracers, fld)
         end
-        data(ϕ) .= ic.(nodes(ϕ)...)
+        
+        arch, grid = model.arch, model.grid
+        @launch device(arch) config=launch_config(grid, 3) set_initial_condition!(grid, ϕ.data, ic, nodes(ϕ)...)
     end
 end
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -77,10 +77,7 @@ FaceFieldX(arch, grid) = FaceFieldX(zeros(arch, grid), grid)
 FaceFieldY(arch, grid) = FaceFieldY(zeros(arch, grid), grid)
 FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
 
-fieldtype(::CellField) = CellField
-fieldtype(::FaceFieldX) = FaceFieldX
-fieldtype(::FaceFieldY) = FaceFieldY
-fieldtype(::FaceFieldZ) = FaceFieldZ
+fieldtype(f::Field) = typeof(f).name.wrapper
 
 @inline size(f::Field) = size(f.grid)
 @inline length(f::Field) = length(f.data)
@@ -208,8 +205,7 @@ set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
 @hascuda function set!(u::Field{A1}, f::Function) where {
     A1 <: OffsetArray{T, D, <:CuArray} where {T, D}}
 
-    # Get type of u, e.g. CellField or FaceFieldX.
-    field_type = typeof(u).name.wrapper
+    FieldType = fieldtype(u)
     u_cpu = field_type(CPU(), u.grid)
 
     set!(u_cpu, f)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -207,8 +207,11 @@ set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
 "Set the GPU field `u` data to the function `f(x, y, z)`."
 @hascuda function set!(u::Field{A1}, f::Function) where {
     A1 <: OffsetArray{T, D, <:CuArray} where {T, D}}
-                                                                 
-    u_cpu = CellField(CPU(), u.grid)
+
+    # Get type of u, e.g. CellField or FaceFieldX.
+    field_type = typeof(u).name.wrapper
+    u_cpu = field_type(CPU(), u.grid)
+
     set!(u_cpu, f)
     set!(u, u_cpu)
     return nothing

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -164,7 +164,9 @@ nodes(ϕ) = (xnodes(ϕ), ynodes(ϕ), znodes(ϕ))
 
 zerofunk(args...) = 0
 
-function set_ic!(model; ics...)
+set_ic!(model; vals..) = set!(mode; vals...)  # legacy wrapper
+
+function set!(model; ics...)
     for (fld, ic) in ics
         if fld ∈ (:u, :v, :w)
             ϕ = getproperty(model.velocities, fld)
@@ -175,7 +177,7 @@ function set_ic!(model; ics...)
     end
 end
 
-function set_initial_condition!(grid, ϕ, ic::AbstractArray, args...)
+function set!(grid, ϕ, ic::AbstractArray, args...)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -185,7 +187,7 @@ function set_initial_condition!(grid, ϕ, ic::AbstractArray, args...)
     end
 end
 
-function set_initial_condition!(grid, ϕ, ic::Function, xN, yN, zN)
+function set!(grid, ϕ, ic::Function, xN, yN, zN)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -187,8 +187,7 @@ end
 
 "Set the GPU field `u` data to the CPU field data of `v`."
 @hascuda function set!(u::Field{Au}, v::Field{Av}) where {
-    Au<:OffsetArray{T1, D, <:CuArray}, Av<:OffsetArray{T2, D, <:Array} where {
-    T1, T2, D}}
+    Au<:OffsetArray{T1, D, <:CuArray}, Av<:OffsetArray{T2, D, <:Array}} where {T1, T2, D}
 
     copyto!(u.data.parent, v.data.parent)
     return nothing
@@ -196,8 +195,7 @@ end
 
 "Set the CPU field `u` data to the GPU field data of `v`."
 @hascuda function set!(u::Field{Au}, v::Field{Av}) where {
-    Au<:OffsetArray{T1, D, <:Array}, Av<:OffsetArray{T2, D, <:CuArray} where {
-    T1, T2, D}}
+    Au<:OffsetArray{T1, D, <:Array}, Av<:OffsetArray{T2, D, <:CuArray}} where {T1, T2, D}
 
     u.data.parent .= Array(v.data.parent)
     return nothing

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,3 +1,5 @@
+ import GPUifyLoops: @launch, @loop
+
 """
     CellField{A<:AbstractArray, G<:Grid} <: Field
 
@@ -171,5 +173,14 @@ function set_ic!(model; ics...)
         end
         data(ϕ) .= ic.(nodes(ϕ)...)
     end
-    return nothing
+end
+
+function set_initial_condition!(grid, ϕ, ic, xN, yN, zN)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                ϕ[i, j, k] = ic(xN[i], yN[j], zN[k])
+            end
+        end
+    end
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -2,7 +2,7 @@ using .TurbulenceClosures
 
 mutable struct Model{A<:Architecture, GR, T, EOS<:EquationOfState, 
                      PC<:PlanetaryConstants, 
-                     VC, TR, PF, F, TC, BCS, TS, PS, D}
+                     VC, TR, PF, F, TC, BCS, TS, PS, D} <: AbstractModel
 
               arch :: A                      # Computer `Architecture` on which `Model` is run
               grid :: GR                     # Grid of physical points on which `Model` is solved

--- a/src/operators/ops_regular_cartesian_grid.jl
+++ b/src/operators/ops_regular_cartesian_grid.jl
@@ -1,6 +1,5 @@
 using Oceananigans:
-    RegularCartesianGrid,
-    Field, CellField, FaceField, FaceFieldX, FaceFieldY, FaceFieldZ, EdgeField
+    RegularCartesianGrid
 
 @inline δx_c2f(g::RegularCartesianGrid, f, i, j, k) = @inbounds f[i,   j, k] - f[i-1, j, k]
 @inline δx_f2c(g::RegularCartesianGrid, f, i, j, k) = @inbounds f[i+1, j, k] - f[i,   j, k]

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -71,29 +71,6 @@ function time_step!(model, arch, grid, constants, eos, closure, forcing, bcs, U,
     return nothing
 end
 
-# Dynamic launch configuration
-function launch_config(grid, dims)
-    return function (kernel)
-        fun = kernel.fun
-        config = launch_configuration(fun)
-
-        # adapt the suggested config from 1D to the requested grid dimensions
-        if dims == 3
-            threads = floor(Int, cbrt(config.threads))
-            blocks = ceil.(Int, [grid.Nx, grid.Ny, grid.Nz] ./ threads)
-            threads = [threads, threads, threads]
-        elseif dims == 2
-            threads = floor(Int, sqrt(config.threads))
-            blocks = ceil.(Int, [grid.Nx, grid.Ny] ./ threads)
-            threads = [threads, threads]
-        else
-            error("unsupported launch configuration")
-        end
-
-        return (threads=Tuple(threads), blocks=Tuple(blocks))
-    end
-end
-
 time_step!(model; Nt, Δt, kwargs...) = time_step!(model, Nt, Δt; kwargs...)
 
 function solve_for_pressure!(::CPU, model::Model)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -128,3 +128,25 @@ function getindex(t::NamedTuple, r::AbstractUnitRange{<:Real})
     NamedTuple{Tuple(names)}(Tuple(elems))
 end
 
+# Dynamic launch configuration
+function launch_config(grid, dims)
+    return function (kernel)
+        fun = kernel.fun
+        config = launch_configuration(fun)
+
+        # adapt the suggested config from 1D to the requested grid dimensions
+        if dims == 3
+            threads = floor(Int, cbrt(config.threads))
+            blocks = ceil.(Int, [grid.Nx, grid.Ny, grid.Nz] ./ threads)
+            threads = [threads, threads, threads]
+        elseif dims == 2
+            threads = floor(Int, sqrt(config.threads))
+            blocks = ceil.(Int, [grid.Nx, grid.Ny] ./ threads)
+            threads = [threads, threads]
+        else
+            error("unsupported launch configuration")
+        end
+
+        return (threads=Tuple(threads), blocks=Tuple(blocks))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,4 +30,5 @@ float_types = (Float32, Float64)
     include("test_dynamics.jl")
     include("test_output_writers.jl")
     include("test_regression.jl")
+    include("test_examples.jl")
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -7,5 +7,5 @@ function run_example(examplename)
 end
 
 @testset "Examples" begin
-    @test run_example("deepening_mixed_layer.jl")
+    @test_skip run_example("deepening_mixed_layer.jl")
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,0 +1,11 @@
+examplespath = normpath(joinpath(@__FILE__, "..", "..", "examples"))
+
+function run_example(examplename)
+    println("    Running example $examplename")
+    include(joinpath(examplespath, examplename))
+    return true
+end
+
+@testset "Examples" begin
+    @test run_example("deepening_mixed_layer.jl")
+end

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -4,9 +4,9 @@
 Test that the field initialized by the field type function `ftf` on the grid g
 has the correct size.
 """
-function correct_field_size(arch::Architecture, g::Grid, field_type)
-    f = field_type(arch, g)
-    size(f) == size(g)
+function correct_field_size(arch::Architecture, g::Grid, fieldtype)
+    f = fieldtype(arch, g)
+    return size(f) == size(g)
 end
 
 """
@@ -16,15 +16,15 @@ Test that the field initialized by the field type function `ftf` on the grid g
 can be correctly filled with the value `val` using the `set!(f::Field, v)`
 function.
 """
-function correct_field_value_was_set(arch::Architecture, g::Grid, field_type, val::Number)
-    f = field_type(arch, g)
+function correct_field_value_was_set(arch::Architecture, g::Grid, fieldtype, val::Number)
+    f = fieldtype(arch, g)
     set!(f, val)
-    data(f) ≈ val * ones(size(f))
+    return data(f) ≈ val * ones(size(f))
 end
 
-function correct_field_addition(arch::Architecture, g::Grid, field_type, val1::Number, val2::Number)
-    f1 = field_type(arch, g)
-    f2 = field_type(arch, g)
+function correct_field_addition(arch::Architecture, g::Grid, fieldtype, val1::Number, val2::Number)
+    f1 = fieldtype(arch, g)
+    f2 = fieldtype(arch, g)
 
     set!(f1, val1)
     set!(f2, val2)
@@ -32,24 +32,41 @@ function correct_field_addition(arch::Architecture, g::Grid, field_type, val1::N
 
     val3 = convert(mm.float_type, val1) + convert(mm.float_type, val2)
     f_ans = val3 * ones(size(f1))
-    f3.data ≈ f_ans
+    return f3.data ≈ f_ans
 end
 
+function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
+
+    model = Model(arch=arch, float_type=eltype(grid), 
+                  N=size(grid), L=(grid.Lx, grid.Ly, grid.Lz))
+
+    kwarg = Dict(fieldname=>value)
+    set!(model; kwarg...)
+
+    if fieldname ∈ propertynames(model.velocities)
+        ϕ = getproperty(model.velocities, fieldname)
+    else
+        ϕ = getproperty(model.tracers, fieldname)
+    end
+
+    return data(ϕ) ≈ answer
+end
+ 
 @testset "Fields" begin
     println("Testing fields...")
 
     N = (4, 6, 8)
     L = (2π, 3π, 5π)
 
-    field_types = [CellField, FaceFieldX, FaceFieldY, FaceFieldZ, EdgeField]
+    fieldtypes = (CellField, FaceFieldX, FaceFieldY, FaceFieldZ)
 
     @testset "Field initialization" begin
         println("  Testing field initialization...")
         for arch in archs, FT in float_types
             grid = RegularCartesianGrid(FT, N, L)
 
-            for field_type in field_types
-                @test correct_field_size(arch, grid, field_type)
+            for fieldtype in fieldtypes
+                @test correct_field_size(arch, grid, fieldtype)
             end
         end
     end
@@ -67,19 +84,27 @@ end
         for arch in archs, FT in float_types
             grid = RegularCartesianGrid(FT, N, L)
 
-            for field_type in field_types, val in vals
-                @test correct_field_value_was_set(arch, grid, field_type, val)
+            for fieldtype in fieldtypes, val in vals
+                @test correct_field_value_was_set(arch, grid, fieldtype, val)
+            end
+        end
+
+        for FT in float_types
+            grid = RegularCartesianGrid(FT, N, L)
+            xF = reshape(grid.xF[1:end-1], N[1], 1, 1)
+            yC = reshape(grid.yC, 1, N[2], 1)
+            zC = reshape(grid.zC, 1, 1, N[3])
+
+            u₀(x, y, z) = x * y^2 * z^3
+            u_answer = @. xF * yC^2 * zC^3
+
+            T₀ = rand(size(grid)...)
+            T_answer = deepcopy(T₀)
+
+            for arch in archs
+                @test set_velocity_tracer_fields(arch, grid, :u, u₀, u_answer)
+                @test set_velocity_tracer_fields(arch, grid, :T, T₀, T_answer)
             end
         end
     end
-
-    # @testset "Field operations" begin
-    #     for arch in archs, FT in float_types
-    #         grid = RegularCartesianGrid(FT, N, L)
-    #
-    #         for field_type in field_types, val1 in vals, val2 in vals
-    #             @test correct_field_addition(arch, grid, field_type, val1, val2)
-    #         end
-    #     end
-    # end
 end

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -35,23 +35,6 @@ function correct_field_addition(arch::Architecture, g::Grid, fieldtype, val1::Nu
     return f3.data ≈ f_ans
 end
 
-function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
-
-    model = Model(arch=arch, float_type=eltype(grid), 
-                  N=size(grid), L=(grid.Lx, grid.Ly, grid.Lz))
-
-    kwarg = Dict(fieldname=>value)
-    set!(model; kwarg...)
-
-    if fieldname ∈ propertynames(model.velocities)
-        ϕ = getproperty(model.velocities, fieldname)
-    else
-        ϕ = getproperty(model.tracers, fieldname)
-    end
-
-    return data(ϕ) ≈ answer
-end
- 
 @testset "Fields" begin
     println("Testing fields...")
 
@@ -86,24 +69,6 @@ end
 
             for fieldtype in fieldtypes, val in vals
                 @test correct_field_value_was_set(arch, grid, fieldtype, val)
-            end
-        end
-
-        for FT in float_types
-            grid = RegularCartesianGrid(FT, N, L)
-            xF = reshape(grid.xF[1:end-1], N[1], 1, 1)
-            yC = reshape(grid.yC, 1, N[2], 1)
-            zC = reshape(grid.zC, 1, 1, N[3])
-
-            u₀(x, y, z) = x * y^2 * z^3
-            u_answer = @. xF * yC^2 * zC^3
-
-            T₀ = rand(size(grid)...)
-            T_answer = deepcopy(T₀)
-
-            for arch in archs
-                @test set_velocity_tracer_fields(arch, grid, :u, u₀, u_answer)
-                @test set_velocity_tracer_fields(arch, grid, :T, T₀, T_answer)
             end
         end
     end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -1,28 +1,46 @@
+function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
+    model = Model(arch=arch, float_type=eltype(grid),
+                  N=size(grid), L=(grid.Lx, grid.Ly, grid.Lz))
+
+    kwarg = Dict(fieldname=>value)
+    set!(model; kwarg...)
+
+    if fieldname ∈ propertynames(model.velocities)
+        ϕ = getproperty(model.velocities, fieldname)
+    else
+        ϕ = getproperty(model.tracers, fieldname)
+    end
+
+    return data(ϕ) ≈ answer
+end
+
 function initial_conditions_correctly_set(arch, FT)
-    model = Model(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT)
+    model = Model(N=(16, 16, 8), L=(1, 2, 3), arch=arch, float_type=FT)
 
     # Set initial condition to some basic function we can easily check for.
     # We offset the functions by an integer so that we don't end up comparing
     # zero values with other zero values. I was too lazy to pick clever functions.
     u₀(x, y, z) = 1 + x+y+z
     v₀(x, y, z) = 2 + sin(x*y*z)
-    w₀(x, y, z) = 3 + exp(y/z)
+    w₀(x, y, z) = 3 + y*z
     T₀(x, y, z) = 4 + tanh(x+y-z)
+    S₀(x, y, z) = 5
 
-    set_ic!(model; u=u₀, v=v₀, w=w₀, T=T₀)
+    set_ic!(model; u=u₀, v=v₀, w=w₀, T=T₀, S=S₀)
 
     Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
     xC, yC, zC = model.grid.xC, model.grid.yC, model.grid.zC
     xF, yF, zF = model.grid.xF, model.grid.yF, model.grid.zF
     u, v, w = model.velocities.u.data, model.velocities.v.data, model.velocities.w.data
-    T = model.tracers.T.data
+    T, S = model.tracers.T.data, model.tracers.S.data
 
     all_values_match = true
     for i in 1:Nx, j in 1:Ny, k in 1:Nz
-        values_match = ( u[i, j, k] ≈ 1 + xF[i] + yC[j] + zC[k]      &&
-                         v[i, j, k] ≈ 2 + sin(xC[i] * yF[j] * zC[k]) &&
-                         w[i, j, k] ≈ 3 + exp(yC[j] / zF[k])         &&
-                         T[i, j, k] ≈ 4 + tanh(xC[i] + yC[j] - zC[k]))
+        values_match = ( u[i, j, k] ≈ 1 + xF[i] + yC[j] + zC[k]       &&
+                         v[i, j, k] ≈ 2 + sin(xC[i] * yF[j] * zC[k])  &&
+                         w[i, j, k] ≈ 3 + yC[j] * zF[k]               &&
+                         T[i, j, k] ≈ 4 + tanh(xC[i] + yC[j] - zC[k]) &&
+                         S[i, j, k] ≈ 5)
         all_values_match = all_values_match & values_match
     end
 
@@ -52,9 +70,26 @@ end
         end
     end
 
-    @testset "Setting initial conditions" begin
-        println("  Testing setting initial conditions...")
+    @testset "Setting model fields" begin
+        println("  Testing setting model fields...")
         for arch in archs, FT in float_types
+            N = (4, 6, 8)
+            L = (2π, 3π, 5π)
+
+            grid = RegularCartesianGrid(FT, N, L)
+            xF = reshape(grid.xF[1:end-1], N[1], 1, 1)
+            yC = reshape(grid.yC, 1, N[2], 1)
+            zC = reshape(grid.zC, 1, 1, N[3])
+
+            u₀(x, y, z) = x * y^2 * z^3
+            u_answer = @. xF * yC^2 * zC^3
+
+            T₀ = rand(size(grid)...)
+            T_answer = deepcopy(T₀)
+
+            @test set_velocity_tracer_fields(arch, grid, :u, u₀, u_answer)
+            @test set_velocity_tracer_fields(arch, grid, :T, T₀, T_answer)
+
             @test initial_conditions_correctly_set(arch, FT)
         end
     end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -1,3 +1,34 @@
+function initial_conditions_correctly_set(arch, FT)
+    model = Model(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT)
+
+    # Set initial condition to some basic function we can easily check for.
+    # We offset the functions by an integer so that we don't end up comparing
+    # zero values with other zero values. I was too lazy to pick clever functions.
+    u₀(x, y, z) = 1 + x+y+z
+    v₀(x, y, z) = 2 + sin(x*y*z)
+    w₀(x, y, z) = 3 + exp(y/z)
+    T₀(x, y, z) = 4 + tanh(x+y-z)
+
+    set_ic!(model; u=u₀, v=v₀, w=w₀, T=T₀)
+
+    Nx, Ny, Nz = model.grid.Nx, model.grid.Ny, model.grid.Nz
+    xC, yC, zC = model.grid.xC, model.grid.yC, model.grid.zC
+    xF, yF, zF = model.grid.xF, model.grid.yF, model.grid.zF
+    u, v, w = model.velocities.u.data, model.velocities.v.data, model.velocities.w.data
+    T = model.tracers.T.data
+
+    all_values_match = true
+    for i in 1:Nx, j in 1:Ny, k in 1:Nz
+        values_match = ( u[i, j, k] ≈ 1 + xF[i] + yC[j] + zC[k]      &&
+                         v[i, j, k] ≈ 2 + sin(xC[i] * yF[j] * zC[k]) &&
+                         w[i, j, k] ≈ 3 + exp(yC[j] / zF[k])         &&
+                         T[i, j, k] ≈ 4 + tanh(xC[i] + yC[j] - zC[k]))
+        all_values_match = all_values_match & values_match
+    end
+
+    return all_values_match
+end
+
 @testset "Models" begin
     println("Testing models...")
 
@@ -18,6 +49,13 @@
 
             # Just testing that a ChannelModel was constructed with no errors/crashes.
             @test true
+        end
+    end
+
+    @testset "Setting initial conditions" begin
+        println("  Testing setting initial conditions...")
+        for arch in archs, FT in float_types
+            @test initial_conditions_correctly_set(arch, FT)
         end
     end
 end


### PR DESCRIPTION
Just combining my commits from PRs #337 and #341.

Idea is to make life more comfortable by getting `set!` to work out of the box for CPU and GPU fields, and for setting them with functions or arrays.

The functions should be evaluated on the CPU as not every function is available through CUDAnative (notably `rand` and `randn` are missing).

Will switch to using `copyto!`.