### PR TITLE
time_to_run utility shared between diagnostics and output writers

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -3,26 +3,6 @@ using Printf
 
 @hascuda using CUDAdrv, CUDAnative
 
-function time_to_run(clock::Clock, diag::Diagnostic)
-    if :interval in propertynames(diag) && diag.interval != nothing
-        if clock.time >= diag.previous + diag.interval
-            diag.previous = clock.time - rem(clock.time, diag.interval)
-            return true
-        else
-            return false
-        end
-    elseif :frequency in propertynames(diag) && diag.frequency != nothing
-        return clock.iteration % diag.frequency == 0
-    else
-        error("Diagnostic $(typeof(diag)) must have a frequency or interval specified!")
-    end
-end
-
-function validate_interval(frequency, interval)
-    isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
-    return
-end
-
 ####
 #### Useful kernels
 ####

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -1,25 +1,5 @@
 ext(fw::OutputWriter) = throw("Extension for $(typeof(fw)) is not implemented.")
 
-function time_to_write(clock::Clock, diag::OutputWriter)
-    if :interval in propertynames(diag) && diag.interval != nothing
-        if clock.time >= diag.previous + diag.interval
-            diag.previous = clock.time - rem(clock.time, diag.interval)
-            return true
-        else
-            return false
-        end
-    elseif :frequency in propertynames(diag) && diag.frequency != nothing
-        return clock.iteration % diag.frequency == 0
-    else
-        error("$(typeof(diag)) must have a frequency or interval specified!")
-    end
-end
-
-function validate_interval(frequency, interval)
-    isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
-    return
-end
-
 # When saving stuff to disk like a JLD2 file, `saveproperty!` is used, which
 # converts Julia objects to language-agnostic objects.
 saveproperty!(file, location, p::Number)        = file[location] = p

--- a/src/planetary_constants.jl
+++ b/src/planetary_constants.jl
@@ -1,8 +1,3 @@
-# Some useful constants
-const second = 1.0
-const minute = 60.0
-const hour = 60minute
-const day = 24hour
 
 struct PlanetaryConstants{T<:AbstractFloat} <: ConstantsCollection
     Ω::T  # Rotation rate of the planet [rad/s].

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -28,7 +28,7 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
                    model.forcing, model.boundary_conditions, U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)
 
         [ time_to_run(model.clock, diag) && run_diagnostic(model, diag) for diag in model.diagnostics ]
-        [ time_to_write(model.clock, out) && write_output(model, out) for out in model.output_writers ]
+        [ time_to_run(model.clock, out) && write_output(model, out) for out in model.output_writers ]
     end
 
     return nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,8 +205,8 @@ function validate_interval(frequency, interval)
     return
 end
 
-hasinterval(obj) = :interval in propertynames(d) && d.interval != nothing
-hasfrequency(obj) = :frequency in propertynames(d) && d.frequency != nothing
+hasinterval(obj) = :interval in propertynames(obj) && obj.interval != nothing
+hasfrequency(obj) = :frequency in propertynames(obj) && obj.frequency != nothing
 
 frequencyover(clock, obj) = clock.iteration % obj.frequency == 0
 
@@ -219,13 +219,13 @@ function intervalover(clock, obj)
     end
 end
 
-function time_to_write(clock, d::Union{Diagnostic,OutputWriter})
+function time_to_run(clock, d::Union{Diagnostic,OutputWriter})
     if hasinterval(d) && hasfrequency(d)
-        return intervalover(clock, d) || frequencyover(d)
+        return intervalover(clock, d) || frequencyover(clock, d)
     elseif hasinterval(d)
-        return intervalover(d)
+        return intervalover(clock, d)
     elseif hasfrequency(d)
-        return frequencyover(d)
+        return frequencyover(clock, d)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -195,3 +195,25 @@ function launch_config(grid, dims)
         return (threads=Tuple(threads), blocks=Tuple(blocks))
     end
 end
+
+####
+#### Utilities shared between 
+####
+
+function validate_interval(frequency, interval)
+    isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
+    return
+end
+
+function time_to_write(clock, d::Union{Diagnostic,OutputWriter})
+    if :interval in propertynames(d) && d.interval != nothing
+        if clock.time >= d.previous + d.interval
+            d.previous = clock.time - rem(clock.time, d.interval)
+            return true
+        else
+            return false
+        end
+    elseif :frequency in propertynames(d) && d.frequency != nothing
+        return clock.iteration % d.frequency == 0
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,21 @@ Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(adapt(to, parent(x)), x.
 #Adapt.adapt_structure(to, A::SubArray{<:Any,<:Any,AT}) where {AT} =
 #    SubArray(adapt(to, parent(A)), adapt.(Ref(to), parentindices(A)))
 
+####
+#### Convinient definitions
+####
+
+const second = 1.0
+const minute = 60.0
+const hour   = 60minute
+const day    = 24hour
+
+KiB, MiB, GiB, TiB = 1024.0 .^ (1:4)
+
+####
+#### Pretty printing
+####
+
 # Source: https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/src/trials.jl
 function prettytime(t)
     if t < 1e-6
@@ -22,9 +37,8 @@ function prettytime(t)
     return @sprintf("%.3f", value) * " " * units
 end
 
-KiB, MiB, GiB, TiB = 1024.0 .^ (1:4)
 
-# Code credit: https://stackoverflow.com/a/1094933
+# Source: https://stackoverflow.com/a/1094933
 function pretty_filesize(s, suffix="B")
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]
         abs(s) < 1024 && return @sprintf("%3.1f %s%s", s, unit, suffix)
@@ -32,6 +46,10 @@ function pretty_filesize(s, suffix="B")
     end
     return @sprintf("%.1f %s%s", s, "Yi", suffix)
 end
+
+####
+#### Creating fields by dispatching on architecture
+####
 
 function Base.zeros(T, ::CPU, grid)
     # Starting and ending indices for the offset array.
@@ -61,6 +79,10 @@ Base.zeros(T, ::GPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz) |> CuArray
 Base.zeros(arch, grid::Grid{T}) where T = zeros(T, arch, grid)
 Base.zeros(arch, grid::Grid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, Ny, Nz)
 
+####
+#### Courant–Friedrichs–Lewy (CFL) condition number calculation
+####
+
 function cell_advection_timescale(u, v, w, grid)
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
@@ -78,6 +100,10 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
+
+####
+#### Adaptive time stepping
+####
 
 """
     TimeStepWizard(cfl=0.1, max_change=2.0, min_change=0.5, max_Δt=Inf, kwargs...)
@@ -119,6 +145,10 @@ function update_Δt!(wizard, model)
     return nothing
 end
 
+####
+#### Data tuples
+####
+
 @inline datatuple(obj::Nothing) = nothing
 @inline datatuple(obj::AbstractArray) = obj
 @inline datatuple(obj::Field) = obj.data
@@ -140,7 +170,10 @@ function getindex(t::NamedTuple, r::AbstractUnitRange{<:Real})
     NamedTuple{Tuple(names)}(Tuple(elems))
 end
 
-# Dynamic launch configuration
+####
+#### Dynamic launch configuration
+####
+
 function launch_config(grid, dims)
     return function (kernel)
         fun = kernel.fun

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -197,7 +197,7 @@ function launch_config(grid, dims)
 end
 
 ####
-#### Utilities shared between 
+#### Utilities shared between diagnostics and output writers
 ####
 
 function validate_interval(frequency, interval)


### PR DESCRIPTION
This is because we agreed that diagnostics and output writers should be able to specify both a frequency and an interval.

Also reorganizing `utils.jl` as it was bothering me.