### PR TITLE
Fill halo regions for diffusivity

### DIFF
--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -69,7 +69,7 @@ end
 Fill halo regions for all fields in the tuple `fields` according
 to the corresponding tuple of `bcs`.
 """
-function fill_halo_regions!(fields::NamedTuple, bcs::NamedTuple, grid)
+function fill_halo_regions!(fields::NamedTuple, bcs, grid)
     for (field, fieldbcs) in zip(fields, bcs)
         fill_halo_regions!(field, fieldbcs, grid)
     end

--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -69,12 +69,26 @@ end
 Fill halo regions for all fields in the tuple `fields` according
 to the corresponding tuple of `bcs`.
 """
-function fill_halo_regions!(fields::NamedTuple, bcs, grid)
+function fill_halo_regions!(fields::NamedTuple, bcs::NamedTuple, grid)
     for (field, fieldbcs) in zip(fields, bcs)
         fill_halo_regions!(field, fieldbcs, grid)
     end
     return
 end
+
+"""
+    fill_halo_regions!(fields, bcs, grid)
+
+Fill halo regions for each field in the tuple `fields` according
+to the single instances of `FieldBoundaryConditions` in `bcs`.
+"""
+function fill_halo_regions!(fields::NamedTuple, bcs::NamedTuple{(:x, :y, :z)}, grid)
+    for field in fields
+        fill_halo_regions!(field, bcs, grid)
+    end
+end
+
+fill_halo_regions!(::Nothing, args...) = nothing
 
 ####
 #### Zeroing out halo regions

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -46,8 +46,9 @@ function time_step!(model, arch, grid, constants, eos, closure, forcing, bcs, U,
     fill_halo_regions!(merge(U, Φ), bcs, grid)
 
     @launch device(arch) config=launch_config(grid, 3) calc_diffusivities!(K, grid, closure, eos, constants.g, U, Φ)
+    fill_halo_regions!(K, bcs[4], grid) # fill diffusivity halo regions with same conditions as temperature
     @launch device(arch) config=launch_config(grid, 2) update_hydrostatic_pressure!(p.pHY′, grid, constants, eos, Φ)
-    fill_halo_regions!(p.pHY′, bcs[4], grid)
+    fill_halo_regions!(p.pHY′, bcs[4], grid) # fill pressure halo regions with same conditions as temperature
 
     # Calc RHS:
     calculate_interior_source_terms!(arch, grid, constants, eos, closure, U, Φ, p.pHY′, Gⁿ, K, forcing)


### PR DESCRIPTION
This fixes a bug in which halo regions were not filled for subgrid-scale LES diffusivities. 

To do this robustly for various diffusivity structures with different nesting hierarchies, a recursive halo region filling functionality is implemented that dispatches on `bcs::NamedTuple{(:x, :y:, :z)}`, corresponding to a `FieldBoundaryCondition`. Thus, when `fill_halo_regions!(fields, bcs, grid)` is called with matching tuples for *both* `fields` and `bcs`, a simultaneous loop is done over the members of the two tuples. However, when `fill_halo_regions!(fields, bcs, grid)` is called and `bcs` is a `FieldBoundaryCondition`, a loop is performed over the members of `fields` *only*, and `bcs` is reused for every member of `fields`. Thus halo regions for fields embedded in nested structures (like diffusivities in `AnisotropicMinimumDissipation`) are all filled with a single call to `fill_halo_regions!`.

For now, the code uses temperature boundary conditions to determine the diffusivity boundary conditions. This will work until we implement the changes proposed in #371.