### PR TITLE
[WIP] Use halo regions to enforce Value and Gradient boundary co…

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -9,138 +9,70 @@ export
     HAVE_CUDA,
     @hascuda,
 
-    Architecture,
-    CPU,
-    GPU,
-    device,
+    Architecture, CPU, GPU, device,
 
     # Planetary Constants
-    ConstantsCollection,
     PlanetaryConstants,
-    Earth,
-    EarthStationary,
-    Europa,
-    Enceladus,
-    second,
-    minute,
-    hour,
-    day,
+    Earth, Europa, Enceladus,
+    second, minute, hour, day,
 
     # Grids
-    Grid,
-    RegularCartesianGrid,
+    Grid, RegularCartesianGrid,
 
     # Fields
-    Field,
-    FaceField,
-    CellField,
-    FaceFieldX,
-    FaceFieldY,
-    FaceFieldZ,
-    EdgeField,
-    data,
-    ardata,
-    ardata_view,
-    underlying_data,
-    set!,
-    xnodes,
-    ynodes,
-    znodes,
-    nodes,
-    set_ic!,
+    Field, FaceField, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
+    data, ardata, ardata_view, underlying_data,
+    set!, set_ic!,
+    nodes, xnodes, ynodes, znodes,
 
-    # FieldSets (collections of related fields)
-    FieldSet,
-    VelocityFields,
-    TracerFields,
-    PressureFields,
-    SourceTerms,
+    # Constructors for NamedTuples of fields
+    VelocityFields, TracerFields, PressureFields,
 
-    # Forcing functions
+    # Constructor for a named tuple of forcing functions
     Forcing,
 
     # Equation of state
-    NoEquationOfState,
-    LinearEquationOfState,
-    δρ,
-    buoyancy,
+    NoEquationOfState, LinearEquationOfState,
+    δρ, buoyancy,
 
     # Boundary conditions
-    BoundaryCondition,
-    Periodic,
-    Flux,
-    Gradient,
-    Value,
-    Dirchlet,
-    Neumann,
-    CoordinateBoundaryConditions,
-    ZBoundaryConditions,
-    FieldBoundaryConditions,
-    ModelBoundaryConditions,
-    BoundaryConditions,
-    HorizontallyPeriodicBCs,
-    ChannelBCs,
-    HorizontallyPeriodicModelBCs,
-    ChannelModelBCs,
-    getbc,
-    setbc!,
+    BoundaryCondition, Periodic, Flux, Gradient, Value, Dirchlet, Neumann,
+    CoordinateBoundaryConditions, FieldBoundaryConditions, ModelBoundaryConditions,
+    HorizontallyPeriodicBCs, ChannelBCs,
+    BoundaryConditions, HorizontallyPeriodicModelBCs, ChannelModelBCs,
+    getbc, setbc!,
 
     # Halo regions
-    fill_halo_regions!,
-    zero_halo_regions!,
+    fill_halo_regions!, zero_halo_regions!,
 
     # Time stepping
-    TimeStepWizard,
-    cell_advection_timescale,
-    update_Δt!,
-    time_step!,
+    TimeStepWizard, cell_advection_timescale, update_Δt!, time_step!,
 
     # Poisson solver
-    PoissonBCs,
-    PPN, PNN,
-    PoissonSolver,
-    PoissonSolverCPU,
-    PoissonSolverGPU,
-    solve_poisson_3d!,
-    solve_poisson_3d_ppn_gpu_planned!,
+    PoissonBCs, PPN, PNN,
+    PoissonSolver, PoissonSolverCPU, PoissonSolverGPU,
+    solve_poisson_3d!, solve_poisson_3d_ppn_gpu_planned!,
 
     # Clock
     Clock,
 
     # Models
-    Model,
-    ChannelModel,
+    Model, ChannelModel,
 
     # Model output writers
-    OutputWriter,
-    BinaryOutputWriter,
-    NetCDFOutputWriter,
-    JLD2OutputWriter,
-    Checkpointer,
-    write_output,
-    read_output,
-    restore_from_checkpoint,
+    OutputWriter, NetCDFOutputWriter, JLD2OutputWriter, Checkpointer,
+    write_output, read_output, restore_from_checkpoint,
 
     # Model diagnostics
-    Diagnostic,
-    run_diagnostic,
-    HorizontalAverage,
-    ProductProfile,
-    VelocityCovarianceProfiles,
-    NaNChecker,
+    Diagnostic, run_diagnostic, HorizontalAverage, NaNChecker,
 
     # Package utilities
-    prettytime,
-    pretty_filesize,
-    KB, MB, GB, TB,
+    prettytime, pretty_filesize,
     KiB, MiB, GiB, TiB,
 
     # Turbulence closures
-    TurbulenceClosures,
-    ConstantIsotropicDiffusivity,
-    ConstantAnisotropicDiffusivity,
-    ConstantSmagorinsky,
-    AnisotropicMinimumDissipation
+    TurbulenceClosures, ConstantIsotropicDiffusivity, ConstantAnisotropicDiffusivity,
+    ConstantSmagorinsky, AnisotropicMinimumDissipation
 
 # Standard library modules
 using

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -19,13 +19,13 @@ end
 #### Horizontally averaged vertical profiles
 ####
 
-mutable struct HorizontalAverage{F, RT, P, I, T} <: Diagnostic
+mutable struct HorizontalAverage{F, R, P, I, T} <: Diagnostic
         profile :: P
          fields :: F
       frequency :: I
        interval :: T
        previous :: Float64
-    return_type :: RT
+    return_type :: R
 end
 
 
@@ -77,7 +77,7 @@ end
 
 function (havg::HorizontalAverage)(model)
     run_diagnostic(model, havg)
-    return return_type(havg.profile)
+    return havg.return_type(havg.profile)
 end
 
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -72,7 +72,7 @@ end
 
 function (havg::HorizontalAverage{F, Nothing})(model) where F
     run_diagnostic(model, havg)
-    return p.profile
+    return havg.profile
 end
 
 function (havg::HorizontalAverage)(model)

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,4 +1,5 @@
 using .TurbulenceClosures
+using .TurbulenceClosures: ν₀, κ₀
 
 mutable struct Model{TS, TC, A<:Architecture, GR, T, EOS<:EquationOfState,
                      PC<:PlanetaryConstants,
@@ -38,8 +39,8 @@ function Model(;
     float_type = Float64,
           grid = RegularCartesianGrid(float_type, N, L),
     # Isotropic transport coefficients (exposed to `Model` constructor for convenience)
-             ν = 1.05e-6, νh=ν, νv=ν,
-             κ = 1.43e-7, κh=κ, κv=κ,
+             ν = ν₀, νh=ν, νv=ν,
+             κ = κ₀, κh=κ, κv=κ,
        closure = ConstantAnisotropicDiffusivity(float_type, νh=νh, νv=νv, κh=κh, κv=κv),
     # Time stepping
     start_time = 0,
@@ -64,7 +65,7 @@ function Model(;
        velocities = VelocityFields(arch, grid)
           tracers = TracerFields(arch, grid)
         pressures = PressureFields(arch, grid)
-      timestepper = AdamsBashforthTimestepper(float_type, arch, grid, 0.125)
+      timestepper = AdamsBashforthTimestepper(float_type, arch, grid, 0.125, bcs)
     diffusivities = TurbulentDiffusivities(arch, grid, closure)
 
     # Initialize Poisson solver.
@@ -185,14 +186,16 @@ end
 Return an AdamsBashforthTimestepper object with tendency
 fields on `arch` and `grid` and AB2 parameter `χ`.
 """
-struct AdamsBashforthTimestepper{T, TG}
-    Gⁿ :: TG
-    G⁻ :: TG
-     χ :: T
+struct AdamsBashforthTimestepper{T, TG, BC}
+      Gⁿ :: TG
+      G⁻ :: TG
+       χ :: T
+    Gbcs :: BC
 end
 
-function AdamsBashforthTimestepper(float_type, arch, grid, χ)
+function AdamsBashforthTimestepper(float_type, arch, grid, χ, modelbcs)
    Gⁿ = Tendencies(arch, grid)
    G⁻ = Tendencies(arch, grid)
-   return AdamsBashforthTimestepper{float_type, typeof(Gⁿ)}(Gⁿ, G⁻, χ)
+   Gbcs = TendenciesBoundaryConditions(modelbcs)
+   return AdamsBashforthTimestepper{float_type, typeof(Gⁿ), typeof(Gbcs)}(Gⁿ, G⁻, χ, Gbcs)
 end

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -45,6 +45,14 @@ function saveproperty!(file, location, cbcs::CoordinateBoundaryConditions)
     end
 end
 
+# Special savepropety! for AB2 time stepper struct used by the checkpointer so
+# it only saves the fields and not the tendency BCs or χ value (as they can be
+# constructed by the `Model` constructor).
+function saveproperty!(file, location, ts::AdamsBashforthTimestepper)
+    saveproperty!(file, location * "/Gⁿ", ts.Gⁿ)
+    saveproperty!(file, location * "/G⁻", ts.G⁻)
+end
+
 saveproperties!(file, structure, ps) = [saveproperty!(file, "$p", getproperty(structure, p)) for p in ps]
 
 # When checkpointing, `serializeproperty!` is used, which serializes objects

--- a/src/poisson_solvers.jl
+++ b/src/poisson_solvers.jl
@@ -136,15 +136,15 @@ function plan_transforms(::PNN, A::Array, planner_flag=FFTW.PATIENT)
 end
 
 struct PoissonSolverCPU{BC, AAR, AAC, FFTT, DCTT, IFFTT, IDCTT} <: PoissonSolver
-    bcs::BC
-    kx²::AAR
-    ky²::AAR
-    kz²::AAR
-    storage::AAC
-    FFT!::FFTT
-    DCT!::DCTT
-    IFFT!::IFFTT
-    IDCT!::IDCTT
+        bcs :: BC
+        kx² :: AAR
+        ky² :: AAR
+        kz² :: AAR
+    storage :: AAC
+       FFT! :: FFTT
+       DCT! :: DCTT
+      IFFT! :: IFFTT
+      IDCT! :: IDCTT
 end
 
 function PoissonSolverCPU(pbcs::PoissonBCs, grid::Grid, planner_flag=FFTW.PATIENT)
@@ -226,26 +226,26 @@ function plan_transforms(::PNN, A)
 end
 
 struct PoissonSolverGPU{BC, AAR, AAC, AAI, FFT, FFTD, IFFT, IFFTD} <: PoissonSolver
-    bcs::BC
-    kx²::AAR
-    ky²::AAR
-    kz²::AAR
-    ω_4Ny⁺::AAC
-    ω_4Ny⁻::AAC
-    ω_4Nz⁺::AAC
-    ω_4Nz⁻::AAC
-    p_y_inds::AAI
-    p_z_inds::AAI
-    r_y_inds::AAI
-    r_z_inds::AAI
-    M_ky::AAR
-    M_kz::AAR
-    storage::AAC
-    storage2::AAC
-    FFT!::FFT
-    FFT_DCT!::FFTD
-    IFFT!::IFFT
-    IFFT_DCT!::IFFTD
+          bcs :: BC
+          kx² :: AAR
+          ky² :: AAR
+          kz² :: AAR
+       ω_4Ny⁺ :: AAC
+       ω_4Ny⁻ :: AAC
+       ω_4Nz⁺ :: AAC
+       ω_4Nz⁻ :: AAC
+     p_y_inds :: AAI
+     p_z_inds :: AAI
+     r_y_inds :: AAI
+     r_z_inds :: AAI
+         M_ky :: AAR
+         M_kz :: AAR
+      storage :: AAC
+     storage2 :: AAC
+         FFT! :: FFT
+     FFT_DCT! :: FFTD
+        IFFT! :: IFFT
+    IFFT_DCT! :: IFFTD
 end
 
 function PoissonSolverGPU(pbcs::PoissonBCs, grid::Grid)

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -37,9 +37,9 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
 end
 
 """
-    time_step!(args...)
+    adams_bashforth_time_step!(args...)
 
-Step forward one time step.
+Step forward one time step with a 2nd-order Adams-Bashforth method and pressure-correction substep.
 """
 function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, forcing, bcs, pressure_bcs,
                                     U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -167,7 +167,7 @@ parenttuple(obj) = Tuple(f.data.parent for f in obj)
 
 function getindex(t::NamedTuple, r::AbstractUnitRange{<:Real})
     n = length(r)
-    n == 0 && return ()
+    n == 0 && return NamedTuple()
     elems = Vector{eltype(t)}(undef, n)
     names = Vector{Symbol}(undef, n)
     o = first(r) - 1

--- a/test/test_halo_regions.jl
+++ b/test/test_halo_regions.jl
@@ -28,7 +28,7 @@ function halo_regions_correctly_filled(arch, FT, Nx, Ny, Nz)
     fbcs = HorizontallyPeriodicBCs()
 
     data(field) .= rand(FT, Nx, Ny, Nz)
-    fill_halo_regions!(field.data, fbcs, grid)
+    fill_halo_regions!(field.data, fbcs, arch, grid)
 
     Hx, Hy, Hz = grid.Hx, grid.Hy, grid.Hz
 

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -6,6 +6,7 @@
         Nx, Ny, Nz = 32, 16, 8
         Lx, Ly, Lz = 100, 100, 100
 
+        arch = CPU()
         grid = RegularCartesianGrid((Nx, Ny, Nz), (Lx, Ly, Lz))
 
         Hx, Hy, Hz = grid.Hx, grid.Hy, grid.Hz
@@ -13,7 +14,7 @@
 
         A3 = OffsetArray(zeros(Tx, Ty, Tz), 1-Hx:Nx+Hx, 1-Hy:Ny+Hy, 1-Hz:Nz+Hz)
         @. @views A3[1:Nx, 1:Ny, 1:Nz] = rand()
-        fill_halo_regions!(A3, HorizontallyPeriodicBCs(), grid)
+        fill_halo_regions!(A3, HorizontallyPeriodicBCs(), arch, grid)
 
         # A yz-slice with Nx==1.
         A2yz = OffsetArray(zeros(1+2Hx, Ty, Tz), 1-Hx:1+Hx, 1-Hy:Ny+Hy, 1-Hz:Nz+Hz)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -42,11 +42,11 @@ function compute_w_from_continuity(arch, FT)
     data(u) .= rand(FT, Nx, Ny, Nz)
     data(v) .= rand(FT, Nx, Ny, Nz)
 
-    fill_halo_regions!(u.data, bcs.u, grid)
-    fill_halo_regions!(v.data, bcs.v, grid)
+    fill_halo_regions!(u.data, bcs.u, arch, grid)
+    fill_halo_regions!(v.data, bcs.v, arch, grid)
     compute_w_from_continuity!(grid, (u=u.data, v=v.data, w=w.data))
 
-    fill_halo_regions!(w.data, bcs.w, grid)
+    fill_halo_regions!(w.data, bcs.w, arch, grid)
     velocity_div!(grid, u.data, v.data, w.data, div_u.data)
 
     # Set div_u to zero at the bottom because the initial velocity field is not divergence-free

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -6,7 +6,7 @@ using Oceananigans.TurbulenceClosures: ∂x_caa, ∂x_faa, ∂x²_caa, ∂x²_fa
 
 using GPUifyLoops: @launch
 using Oceananigans: launch_config, datatuples, device
-import Oceananigans: data_tuple
+import Oceananigans: datatuple
 
 closures = (
             :ConstantIsotropicDiffusivity,
@@ -75,7 +75,7 @@ function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64;
     end
 
     U, Φ = datatuples(velocities, tracers)
-    fill_halo_regions!(merge(U, Φ), bcs, grid)
+    fill_halo_regions!(merge(U, Φ), bcs, arch, grid)
 
     return (   ∇_κ_∇c(2, 1, 3, grid, Φ.T, closure) == 2κ &&
             ∂ⱼ_2ν_Σ₁ⱼ(2, 1, 3, grid, closure, U...) == 2ν &&
@@ -115,7 +115,7 @@ function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.
     data(T)[:, 1, 4] .= [0,  1, 0]
 
     U, Φ = datatuples(velocities, tracers)
-    fill_halo_regions!(merge(U, Φ), bcs, grid)
+    fill_halo_regions!(merge(U, Φ), bcs, arch, grid)
 
     return (   ∇_κ_∇c(2, 1, 3, grid, Φ.T, closure, eos, grav, U..., Φ...) == 8κh + 10κv &&
             ∂ⱼ_2ν_Σ₁ⱼ(2, 1, 3, grid, closure, eos, grav, U..., Φ...) == 2νh + 4νv &&


### PR DESCRIPTION
This PR modifies `fill_halo_regions!` and `calculate_boundary_source_terms!` so that halo regions are used to enforced `Value` and `Gradient` boundary conditions. This is done by linearly extrapolating the interior field across the boundary into the halo region, using

* the specified gradient (for `Gradient` boundary conditions)
* the gradient between the interior node of a field and the associated boundary where the boundary condition is prescribed (for `Value` boundary conditions)

`calculate_boundary_source_terms!` is still a part of the algorithm and is used to enforce `Flux` boundary conditions. This function may also prove useful in the future for more sophisticated boundary conditions and for enforcing boundary conditions associated with irregular boundaries.

This algorithm permits the gradients of fields to be computed accurately on the boundary both in time stepping and post processing (which is useful, for example, for computing nonlinear diffusivities on the boundary when `Value` or `Gradient` boundary conditions are prescribed), and the code is more mathematically correct as a result. It also means that diffusivities are never involved in enforcing boundary conditions, which is an important simplification.

Previously, the diffusivity of a field (or some proxy for diffusivity) on the boundary was used to add the flux associated with a `Value` or `Gradient` boundary condition. 

This PR also adds special boundary conditions for tendency terms (sometimes called 'source terms' in the code), and for the pressure field.

Finally, we introduce the boundary condition `BoundaryCondition{Flux, Nothing}` as a synonym for a no-flux boundary condition that does not require the calculation of boundary source terms, to save a few accesses to global memory.

Right now there is a bit left to do:

- [x] adapt the checkpointer for the new `timestepper` structure (checkpointer tests currently fail)
- [ ] decide whether pressure boundary conditions should be precomputed and stored in `poisson_solver` (currently they are computed at the beginning of a time-stepping cycle inside `time_step!`).

If we add pressure boundary conditions to `poisson_solver`, we can also get rid of the special `PoissonBCs` types, since the pressure fields now have explicit bcs associated with them. But this is not urgent.