### PR TITLE
Add warning if GPU model grid Nx, Ny are not multiple of 16

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -58,8 +58,12 @@ function Model(;
        diagnostics = Diagnostic[]
     )
 
-    arch == GPU() && !has_cuda() && throw(
-        ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
+    if arch == GPU()
+        !has_cuda() && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
+        if mod(grid.Nx, 16) != 0 || mod(grid.Ny, 16) != 0
+            throw(ArgumentError("For GPU models, Nx and Ny must be multiples of 16."))
+        end
+    end
 
     # Initialize fields.
        velocities = VelocityFields(arch, grid)

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -53,7 +53,7 @@ end
     @testset "Doubly periodic model" begin
         println("  Testing doubly periodic model construction...")
         for arch in archs, FT in float_types
-            model = Model(N=(4, 5, 6), L=(1, 2, 3), arch=arch, float_type=FT)
+            model = Model(N=(16, 16, 2), L=(1, 2, 3), arch=arch, float_type=FT)
 
             # Just testing that a Model was constructed with no errors/crashes.
             @test true
@@ -63,7 +63,7 @@ end
     @testset "Reentrant channel model" begin
         println("  Testing reentrant channel model construction...")
         for arch in archs, FT in float_types
-            model = ChannelModel(N=(6, 5, 4), L=(3, 2, 1), arch=arch, float_type=FT)
+            model = ChannelModel(N=(16, 16, 2), L=(3, 2, 1), arch=arch, float_type=FT)
 
             # Just testing that a ChannelModel was constructed with no errors/crashes.
             @test true
@@ -73,7 +73,7 @@ end
     @testset "Setting model fields" begin
         println("  Testing setting model fields...")
         for arch in archs, FT in float_types
-            N = (4, 6, 8)
+            N = (16, 16, 8)
             L = (2π, 3π, 5π)
 
             grid = RegularCartesianGrid(FT, N, L)


### PR DESCRIPTION
Add a warning if trying to create a GPU model with a grid where `Nx` or `Ny` are not a multiple of 16.

Some GPU kernels still use the hard-coded `Tx = Ty = 16` for calculating thread-block layouts. See PR https://github.com/climate-machine/Oceananigans.jl/pull/308 for why.

Even if we were to get rid of the hard-coded `Tx, Ty` there will always be weird grid sizes like 17x33x47 that you can run no problem on a CPU, but might not be able to create a perfect thread-block layout for without having extra threads that do nothing, but extra threads can do bad stuff like apply a boundary condition twice if we're not careful.

Apologies to @beta-effect who was burned by this in the past.