### PR TITLE
Improve HorizontalAverage and time to write function

### DIFF
--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -52,7 +52,7 @@ staggered grid) before computing the horizontal average.
 function run_diagnostic(model::Model, havg::HorizontalAverage{NTuple{1}})
     zero_halo_regions!(havg.fields[1], model.grid)
     sum!(havg.profile, havg.fields[1])
-    normalize_horizontal_sum!(havg.profile, model.grid)
+    normalize_horizontal_sum!(havg, model.grid)
     return
 end
 
@@ -65,7 +65,7 @@ function run_diagnostic(model::Model, havg::HorizontalAverage)
 
     @. tmp = *(havg.fields...)
     sum!(havg.profile, tmp)
-    normalize_horizontal_sum!(havg.profile, model.grid)
+    normalize_horizontal_sum!(havg, model.grid)
 
     return
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,11 +1,6 @@
 using Statistics: mean
 using Printf
 
-@hascuda using CUDAdrv, CUDAnative
-
-# Use time_to_write from output_writers.jl
-time_to_run(clock, diag) = time_to_write(clock, diag)
-
 ####
 #### Useful kernels
 ####
@@ -43,13 +38,13 @@ function HorizontalAverage(model, fields; frequency=nothing, interval=nothing,
 end
 
 "Normalize a horizontal sum to get the horizontal average."
-normalize_horizontal_sum!(hsum, grid) = hsum.profile /= (grid.Nx * grid.Ny)  
+normalize_horizontal_sum!(hsum, grid) = hsum.profile /= (grid.Nx * grid.Ny)
 
 """
     run_diagnostic(model, havg)
 
 Compute the horizontal average of `havg.fields` and store the
-result in `havg.profile`. If length(fields) > 1, compute the 
+result in `havg.profile`. If length(fields) > 1, compute the
 product of the elements of fields (without taking into account
 the possibility that they may have different locations in the
 staggered grid) before computing the horizontal average.
@@ -80,7 +75,7 @@ function (havg::HorizontalAverage{F, Nothing})(model) where F
     return p.profile
 end
 
-function (havg::HorizontalAverage)(model) 
+function (havg::HorizontalAverage)(model)
     run_diagnostic(model, havg)
     return return_type(havg.profile)
 end

--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -77,7 +77,7 @@ function fill_halo_regions!(fields::NamedTuple, bcs, grid)
 end
 
 ####
-#### Zeroing out halo regions
+#### Halo region zeroing
 ####
 
  zero_west_halo!(ϕ, H, N) = @views @. ϕ[1:H, :, :] = 0

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -1,23 +1,40 @@
 ext(fw::OutputWriter) = throw("Extension for $(typeof(fw)) is not implemented.")
 
-function time_to_write(clock::Clock, diag::OutputWriter)
-    if :interval in propertynames(diag) && diag.interval != nothing
-        if clock.time >= diag.previous + diag.interval
-            diag.previous = clock.time - rem(clock.time, diag.interval)
-            return true
-        else
-            return false
-        end
-    elseif :frequency in propertynames(diag) && diag.frequency != nothing
-        return clock.iteration % diag.frequency == 0
-    else
-        error("$(typeof(diag)) must have a frequency or interval specified!")
-    end
-end
+"""
+    validate_interval(frequency, interval)
 
+Ensure that frequency and interval are not both `nothing`.
+"""
 function validate_interval(frequency, interval)
     isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
     return
+end
+
+has_interval(obj) = :interval in propertynames(obj) && obj.interval != nothing
+has_frequency(obj) = :frequency in propertynames(obj) && obj.frequency != nothing
+
+function interval_is_ripe(clock, obj)
+    if has_interval(obj) && clock.time >= obj.previous + obj.interval
+        obj.previous = clock.time - rem(clock.time, obj.interval)
+        return true
+    else
+        return false
+    end
+end
+
+frequency_is_ripe(clock, obj) = has_frequency(obj) && clock.iteration % obj.frequency == 0
+
+function time_to_write(clock, output_writer)
+
+    interval_is_ripe(clock, output_writer) && return true
+    frequency_is_ripe(clock, output_writer) && return true
+
+    # If the output writer does not specify an interval or frequency, 
+    # it is unable to write output and we throw an error as a convenience.
+    has_interval(output_writer) || has_frequency(output_writer) ||
+        error("$(typeof(output_writer)) must have a frequency or interval specified!")
+
+    return false
 end
 
 # When saving stuff to disk like a JLD2 file, `saveproperty!` is used, which

--- a/src/planetary_constants.jl
+++ b/src/planetary_constants.jl
@@ -1,8 +1,3 @@
-# Some useful constants
-const second = 1.0
-const minute = 60.0
-const hour = 60minute
-const day = 24hour
 
 struct PlanetaryConstants{T<:AbstractFloat} <: ConstantsCollection
     Ω::T  # Rotation rate of the planet [rad/s].

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -28,7 +28,7 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
                    model.forcing, model.boundary_conditions, U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)
 
         [ time_to_run(model.clock, diag) && run_diagnostic(model, diag) for diag in model.diagnostics ]
-        [ time_to_write(model.clock, out) && write_output(model, out) for out in model.output_writers ]
+        [ time_to_run(model.clock, out) && write_output(model, out) for out in model.output_writers ]
     end
 
     return nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,6 +119,16 @@ function update_Δt!(wizard, model)
     return nothing
 end
 
+#####
+##### Some utilities for tupling
+#####
+
+tupleit(t::Tuple) = t
+tupleit(a::AbstractArray) = Tuple(a)
+tupleit(nt) = tuple(nt)
+
+parenttuple(obj) = Tuple(f.data.parent for f in obj)
+
 @inline datatuple(obj::Nothing) = nothing
 @inline datatuple(obj::AbstractArray) = obj
 @inline datatuple(obj::Field) = obj.data

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,3 +205,44 @@ function launch_config(grid, dims)
         return (threads=Tuple(threads), blocks=Tuple(blocks))
     end
 end
+
+####
+#### Utilities shared between diagnostics and output writers
+####
+
+"""
+    validate_interval(frequency, interval)
+
+Ensure that frequency and interval are not both `nothing`.
+"""
+function validate_interval(frequency, interval)
+    isnothing(frequency) && isnothing(interval) && @error "Must specify a frequency or interval!"
+    return
+end
+
+has_interval(obj) = :interval in propertynames(obj) && obj.interval != nothing
+has_frequency(obj) = :frequency in propertynames(obj) && obj.frequency != nothing
+
+function interval_is_ripe(clock, obj)
+    if has_interval(obj) && clock.time >= obj.previous + obj.interval
+        obj.previous = clock.time - rem(clock.time, obj.interval)
+        return true
+    else
+        return false
+    end
+end
+
+frequency_is_ripe(clock, obj) = has_frequency(obj) && clock.iteration % obj.frequency == 0
+
+function time_to_write(clock, output_writer)
+
+    interval_is_ripe(clock, output_writer) && return true
+    frequency_is_ripe(clock, output_writer) && return true
+
+    # If the output writer does not specify an interval or frequency,
+    # it is unable to write output and we throw an error as a convenience.
+    has_interval(output_writer) || has_frequency(output_writer) ||
+        error("$(typeof(output_writer)) must have a frequency or interval specified!")
+
+    return false
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -234,8 +234,8 @@ end
 
 frequency_is_ripe(clock, obj) = has_frequency(obj) && clock.iteration % obj.frequency == 0
 
-function time_to_write(clock, output_writer)
-
+function time_to_run(clock, output_writer)
+    
     interval_is_ripe(clock, output_writer) && return true
     frequency_is_ripe(clock, output_writer) && return true
 


### PR DESCRIPTION
This PR improves the `HorizontalAverage` utility to allow users to specify a return type, and refactors the code a bit to dispatch on the length of `fields`. This will be useful in the future when more sophisticated functions for computing horizontal averages (which, for example, interpolate fields to a common location) are implemented.

It also refactors the time to write function and eliminates some boilerplate.