### PR TITLE
Update CUDA packages (attempt 2)

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -34,15 +34,15 @@ version = "0.2.0"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "0ff80f68f55fcde2ed98d7b24d7abaf20727f3f8"
+git-tree-sha1 = "c69698c3d4a7255bc1b4bc2afc09f59db910243b"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.6.1"
+version = "0.6.2"
 
 [[CUDAapi]]
 deps = ["Libdl", "Logging"]
-git-tree-sha1 = "a17bc2b4624ac59a0c03be5dd2ea7e9f9834025c"
+git-tree-sha1 = "9b2b4b71d6b7f946c9689bb4dea03ff92e3c7091"
 uuid = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
-version = "1.0.1"
+version = "1.1.0"
 
 [[CUDAdrv]]
 deps = ["CUDAapi", "Libdl", "Printf"]
@@ -54,20 +54,20 @@ version = "3.1.0"
 
 [[CUDAnative]]
 deps = ["Adapt", "CUDAapi", "CUDAdrv", "DataStructures", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Printf", "TimerOutputs"]
-git-tree-sha1 = "36cbb94f74cd3e5db774134a68dc5d033ae2c87e"
+git-tree-sha1 = "0a00bef482b7c9127495c7f4a2a85e73b13b5af8"
 uuid = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
-version = "2.2.1"
+version = "2.3.0"
 
 [[Cassette]]
-git-tree-sha1 = "09aed2c4093e9ed29b08f6660ad959fcb6847cd1"
+git-tree-sha1 = "da85d135b6048d3e78603e277cf9a4609f7e0673"
 uuid = "7057c7e9-c182-5462-911a-8362d720325c"
-version = "0.2.5"
+version = "0.2.6"
 
 [[CodecZlib]]
-deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
-git-tree-sha1 = "36bbf5374c661054d41410dc53ff752972583b9b"
+deps = ["BinaryProvider", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "05916673a2627dd91b4969ff8ba6941bc85a960e"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.5.2"
+version = "0.6.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
@@ -95,9 +95,9 @@ version = "4.0.0"
 
 [[CuArrays]]
 deps = ["AbstractFFTs", "Adapt", "CUDAapi", "CUDAdrv", "CUDAnative", "GPUArrays", "LinearAlgebra", "MacroTools", "NNlib", "Printf", "Random", "Requires", "SparseArrays", "TimerOutputs"]
-git-tree-sha1 = "e1fae3c0cbddc4ea7e5ecddb04d045936bc444f5"
+git-tree-sha1 = "46b48742a84bb839e74215b7e468a4a1c6ba30f9"
 uuid = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
-version = "1.1.0"
+version = "1.2.1"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -130,10 +130,10 @@ uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.0.7"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "8fba6ddaf66b45dec830233cea0aae43eb1261ad"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.6.3"
+version = "0.6.4"
 
 [[Formatting]]
 deps = ["Compat"]
@@ -143,9 +143,9 @@ version = "0.3.5"
 
 [[GPUArrays]]
 deps = ["Adapt", "FFTW", "FillArrays", "LinearAlgebra", "Printf", "Random", "Serialization", "StaticArrays", "Test"]
-git-tree-sha1 = "4310da9bc8d51dccbffbd77138546208d0da93bf"
+git-tree-sha1 = "dd169c636d1d3656a9faca772f5bd7c226a61254"
 uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
-version = "1.0.0"
+version = "1.0.1"
 
 [[GPUifyLoops]]
 deps = ["Cassette", "Requires", "StaticArrays"]
@@ -296,9 +296,9 @@ uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.0"
 
 [[Tokenize]]
-git-tree-sha1 = "c8a8b00ae44a94950814ff77850470711a360225"
+git-tree-sha1 = "dfcdbbfb2d0370716c815cbd6f8a364efb6f42cf"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.5"
+version = "0.5.6"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.10.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
 CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"

--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -32,7 +32,7 @@ ubcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fu))
 Tbcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fθ), bottom=BoundaryCondition(Gradient, dTdz))
 
 # Instantiate the model
-model = Model(      arch = CPU(), #HAVE_CUDA ? GPU() : CPU(), # this example will run on the GPU if cuda is available.
+model = Model(      arch = CPU(), #has_cuda() ? GPU() : CPU(), # this example will run on the GPU if cuda is available.
                        N = (N, N, N),
                        L = (N*Δ, N*Δ, N*Δ),
                      eos = LinearEquationOfState(βT=βT, βS=0.0),

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -183,8 +183,6 @@ end
     end
 end
 
-@hascuda CuArrays.allowscalar(false)
-
 abstract type Architecture end
 struct CPU <: Architecture end
 struct GPU <: Architecture end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -159,28 +159,24 @@ using
     NetCDF
 
 import
+    CUDAapi,
     GPUifyLoops
+
+import GPUifyLoops: @launch, @loop, @unroll
 
 import Base:
     size, length,
     getindex, lastindex, setindex!,
     iterate, similar, *, +, -
 
-# Import CUDA utilities if cuda is detected.
-const HAVE_CUDA = try
-    using CUDAdrv, CUDAnative, CuArrays
-    true
-catch
-    false
-end
-
-import GPUifyLoops: @launch, @loop, @unroll
-
 macro hascuda(ex)
-    return HAVE_CUDA ? :($(esc(ex))) : :(nothing)
+    return CUDAapi.has_cuda()
 end
 
 @hascuda begin
+    # Import CUDA utilities if it's detected.
+    using CUDAdrv, CUDAnative, CuArrays
+
     println("CUDA-enabled GPU(s) detected:")
     for (gpu, dev) in enumerate(CUDAnative.devices())
         println(dev)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -170,7 +170,7 @@ import Base:
     iterate, similar, *, +, -
 
 macro hascuda(ex)
-    return CUDAapi.has_cuda()
+    return CUDAapi.has_cuda() ? :($(esc(ex))) : :(nothing)
 end
 
 @hascuda begin

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -161,7 +161,7 @@ import
     CUDAapi,
     GPUifyLoops
 
-import CUDAapi: has_cuda()
+import CUDAapi: has_cuda
 import GPUifyLoops: @launch, @loop, @unroll
 
 import Base:

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -5,8 +5,7 @@ if VERSION < v"1.1"
 end
 
 export
-    # Helper variables and macros for determining if machine is CUDA-enabled.
-    HAVE_CUDA,
+    # Helper macro for determining if a CUDA-enabled GPU is available.
     @hascuda,
 
     Architecture,
@@ -162,6 +161,7 @@ import
     CUDAapi,
     GPUifyLoops
 
+import CUDAapi: has_cuda()
 import GPUifyLoops: @launch, @loop, @unroll
 
 import Base:
@@ -170,7 +170,7 @@ import Base:
     iterate, similar, *, +, -
 
 macro hascuda(ex)
-    return CUDAapi.has_cuda() ? :($(esc(ex))) : :(nothing)
+    return has_cuda() ? :($(esc(ex))) : :(nothing)
 end
 
 @hascuda begin

--- a/src/models.jl
+++ b/src/models.jl
@@ -57,7 +57,7 @@ function Model(;
        diagnostics = Diagnostic[]
     )
 
-    arch == GPU() && !HAVE_CUDA && throw(
+    arch == GPU() && !has_cuda() && throw(
         ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
 
     # Initialize fields.

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -1,16 +1,46 @@
+add_one(args...) = 1.0
+
+function test_forcing(fld)
+    kwarg = Dict(Symbol(:F, fld) => add_one)
+    forcing = Forcing(; kwarg...)
+    f = getfield(forcing, fld)
+    f() == 1.0
+end
+
+function time_step_with_forcing_function(arch)
+    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -u[i, j, k] / 60, 0)
+    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -v[i, j, k] / 60, 0)
+    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -w[i, j, k] / 60, 0)
+
+    forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
+
+    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    time_step!(model, 1, 1)
+    return true
+end
+
+function time_step_with_forcing_function_const(arch)
+    const τ = 60
+    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -u[i, j, k] / τ, 0)
+    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -v[i, j, k] / τ, 0)
+    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -w[i, j, k] / τ, 0)
+
+    forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
+
+    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    time_step!(model, 1, 1)
+    return true
+end
+
 @testset "Forcings" begin
     println("Testing forcings...")
 
-    add_one(args...) = 1.0
-
-    function test_forcing(fld)
-        kwarg = Dict(Symbol(:F, fld)=>add_one)
-        forcing = Forcing(; kwarg...)
-        f = getfield(forcing, fld)
-        f() == 1.0
-    end
-
     for fld in (:u, :v, :w, :T, :S)
         @test test_forcing(fld)
+    end
+
+    for arch in archs
+        @test time_step_with_forcing_function(arch)
+        @test time_step_with_forcing_function_const(arch)
     end
 end

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -19,8 +19,8 @@ function time_step_with_forcing_function(arch)
     return true
 end
 
+const τ = 60
 function time_step_with_forcing_function_const(arch)
-    const τ = 60
     @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -u[i, j, k] / τ, 0)
     @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -v[i, j, k] / τ, 0)
     @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -w[i, j, k] / τ, 0)

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -7,7 +7,7 @@ function test_forcing(fld)
     f() == 1.0
 end
 
-function time_step_with_forcing_function(arch)
+function time_step_with_forcing_functions(arch)
     @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / 60, 0)
     @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / 60, 0)
     @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / 60, 0)
@@ -20,7 +20,7 @@ function time_step_with_forcing_function(arch)
 end
 
 const τ = 60
-function time_step_with_forcing_function_const(arch)
+function time_step_with_forcing_functions_const(arch)
     @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / τ, 0)
     @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / τ, 0)
     @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / τ, 0)
@@ -32,15 +32,36 @@ function time_step_with_forcing_function_const(arch)
     return true
 end
 
+
+const α = 1
+const β = 2
+function time_step_with_forcing_functions_sin_exp(arch)
+    @inline Fu(grid, U, Φ, i, j, k) = @inbounds sin(α * grid.xC[i])
+    @inline FT(grid, U, Φ, i, j, k) = @inbounds exp(-β * Φ.T[i, j, k])
+
+    forcing = Forcing(Fu=Fu, FT=FT)
+
+    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    time_step!(model, 1, 1)
+    return true
+end
+
 @testset "Forcings" begin
     println("Testing forcings...")
 
-    for fld in (:u, :v, :w, :T, :S)
-        @test test_forcing(fld)
+    @testset "Forcing function initialization" begin
+        println("Testing forcing function initialization...")
+        for fld in (:u, :v, :w, :T, :S)
+            @test test_forcing(fld)
+        end
     end
 
     for arch in archs
-        @test time_step_with_forcing_function(arch)
-        @test time_step_with_forcing_function_const(arch)
+        @testset "Forcing function time stepping [$(typeof(arch))]" begin
+            println("Testing forcing function time stepping [$(typeof(arch))]...")
+            @test time_step_with_forcing_functions(arch)
+            @test time_step_with_forcing_functions_const(arch)
+            @test time_step_with_forcing_functions_sin_exp(arch)
+        end
     end
 end

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -8,9 +8,9 @@ function test_forcing(fld)
 end
 
 function time_step_with_forcing_function(arch)
-    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -u[i, j, k] / 60, 0)
-    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -v[i, j, k] / 60, 0)
-    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -w[i, j, k] / 60, 0)
+    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / 60, 0)
+    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / 60, 0)
+    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / 60, 0)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
@@ -21,9 +21,9 @@ end
 
 const τ = 60
 function time_step_with_forcing_function_const(arch)
-    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -u[i, j, k] / τ, 0)
-    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -v[i, j, k] / τ, 0)
-    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -w[i, j, k] / τ, 0)
+    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / τ, 0)
+    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / τ, 0)
+    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / τ, 0)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -14,7 +14,7 @@ function time_step_with_forcing_functions(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
@@ -27,7 +27,7 @@ function time_step_with_forcing_functions_const(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
@@ -41,7 +41,7 @@ function time_step_with_forcing_functions_sin_exp(arch)
 
     forcing = Forcing(Fu=Fu, FT=FT)
 
-    model = Model(N=(8, 8, 8), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end


### PR DESCRIPTION
The main point of upgrading is to get rid of CUDA errors on the CPU and use `CUDAapi.has_cuda()` which replaces the `HAVE_CUDA` variable we've been using.

This was originally in PR https://github.com/climate-machine/Oceananigans.jl/pull/378 (this PR is mostly cherry picked commits) but when it was merged @glwagner reported issues with forcing functions on the GPU.

So now I've added a test that makes sure that forcing functions don't crash when used in a CPU or GPU model (one with and one without `const`).