### PR TITLE
Parameters field in Model for user convenience

### DIFF
--- a/benchmark/benchmark_forcing_functions.jl
+++ b/benchmark/benchmark_forcing_functions.jl
@@ -32,24 +32,24 @@ end
 
 benchmark_name(N, id) = benchmark_name(N, id, "", "", "")
 
-@inline function Fu(grid, U, Φ, i, j, k)
+@inline function Fu(grid, U, Φ, i, j, k, params)
     if k == 1
-        return @inbounds -2*0.1/grid.Δz^2 * (U.u[i, j, 1] - 0)
+        return @inbounds -2*params.K/grid.Δz^2 * (U.u[i, j, 1] - 0)
     elseif k == grid.Nz
-        return @inbounds -2*0.1/grid.Δz^2 * (U.u[i, j, grid.Nz] - 0)
+        return @inbounds -2*params.K/grid.Δz^2 * (U.u[i, j, grid.Nz] - 0)
     else
         return 0
     end
 end
 
-@inline FT(grid, U, Φ, i, j, k) = @inbounds ifelse(k == 1, -1e-4 * (Φ.T[i, j, 1] - 0), 0)
+@inline FT(grid, U, Φ, i, j, k, params) = @inbounds ifelse(k == 1, -params.λ * (Φ.T[i, j, 1] - 0), 0)
 forcing = Forcing(Fu=Fu, FT=FT)
 
 for arch in archs, float_type in float_types, N in Ns
     Nx, Ny, Nz = N
     Lx, Ly, Lz = 1, 1, 1
     
-    forced_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type, forcing=forcing)
+    forced_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type, forcing=forcing, parameters=(K=0.1, λ=1e-4))
     time_step!(forced_model, Ni, 1)  # First 1-2 iterations usually slower.
 
     bn =  benchmark_name(N, "with forcing", arch, float_type)

--- a/benchmark/benchmark_forcing_functions.jl
+++ b/benchmark/benchmark_forcing_functions.jl
@@ -1,8 +1,13 @@
 using TimerOutputs, Printf
-
 using Oceananigans
 
+include("benchmark_utils.jl")
+
 const timer = TimerOutput()
+
+####
+#### Benchmark parameters
+####
 
 Ni = 2   # Number of iterations before benchmarking starts.
 Nt = 10  # Number of iterations to use for benchmarking time stepping.
@@ -13,26 +18,11 @@ Nt = 10  # Number of iterations to use for benchmarking time stepping.
          archs = [CPU()]    # Architectures to benchmark on.
 @hascuda archs = [GPU()]    # Benchmark GPU on systems with CUDA-enabled GPUs.
 
-arch_name(::String) = ""
-arch_name(::CPU) = "CPU"
-arch_name(::GPU) = "GPU"
+####
+#### Forcing function definitions
+####
 
-function benchmark_name(N, id, arch, FT; npad=2)
-    Nx, Ny, Nz = N
-
-    bn = ""
-    bn *= lpad(Nx, npad, " ") * "×" * lpad(Ny, npad, " ") * "×" * lpad(Nz, npad, " ")
-    bn *= " $id"
-
-    arch = arch_name(arch)
-    bn *= " ($arch, $FT)"
-
-    return bn
-end
-
-benchmark_name(N, id) = benchmark_name(N, id, "", "", "")
-
-@inline function Fu(grid, U, Φ, i, j, k, params)
+@inline function Fu_params(i, j, k, grid, time, U, C, params)
     if k == 1
         return @inbounds -2*params.K/grid.Δz^2 * (U.u[i, j, 1] - 0)
     elseif k == grid.Nz
@@ -42,20 +32,48 @@ benchmark_name(N, id) = benchmark_name(N, id, "", "", "")
     end
 end
 
-@inline FT(grid, U, Φ, i, j, k, params) = @inbounds ifelse(k == 1, -params.λ * (Φ.T[i, j, 1] - 0), 0)
-forcing = Forcing(Fu=Fu, FT=FT)
+const K = 0.1
+@inline function Fu_consts(i, j, k, grid, time, U, C, params)
+    if k == 1
+        return @inbounds -2*K/grid.Δz^2 * (U.u[i, j, 1] - 0)
+    elseif k == grid.Nz
+        return @inbounds -2*K/grid.Δz^2 * (U.u[i, j, grid.Nz] - 0)
+    else
+        return 0
+    end
+end
+
+@inline FT_params(i, j, k, grid, time, U, C, params) = @inbounds ifelse(k == 1, -params.λ * (C.T[i, j, 1] - 0), 0)
+
+const λ = 1e-4
+@inline FT_consts(i, j, k, grid, time, U, C, params) = @inbounds ifelse(k == 1, -λ * (C.T[i, j, 1] - 0), 0)
+
+####
+#### Run benchmarks
+####
 
 for arch in archs, float_type in float_types, N in Ns
     Nx, Ny, Nz = N
     Lx, Ly, Lz = 1, 1, 1
     
-    forced_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type, forcing=forcing, parameters=(K=0.1, λ=1e-4))
-    time_step!(forced_model, Ni, 1)  # First 1-2 iterations usually slower.
+    forced_model_params = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type,
+                                forcing=Forcing(Fu=Fu_params, FT=FT_params), parameters=(K=0.1, λ=1e-4))
+    time_step!(forced_model_params, Ni, 1)  # First 1-2 iterations usually slower.
 
-    bn =  benchmark_name(N, "with forcing", arch, float_type)
+    bn =  benchmark_name(N, "with forcing (params)", arch, float_type)
     @printf("Running benchmark: %s...\n", bn)
     for i in 1:Nt
-        @timeit timer bn time_step!(forced_model, 1, 1)
+        @timeit timer bn time_step!(forced_model_params, 1, 1)
+    end
+    
+    forced_model_consts = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type,
+                                forcing=Forcing(Fu=Fu_consts, FT=FT_consts))
+    time_step!(forced_model_consts, Ni, 1)  # First 1-2 iterations usually slower.
+
+    bn =  benchmark_name(N, "with forcing (consts)", arch, float_type)
+    @printf("Running benchmark: %s...\n", bn)
+    for i in 1:Nt
+        @timeit timer bn time_step!(forced_model_consts, 1, 1)
     end
 
     unforced_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=float_type)

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -45,7 +45,7 @@ function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, 
                                     U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)
 
     # Arguments for user-defined boundary condition functions:
-    boundary_condition_args = (model.clock.time, model.clock.iteration, U, Φ) 
+    boundary_condition_args = (model.clock.time, model.clock.iteration, U, Φ, model.parameters) 
 
     # Pre-computations:
     @launch device(arch) config=launch_config(grid, 3) store_previous_source_terms!(grid, Gⁿ, G⁻)
@@ -57,7 +57,8 @@ function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, 
     fill_halo_regions!(p.pHY′, pressure_bcs, arch, grid)
 
     # Calculate tendency terms (minus non-hydrostatic pressure, which is updated in a pressure correction step):
-    calculate_interior_source_terms!(arch, grid, constants, eos, closure, U, Φ, p.pHY′, Gⁿ, K, forcing)
+    calculate_interior_source_terms!(Gⁿ, arch, grid, constants, eos, closure, U, Φ, p.pHY′, K, forcing, 
+                                     model.parameters, model.clock.time)
     calculate_boundary_source_terms!(Gⁿ, arch, grid, bcs, boundary_condition_args...)
 
     # Complete explicit substep:
@@ -130,88 +131,89 @@ function update_hydrostatic_pressure!(pHY′, grid, constants, eos, Φ)
     end
 end
 
+function calculate_Gu!(Gu, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds Gu[i, j, k] = (-u∇u(grid, U.u, U.v, U.w, i, j, k)
+                                            + fv(grid, U.v, constants.f, i, j, k)
+                                            - δx_c2f(grid, pHY′, i, j, k) / (grid.Δx * eos.ρ₀)
+                                            + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
+                                            + F.u(i, j, k, grid, time, U, Φ, params))
+            end
+        end
+    end
+end
+
+function calculate_Gv!(Gv, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds Gv[i, j, k] = (-u∇v(grid, U.u, U.v, U.w, i, j, k)
+                                            - fu(grid, U.u, constants.f, i, j, k)
+                                            - δy_c2f(grid, pHY′, i, j, k) / (grid.Δy * eos.ρ₀)
+                                            + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
+                                            + F.v(i, j, k, grid, time, U, Φ, params))
+            end
+        end
+    end
+end
+
+function calculate_Gw!(Gw, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds Gw[i, j, k] = (-u∇w(grid, U.u, U.v, U.w, i, j, k)
+                                            + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
+                                            + F.w(i, j, k, grid, time, U, Φ, params))
+            end
+        end
+    end
+end
+
+function calculate_GT!(GT, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds GT[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.T, i, j, k)
+                                            + ∇_κ_∇T(i, j, k, grid, Φ.T, closure, K)
+                                            + F.T(i, j, k, grid, time, U, Φ, params))
+            end
+        end
+    end
+end
+
+function calculate_GS!(GS, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+    @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds GS[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.S, i, j, k)
+                                            + ∇_κ_∇S(i, j, k, grid, Φ.S, closure, K)
+                                            + F.S(i, j, k, grid, time, U, Φ, params))
+            end
+        end
+    end
+end
+
+
 "Store previous value of the source term and calculate current source term."
-function calculate_interior_source_terms!(arch, grid, constants, eos, closure, U, Φ, pHY′, G, K, F)
-
-    function calculate_Gu(grid, constants, eos, closure, U, Φ, pHY′, Gu, K, F)
-        @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-            @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-                @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                    @inbounds Gu[i, j, k] = (-u∇u(grid, U.u, U.v, U.w, i, j, k)
-                                                + fv(grid, U.v, constants.f, i, j, k)
-                                                - δx_c2f(grid, pHY′, i, j, k) / (grid.Δx * eos.ρ₀)
-                                                + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                                + F.u(grid, U, Φ, i, j, k))
-                end
-            end
-        end
-    end
-
-    function calculate_Gv(grid, constants, eos, closure, U, Φ, pHY′, Gv, K, F)
-        @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-            @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-                @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                    @inbounds Gv[i, j, k] = (-u∇v(grid, U.u, U.v, U.w, i, j, k)
-                                                - fu(grid, U.u, constants.f, i, j, k)
-                                                - δy_c2f(grid, pHY′, i, j, k) / (grid.Δy * eos.ρ₀)
-                                                + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                                + F.v(grid, U, Φ, i, j, k))
-                end
-            end
-        end
-    end
-
-    function calculate_Gw(grid, constants, eos, closure, U, Φ, pHY′, Gw, K, F)
-        @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-            @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-                @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                    @inbounds Gw[i, j, k] = (-u∇w(grid, U.u, U.v, U.w, i, j, k)
-                                                + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                                + F.w(grid, U, Φ, i, j, k))
-                end
-            end
-        end
-    end
-
-    function calculate_GT(grid, constants, eos, closure, U, Φ, pHY′, GT, K, F)
-        @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-            @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-                @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                    @inbounds GT[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.T, i, j, k)
-                                                + ∇_κ_∇T(i, j, k, grid, Φ.T, closure, K)
-                                                + F.T(grid, U, Φ, i, j, k))
-                end
-            end
-        end
-    end
-
-    function calculate_GS(grid, constants, eos, closure, U, Φ, pHY′, GS, K, F)
-        @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
-            @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
-                @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                    @inbounds GS[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.S, i, j, k)
-                                                + ∇_κ_∇S(i, j, k, grid, Φ.S, closure, K)
-                                                + F.S(grid, U, Φ, i, j, k))
-                end
-            end
-        end
-    end
+function calculate_interior_source_terms!(G, arch, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
 
     Bx, By, Bz = floor(Int, grid.Nx/Tx), floor(Int, grid.Ny/Ty), grid.Nz  # Blocks in grid
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gu(grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                           G.Gu, K, F)
+    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gu!(G.Gu, grid, constants, eos, closure, U, Φ, pHY′, 
+                                                                            K, F, params, time)
 
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gv(grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                           G.Gv, K, F)
+    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gv!(G.Gv, grid, constants, eos, closure, U, Φ, pHY′, 
+                                                                            K, F, params, time)
 
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gw(grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                           G.Gw, K, F)
+    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gw!(G.Gw, grid, constants, eos, closure, U, Φ, pHY′, 
+                                                                            K, F, params, time)
 
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GT(grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                           G.GT, K, F)
+    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GT!(G.GT, grid, constants, eos, closure, U, Φ, pHY′, 
+                                                                            K, F, params, time)
 
-    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GS(grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                           G.GS, K, F)
+    @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GS!(G.GS, grid, constants, eos, closure, U, Φ, pHY′, 
+                                                                            K, F, params, time)
 end
 
 function adams_bashforth_update_source_terms!(grid::Grid{FT}, Gⁿ, G⁻, χ) where FT

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -131,7 +131,7 @@ function update_hydrostatic_pressure!(pHY′, grid, constants, eos, Φ)
     end
 end
 
-function calculate_Gu!(Gu, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_Gu!(Gu, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -139,13 +139,13 @@ function calculate_Gu!(Gu, grid, constants, eos, closure, U, Φ, pHY′, K, F, p
                                             + fv(grid, U.v, constants.f, i, j, k)
                                             - δx_c2f(grid, pHY′, i, j, k) / (grid.Δx * eos.ρ₀)
                                             + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                            + F.u(i, j, k, grid, time, U, Φ, params))
+                                            + F.u(i, j, k, grid, time, U, Φ, parameters))
             end
         end
     end
 end
 
-function calculate_Gv!(Gv, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_Gv!(Gv, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -153,43 +153,43 @@ function calculate_Gv!(Gv, grid, constants, eos, closure, U, Φ, pHY′, K, F, p
                                             - fu(grid, U.u, constants.f, i, j, k)
                                             - δy_c2f(grid, pHY′, i, j, k) / (grid.Δy * eos.ρ₀)
                                             + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                            + F.v(i, j, k, grid, time, U, Φ, params))
+                                            + F.v(i, j, k, grid, time, U, Φ, parameters))
             end
         end
     end
 end
 
-function calculate_Gw!(Gw, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_Gw!(Gw, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
                 @inbounds Gw[i, j, k] = (-u∇w(grid, U.u, U.v, U.w, i, j, k)
                                             + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U.u, U.v, U.w, K)
-                                            + F.w(i, j, k, grid, time, U, Φ, params))
+                                            + F.w(i, j, k, grid, time, U, Φ, parameters))
             end
         end
     end
 end
 
-function calculate_GT!(GT, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_GT!(GT, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
                 @inbounds GT[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.T, i, j, k)
                                             + ∇_κ_∇T(i, j, k, grid, Φ.T, closure, K)
-                                            + F.T(i, j, k, grid, time, U, Φ, params))
+                                            + F.T(i, j, k, grid, time, U, Φ, parameters))
             end
         end
     end
 end
 
-function calculate_GS!(GS, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_GS!(GS, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
                 @inbounds GS[i, j, k] = (-div_flux(grid, U.u, U.v, U.w, Φ.S, i, j, k)
                                             + ∇_κ_∇S(i, j, k, grid, Φ.S, closure, K)
-                                            + F.S(i, j, k, grid, time, U, Φ, params))
+                                            + F.S(i, j, k, grid, time, U, Φ, parameters))
             end
         end
     end
@@ -197,23 +197,23 @@ end
 
 
 "Store previous value of the source term and calculate current source term."
-function calculate_interior_source_terms!(G, arch, grid, constants, eos, closure, U, Φ, pHY′, K, F, params, time)
+function calculate_interior_source_terms!(G, arch, grid, constants, eos, closure, U, Φ, pHY′, K, F, parameters, time)
 
     Bx, By, Bz = floor(Int, grid.Nx/Tx), floor(Int, grid.Ny/Ty), grid.Nz  # Blocks in grid
     @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gu!(G.Gu, grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                            K, F, params, time)
+                                                                            K, F, parameters, time)
 
     @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gv!(G.Gv, grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                            K, F, params, time)
+                                                                            K, F, parameters, time)
 
     @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_Gw!(G.Gw, grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                            K, F, params, time)
+                                                                            K, F, parameters, time)
 
     @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GT!(G.GT, grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                            K, F, params, time)
+                                                                            K, F, parameters, time)
 
     @launch device(arch) threads=(Tx, Ty) blocks=(Bx, By, Bz) calculate_GS!(G.GS, grid, constants, eos, closure, U, Φ, pHY′, 
-                                                                            K, F, params, time)
+                                                                            K, F, parameters, time)
 end
 
 function adams_bashforth_update_source_terms!(grid::Grid{FT}, Gⁿ, G⁻, χ) where FT

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -19,25 +19,22 @@ function time_step_with_forcing_functions(arch)
     return true
 end
 
-const τ = 60
-function time_step_with_forcing_functions_const(arch)
-    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / τ, 0)
-    @inline Fv(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / τ, 0)
-    @inline Fw(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / τ, 0)
+function time_step_with_forcing_functions_params(arch)
+    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / params.τ, 0)
+    @inline Fv(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / params.τ, 0)
+    @inline Fw(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / params.τ, 0)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing, parameters=(τ=60,))
     time_step!(model, 1, 1)
     return true
 end
 
 
-const α = 1
-const β = 2
 function time_step_with_forcing_functions_sin_exp(arch)
-    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds sin(α * grid.xC[i])
-    @inline FT(i, j, k, grid, time, U, Φ, params) = @inbounds exp(-β * Φ.T[i, j, k])
+    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds sin(grid.xC[i])
+    @inline FT(i, j, k, grid, time, U, Φ, params) = @inbounds exp(-Φ.T[i, j, k])
 
     forcing = Forcing(Fu=Fu, FT=FT)
 
@@ -50,7 +47,7 @@ end
     println("Testing forcings...")
 
     @testset "Forcing function initialization" begin
-        println("Testing forcing function initialization...")
+        println("  Testing forcing function initialization...")
         for fld in (:u, :v, :w, :T, :S)
             @test test_forcing(fld)
         end
@@ -58,9 +55,9 @@ end
 
     for arch in archs
         @testset "Forcing function time stepping [$(typeof(arch))]" begin
-            println("Testing forcing function time stepping [$(typeof(arch))]...")
+            println("  Testing forcing function time stepping [$(typeof(arch))]...")
             @test time_step_with_forcing_functions(arch)
-            @test time_step_with_forcing_functions_const(arch)
+            @test time_step_with_forcing_functions_params(arch)
             @test time_step_with_forcing_functions_sin_exp(arch)
         end
     end

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -8,9 +8,9 @@ function test_forcing(fld)
 end
 
 function time_step_with_forcing_functions(arch)
-    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / 60, 0)
-    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / 60, 0)
-    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / 60, 0)
+    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / 60, 0)
+    @inline Fv(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / 60, 0)
+    @inline Fw(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / 60, 0)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
@@ -21,9 +21,9 @@ end
 
 const τ = 60
 function time_step_with_forcing_functions_const(arch)
-    @inline Fu(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / τ, 0)
-    @inline Fv(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / τ, 0)
-    @inline Fw(grid, U, Φ, i, j, k) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / τ, 0)
+    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.u[i, j, k] / τ, 0)
+    @inline Fv(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.v[i, j, k] / τ, 0)
+    @inline Fw(i, j, k, grid, time, U, Φ, params) = @inbounds ifelse(k == grid.Nz, -U.w[i, j, k] / τ, 0)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
@@ -36,8 +36,8 @@ end
 const α = 1
 const β = 2
 function time_step_with_forcing_functions_sin_exp(arch)
-    @inline Fu(grid, U, Φ, i, j, k) = @inbounds sin(α * grid.xC[i])
-    @inline FT(grid, U, Φ, i, j, k) = @inbounds exp(-β * Φ.T[i, j, k])
+    @inline Fu(i, j, k, grid, time, U, Φ, params) = @inbounds sin(α * grid.xC[i])
+    @inline FT(i, j, k, grid, time, U, Φ, params) = @inbounds exp(-β * Φ.T[i, j, k])
 
     forcing = Forcing(Fu=Fu, FT=FT)
 

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -86,7 +86,7 @@ function run_rayleigh_benard_regression_test(arch)
 
     # Force salinity as a passive tracer (βS=0)
     S★(x, z) = exp(4z) * sin(2π/Lx * x)
-    FS(grid, U, Φ, i, j, k) = 1/10 * (S★(grid.xC[i], grid.zC[k]) - Φ.S[i, j, k])
+    FS(i, j, k, grid, time, U, Φ, params) = 1/10 * (S★(grid.xC[i], grid.zC[k]) - Φ.S[i, j, k])
 
     model = Model(
          arch = arch,


### PR DESCRIPTION
This PR adds a field `parameters` to `Model`. The field is intended to be utilized by users for setting parameters in user-defined forcing functions and boundary conditions functions. 

The forcing functions now have the function signature

```julia
F.u(i, j, k, grid, time, U, C, params)
```

whereas boundary conditions have the function signature

```julia
boundary_condition(i, j, grid, time, iteration, U, C, params)
```

This PR resolves #394 and #390.