### PR TITLE
Simplification and generalization of Model constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ At this time, updating should be done with care, as Oceananigans is under rapid 
 Let's initialize a 3D model with 100×100×50 grid points on a 2×2×1 km domain and simulate it for 10 time steps using steps of 60 seconds each (for a total of 10 minutes of simulation time).
 ```julia
 using Oceananigans
-model = Model(N=(100, 100, 50), L=(2000, 2000, 1000))
+model = BasicModel(N=(100, 100, 50), L=(2000, 2000, 1000))
 time_step!(model; Δt=60, Nt=10)
 ```
 You just simulated what might have been a 3D patch of ocean, it's that easy! It was a still lifeless ocean so nothing interesting happened but now you can add interesting dynamics and visualize the output.
@@ -64,7 +64,7 @@ using Oceananigans
 
 # We'll set up a 2D model with an xz-slice so there's only 1 grid point in y
 # and use an artificially high viscosity ν and diffusivity κ.
-model = Model(N=(256, 1, 256), L=(2000, 1, 2000), arch=CPU(), ν=4e-2, κ=4e-2)
+model = BasicModel(N=(256, 1, 256), L=(2000, 1, 2000), arch=CPU(), ν=4e-2, κ=4e-2)
 
 # Set a temperature perturbation with a Gaussian profile located at the center
 # of the vertical slice. This will create a buoyant thermal bubble that will

--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -32,13 +32,14 @@ ubcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fu))
 Tbcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fθ), bottom=BoundaryCondition(Gradient, dTdz))
 
 # Instantiate the model
-model = Model(      arch = CPU(), #has_cuda() ? GPU() : CPU(), # this example will run on the GPU if cuda is available.
-                       N = (N, N, N),
-                       L = (N*Δ, N*Δ, N*Δ),
-                     eos = LinearEquationOfState(βT=βT, βS=0.0),
-               constants = PlanetaryConstants(f=f, g=g),
-                 closure = AnisotropicMinimumDissipation(), # closure = ConstantSmagorinsky(),
-                     bcs = BoundaryConditions(u=ubcs, T=Tbcs))
+model = Model(      
+                   arch = CPU(), # GPU() # this example will run on the GPU if cuda is available.
+                   grid = RegularCartesianGrid(N = (N, N, N), L = (N*Δ, N*Δ, N*Δ)),
+                    eos = LinearEquationOfState(βT=βT, βS=0.0),
+              constants = PlanetaryConstants(f=f, g=g),
+                closure = AnisotropicMinimumDissipation(), # closure = ConstantSmagorinsky(),
+    boundary_conditions = BoundaryConditions(u=ubcs, T=Tbcs)
+)
 
 # Set initial condition. Initial velocity and salinity fluctuations needed for AMD.
 Ξ(z) = randn() * z / model.grid.Lz * (1 + z / model.grid.Lz) # noise

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -101,9 +101,9 @@ w₀(x, y, z) = w(x, y, z, 0)
 T₀(x, y, z) = T(x, y, z, 0)
 
 # Create a model where temperature = buoyancy.
-model = Model(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
-                eos=LinearEquationOfState(βT=1.),
-                constants=PlanetaryConstants(f=f, g=1.))
+model = BasicModel(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
+                    eos=LinearEquationOfState(βT=1.),
+                    constants=PlanetaryConstants(f=f, g=1.))
 
 set_ic!(model, u=u₀, v=v₀, w=w₀, T=T₀)
 println(informative_message(model, u, w, ℕ))

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -45,7 +45,7 @@ export
     Clock,
 
     # Models
-    Model, ChannelModel,
+    Model, BasicModel, ChannelModel, BasicChannelModel,
 
     # Model output writers
     NetCDFOutputWriter, JLD2OutputWriter, Checkpointer,

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -33,7 +33,7 @@ function HorizontalAverage(model, fields; frequency=nothing, interval=nothing,
                            return_type=nothing)
     fields = parenttuple(tupleit(fields))
     validate_interval(frequency, interval)
-    profile = zeros(model.arch, model.grid, 1, 1, model.grid.Tz)
+    profile = zeros(model.architecture, model.grid, 1, 1, model.grid.Tz)
     return HorizontalAverage(profile, fields, frequency, interval, 0.0, return_type)
 end
 

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -128,6 +128,7 @@ end
 
 # Constructor aliases.
 RegularCartesianGrid(N, L) = RegularCartesianGrid(Float64, N, L)
+RegularCartesianGrid(T=Float64; N, L) = RegularCartesianGrid(T, N, L)
 
 size(g::RegularCartesianGrid) = (g.Nx, g.Ny, g.Nz)
 Base.eltype(g::RegularCartesianGrid{T}) where T = T

--- a/src/models.jl
+++ b/src/models.jl
@@ -31,75 +31,112 @@ end
 Construct an `Oceananigans.jl` model.
 """
 function Model(;
-    # Model resolution and domain size
-                      N,
-                      L,
-    # Model architecture and floating point precision
-                   arch = CPU(),
+                   grid, # model resolution and domain
+                   arch = CPU(), # model architecture
              float_type = Float64,
-                   grid = RegularCartesianGrid(float_type, N, L),
-    # Isotropic transport coefficients (exposed to `Model` constructor for convenience)
-                      ν = ν₀, νh=ν, νv=ν,
-                      κ = κ₀, κh=κ, κv=κ,
-                closure = ConstantAnisotropicDiffusivity(float_type, νh=νh, νv=νv, κh=κh, κv=κv),
-    # Time stepping
-             start_time = 0,
-              iteration = 0,
-                  clock = Clock{float_type}(start_time, iteration),
-    # Fluid and physical parameters
-              constants = Earth(float_type),
-                    eos = LinearEquationOfState(float_type),
+                closure = ConstantIsotropicDiffusivity(float_type, ν=ν₀, κ=κ₀), # Diffusivity / turbulence closure
+                  clock = Clock{float_type}(0, 0), # clock for tracking iteration number and time-stepping
+              constants = Earth(float_type), # rotation rate and gravitational acceleration
+                    eos = LinearEquationOfState(float_type), # relationship between tracers and density
     # Forcing and boundary conditions for (u, v, w, T, S)
                 forcing = Forcing(),
-                    bcs = HorizontallyPeriodicModelBCs(),
-    boundary_conditions = bcs,
-    # Output and diagonstics
+    boundary_conditions = HorizontallyPeriodicModelBCs(),
          output_writers = OutputWriter[],
             diagnostics = Diagnostic[],
-    # User-defined parameters container
-             parameters = nothing
+             parameters = nothing, # user-defined container for parameters in forcing and boundary conditions
+    # Velocity fields, tracer fields, pressure fields, and time-stepper initialization
+             velocities = VelocityFields(arch, grid),
+                tracers = TracerFields(arch, grid),
+     initialize_tracers = true,
+              pressures = PressureFields(arch, grid),
+          diffusivities = TurbulentDiffusivities(arch, grid, closure),
+            timestepper = AdamsBashforthTimestepper(float_type, arch, grid, 0.125, 
+                                                    boundary_conditions),
+    # Solver for Poisson's equation
+         poisson_solver = PoissonSolver(arch, PoissonBCs(boundary_conditions), grid)
     )
 
     arch == GPU() && !has_cuda() && throw(
         ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
 
-    # Initialize fields.
-       velocities = VelocityFields(arch, grid)
-          tracers = TracerFields(arch, grid)
-        pressures = PressureFields(arch, grid)
-      timestepper = AdamsBashforthTimestepper(float_type, arch, grid, 0.125, bcs)
-    diffusivities = TurbulentDiffusivities(arch, grid, closure)
-
-    # Initialize Poisson solver.
-    poisson_solver = PoissonSolver(arch, PoissonBCs(bcs), grid)
-
     # Set the default initial condition
-    initialize_with_defaults!(eos, tracers)
+    initialize_tracers && initialize_with_defaults!(eos, tracers)
 
-    Model(arch, grid, clock, eos, constants, velocities, tracers,
-          pressures, forcing, closure, boundary_conditions, timestepper,
-          poisson_solver, diffusivities, output_writers, diagnostics, parameters)
+    return Model(arch, grid, clock, eos, constants, velocities, tracers,
+                 pressures, forcing, closure, boundary_conditions, timestepper,
+                 poisson_solver, diffusivities, output_writers, diagnostics, parameters)
 end
 
 """
     ChannelModel(; kwargs...)
 
-    Construct a `Model` with walls in the y-direction. This is done by imposing
-    `FreeSlip` boundary conditions in the y-direction instead of `Periodic`.
+Construct a `Model` with walls in the y-direction. This is done by imposing
+`FreeSlip` boundary conditions in the y-direction instead of `Periodic`.
 
-    kwargs are passed to the regular `Model` constructor.
+kwargs are passed to the regular `Model` constructor.
 """
-ChannelModel(; bcs=ChannelModelBCs(), kwargs...) =
-    Model(; bcs=bcs, kwargs...)
+ChannelModel(; boundary_conditions=ChannelModelBCs(), kwargs...) = 
+    Model(; boundary_conditions=boundary_conditions, kwargs...)
 
-#
-# Model initialization utilities
-#
+function BasicChannelModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64, 
+                           boundary_conditions=ChannelModelBCs(), kwargs...)
+
+    grid = RegularCartesianGrid(float_type, N, L)
+    closure = ConstantIsotropicDiffusivity(float_type, ν=ν, κ=κ)
+
+    return Model(; float_type=float_type, grid=grid, closure=closure, 
+                 boundary_conditions=boundary_conditions, kwargs...)
+end
+ 
+"""
+    BasicModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64, kwargs...)
+
+Construct a "Basic" `Model` with resolution `N`, domain extent `L`,
+precision `float_type`, and constant isotropic viscosity and diffusivity `ν`, and `κ`.
+
+Additional `kwargs` are passed to the regular `Model` constructor.
+"""
+function BasicModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64, kwargs...)
+    grid = RegularCartesianGrid(float_type, N, L)
+    closure = ConstantIsotropicDiffusivity(float_type, ν=ν, κ=κ)
+    return Model(; float_type=float_type, grid=grid, closure=closure, kwargs...)
+end
+
+"""
+    NonDimensionalModel(; N, L, Re, Pr=0.7, Ri=1, Ro=Inf, float_type=Float64, kwargs...)
+
+Construct a "Non-dimensional" `Model` with resolution `N`, domain extent `L`,
+precision `float_type`, and the four non-dimensional numbers:
+
+    * `Re = U λ / ν` (Reynolds number)
+    * `Pr = U λ / κ` (Prandtl number)
+    * `Ri = B λ U²`  (Richardson number)
+    * `Ro = U / f λ` (Rossby number) 
+
+for characteristic velocity scale `U`, length-scale `λ`, viscosity `ν`, 
+tracer diffusivity `κ`, buoyancy scale (or differential) `B`, and 
+Coriolis parameter `f`.
+
+Note that `N`, `L`, and `Re` are required.
+
+Additional `kwargs` are passed to the regular `Model` constructor.
+"""
+function NonDimensionalModel(; N, L, Re, Pr=0.7, Ri=1, Ro=Inf, float_type=Float64, kwargs...)
+         grid = RegularCartesianGrid(float_type, N, L)
+      closure = ConstantIsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re))
+    constants = PlanetaryConstants(float_type, g=Ri, f=1/Ro)
+          eos = LinearEquationOfState(float_type, βT=1, βS=0)
+    return Model(; float_type=float_type, grid=grid, closure=closure, kwargs...)
+end
+ 
+    
+#####
+##### Model initialization utilities
+#####
 
 arch(model::Model{A}) where A <: Architecture = A
 float_type(m::Model) = eltype(model.grid)
 add_bcs!(model::Model; kwargs...) = add_bcs(model.boundary_conditions; kwargs...)
-
 
 function initialize_with_defaults!(eos::EquationOfState, tracers, sets...)
     # Default tracer initial condition is deteremined by eos.

--- a/src/models.jl
+++ b/src/models.jl
@@ -126,7 +126,8 @@ function NonDimensionalModel(; N, L, Re, Pr=0.7, Ri=1, Ro=Inf, float_type=Float6
       closure = ConstantIsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re))
     constants = PlanetaryConstants(float_type, g=Ri, f=1/Ro)
           eos = LinearEquationOfState(float_type, βT=1, βS=0)
-    return Model(; float_type=float_type, grid=grid, closure=closure, kwargs...)
+    return Model(; float_type=float_type, grid=grid, closure=closure, 
+                 constants=constants, eos=eos, skwargs...)
 end
  
     

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -389,7 +389,7 @@ mutable struct Checkpointer{I, T, P, A} <: OutputWriter
 end
 
 function Checkpointer(model; frequency=nothing, interval=nothing, dir=".", prefix="checkpoint", force=false, 
-                      verbose=false, properties = [:arch, :boundary_conditions, :grid, :clock, :eos, :constants, 
+                      verbose=false, properties = [:architecture, :boundary_conditions, :grid, :clock, :eos, :constants, 
                                                    :closure, :velocities, :tracers, :timestepper])
                       
     validate_interval(frequency, interval)
@@ -465,7 +465,7 @@ function restore_from_checkpoint(filepath; kwargs=Dict())
     # Now restore fields.
     for p in cps
         if p in has_array_refs
-            restore_fields!(model, file, model.arch, p)
+            restore_fields!(model, file, model.architecture, p)
         end
     end
 

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -460,10 +460,6 @@ function restore_from_checkpoint(filepath; kwargs=Dict())
         end
     end
 
-    # The Model constructor needs N and L.
-    kwargs[:N] = (kwargs[:grid].Nx, kwargs[:grid].Ny, kwargs[:grid].Nz)
-    kwargs[:L] = (kwargs[:grid].Lx, kwargs[:grid].Ly, kwargs[:grid].Lz)
-
     model = Model(; kwargs...)
 
     # Now restore fields.

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -25,7 +25,7 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
     for n in 1:Nt
         χ = ifelse(init_with_euler && n==1, FT(-0.5), model.timestepper.χ)
 
-        adams_bashforth_time_step!(model, model.arch, model.grid, model.constants, model.eos, model.closure,
+        adams_bashforth_time_step!(model, model.architecture, model.grid, model.constants, model.eos, model.closure,
                                    model.forcing, model.boundary_conditions, pressure_bcs, U, Φ, p, K, RHS, Gⁿ, 
                                    G⁻, Δt, χ)
 

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -4,8 +4,8 @@ function test_z_boundary_condition_simple(arch, T, fldname, bctype, bc, Nx, Ny)
     fieldbcs = HorizontallyPeriodicBCs(top=bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
-                  bcs=modelbcs)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
+                       boundary_conditions=modelbcs)
 
     time_step!(model, 1, 1e-16)
 
@@ -19,8 +19,8 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=top_bc, bottom=bottom_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = Model(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=FT,
-                  bcs=modelbcs)
+    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=FT,
+                       boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
 
@@ -42,8 +42,8 @@ function test_z_boundary_condition_array(arch, T, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=value_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = Model(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
-                  bcs=modelbcs)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
+                       boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
 
@@ -60,8 +60,8 @@ function test_flux_budget(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(bottom=flux_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = Model(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, arch=arch, float_type=FT,
-                  eos=LinearEquationOfState(βS=0, βT=0), bcs=modelbcs)
+    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, arch=arch, float_type=FT,
+                  eos=LinearEquationOfState(βS=0, βT=0), boundary_conditions=modelbcs)
 
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -4,8 +4,8 @@ function test_z_boundary_condition_simple(arch, T, fldname, bctype, bc, Nx, Ny)
     fieldbcs = HorizontallyPeriodicBCs(top=bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
-                       boundary_conditions=modelbcs)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch, 
+                       float_type=T, boundary_conditions=modelbcs)
 
     time_step!(model, 1, 1e-16)
 
@@ -19,8 +19,8 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=top_bc, bottom=bottom_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=FT,
-                       boundary_conditions=modelbcs)
+    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), architecture=arch, 
+                       float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
 
@@ -29,10 +29,10 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     getbc(bcs.z.top) == val && getbc(bcs.z.bottom) == -val
 end
 
-function test_z_boundary_condition_array(arch, T, fldname)
+function test_z_boundary_condition_array(arch, FT, fldname)
     Nx = Ny = Nz = 16
 
-    bcarray = rand(T, Nx, Ny)
+    bcarray = rand(FT, Nx, Ny)
 
     if arch == GPU()
         bcarray = CuArray(bcarray)
@@ -42,8 +42,8 @@ function test_z_boundary_condition_array(arch, T, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=value_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
-                       boundary_conditions=modelbcs)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch, 
+                       float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
 
@@ -60,9 +60,10 @@ function test_flux_budget(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(bottom=flux_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, arch=arch, float_type=FT,
-                  eos=LinearEquationOfState(βS=0, βT=0), boundary_conditions=modelbcs)
-
+    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, architecture=arch, 
+                       float_type=FT, eos=LinearEquationOfState(βS=0, βT=0), 
+                       boundary_conditions=modelbcs)
+                       
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)
     else

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1,5 +1,5 @@
 function horizontal_average_is_correct(arch, FT)
-    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), architecture=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile.
     T₀(x, y, z) = 20 + 0.01*z
@@ -14,7 +14,7 @@ function horizontal_average_is_correct(arch, FT)
 end
 
 function product_profile_is_correct(arch, FT)
-    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), architecture=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile and a sinusoidal u(z) profile.
     u₀(x, y, z) = sin(z)
@@ -29,7 +29,7 @@ function product_profile_is_correct(arch, FT)
 end
 
 function nan_checker_aborts_simulation(arch, FT)
-    model = BasicModel(N = (16, 16, 2), L = (1, 1, 1), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 2), L = (1, 1, 1), architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
     nc = NaNChecker(model; frequency=1)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1,5 +1,5 @@
 function horizontal_average_is_correct(arch, FT)
-    model = Model(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile.
     T₀(x, y, z) = 20 + 0.01*z
@@ -14,7 +14,7 @@ function horizontal_average_is_correct(arch, FT)
 end
 
 function product_profile_is_correct(arch, FT)
-    model = Model(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), arch=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile and a sinusoidal u(z) profile.
     u₀(x, y, z) = sin(z)
@@ -29,7 +29,7 @@ function product_profile_is_correct(arch, FT)
 end
 
 function nan_checker_aborts_simulation(arch, FT)
-    model = Model(N = (16, 16, 2), L = (1, 1, 1), arch=arch, float_type=FT)
+    model = BasicModel(N = (16, 16, 2), L = (1, 1, 1), arch=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
     nc = NaNChecker(model; frequency=1)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -1,6 +1,5 @@
 using Printf
 
-
 function getmodelfield(fieldname, model)
     if fieldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fieldname)
@@ -29,7 +28,7 @@ function T_relative_error(model, T)
 end
 
 function test_diffusion_simple(fieldname)
-    model = Model(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
+    model = BasicModel(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
     field = getmodelfield(fieldname, model)
     value = π
     data(field) .= value
@@ -40,23 +39,23 @@ function test_diffusion_simple(fieldname)
 end
 
 function test_diffusion_budget_default(fieldname)
-    model = Model(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
+    model = BasicModel(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
     field = getmodelfield(fieldname, model)
     half_Nz = round(Int, model.grid.Nz/2)
     data(field)[:, :,   1:half_Nz] .= -1
     data(field)[:, :, half_Nz:end] .=  1
 
-    return test_diffusion_budget(field, model, model.closure.κh, model.grid.Lz)
+    return test_diffusion_budget(field, model, model.closure.κ, model.grid.Lz)
 end
 
 function test_diffusion_budget_channel(fieldname)
-    model = ChannelModel(N=(1, 16, 4), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
+    model = BasicChannelModel(N=(1, 16, 4), L=(1, 1, 1), ν=1, κ=1, eos=NoEquationOfState())
     field = getmodelfield(fieldname, model)
     half_Ny = round(Int, model.grid.Ny/2)
     data(field)[:, 1:half_Ny,   :] .= -1
     data(field)[:, half_Ny:end, :] .=  1
 
-    return test_diffusion_budget(field, model, model.closure.κh, model.grid.Ly)
+    return test_diffusion_budget(field, model, model.closure.κ, model.grid.Ly)
 end
 
 function test_diffusion_budget(field, model, κ, L)
@@ -67,7 +66,7 @@ end
 
 function test_diffusion_cosine(fieldname)
     Nz, Lz, κ, m = 128, π/2, 1, 2
-    model = Model(N=(1, 1, Nz), L=(1, 1, Lz), ν=κ, κ=κ, eos=NoEquationOfState())
+    model = BasicModel(N=(1, 1, Nz), L=(1, 1, Lz), ν=κ, κ=κ, eos=NoEquationOfState())
     field = getmodelfield(fieldname, model)
 
     zC = model.grid.zC
@@ -118,9 +117,9 @@ function internal_wave_test(; N=128, Nt=10)
     T₀(x, y, z) = T(x, y, z, 0)
 
     # Create a model where temperature = buoyancy.
-    model = Model(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
-                    eos=LinearEquationOfState(βT=1.),
-                    constants=PlanetaryConstants(f=f, g=1.))
+    model = BasicModel(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
+                       eos=LinearEquationOfState(βT=1.),
+                       constants=PlanetaryConstants(f=f, g=1.))
 
     set_ic!(model, u=u₀, v=v₀, w=w₀, T=T₀)
 
@@ -141,7 +140,7 @@ function passive_tracer_advection_test(; N=128, κ=1e-12, Nt=100)
     v₀(x, y, z) = V
     T₀(x, y, z) = T(x, y, z, 0)
 
-    model = Model(N=(N, N, 2), L=(L, L, L), ν=κ, κ=κ)
+    model = BasicModel(N=(N, N, 2), L=(L, L, L), ν=κ, κ=κ)
 
     set_ic!(model, u=u₀, v=v₀, T=T₀)
     time_step!(model, Nt, Δt)
@@ -172,11 +171,12 @@ function pearson_vortex_test(arch; FT=Float64, N=64, Nt=10)
     vbcs = HorizontallyPeriodicBCs(   top = BoundaryCondition(Gradient, 0),
                                    bottom = BoundaryCondition(Gradient, 0))
 
-    model = Model(N = (Nx, Ny, Nz), L = (Lx, Ly, Lz), arch = arch,
-                  constants = PlanetaryConstants(f=0, g=0),  # Turn off rotation and gravity.
-                    closure = ConstantIsotropicDiffusivity(FT; ν = 1, κ = 0),  # Turn off diffusivity.
-                        eos = LinearEquationOfState(βT=0, βS=0),  # Turn off buoyancy.
-                        bcs = BoundaryConditions(u=ubcs, v=vbcs))
+    model = Model(                arch = arch, 
+                                  grid = RegularCartesianGrid(FT; N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)), 
+                             constants = PlanetaryConstants(f=0, g=0),  # Turn off rotation and gravity.
+                               closure = ConstantIsotropicDiffusivity(FT; ν=1, κ=0),  # Turn off diffusivity.
+                                   eos = LinearEquationOfState(βT=0, βS=0),  # Turn off buoyancy.
+                   boundary_conditions = BoundaryConditions(u=ubcs, v=vbcs))
 
     u₀(x, y, z) = u(x, y, z, 0)
     v₀(x, y, z) = v(x, y, z, 0)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -171,7 +171,7 @@ function pearson_vortex_test(arch; FT=Float64, N=64, Nt=10)
     vbcs = HorizontallyPeriodicBCs(   top = BoundaryCondition(Gradient, 0),
                                    bottom = BoundaryCondition(Gradient, 0))
 
-    model = Model(                arch = arch, 
+    model = Model(        architecture = arch, 
                                   grid = RegularCartesianGrid(FT; N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)), 
                              constants = PlanetaryConstants(f=0, g=0),  # Turn off rotation and gravity.
                                closure = ConstantIsotropicDiffusivity(FT; ν=1, κ=0),  # Turn off diffusivity.

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -14,7 +14,7 @@ function time_step_with_forcing_functions(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
@@ -26,7 +26,7 @@ function time_step_with_forcing_functions_params(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing, parameters=(τ=60,))
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing, parameters=(τ=60,))
     time_step!(model, 1, 1)
     return true
 end
@@ -38,7 +38,7 @@ function time_step_with_forcing_functions_sin_exp(arch)
 
     forcing = Forcing(Fu=Fu, FT=FT)
 
-    model = Model(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -14,7 +14,7 @@ function time_step_with_forcing_functions(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
@@ -26,7 +26,7 @@ function time_step_with_forcing_functions_params(arch)
 
     forcing = Forcing(Fu=Fu, Fv=Fv, Fw=Fw)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing, parameters=(τ=60,))
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing, parameters=(τ=60,))
     time_step!(model, 1, 1)
     return true
 end
@@ -38,7 +38,7 @@ function time_step_with_forcing_functions_sin_exp(arch)
 
     forcing = Forcing(Fu=Fu, FT=FT)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), arch=arch, forcing=forcing)
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -1,7 +1,5 @@
 function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
-    model = Model(arch=arch, float_type=eltype(grid),
-                  N=size(grid), L=(grid.Lx, grid.Ly, grid.Lz))
-
+    model = Model(arch=arch, float_type=eltype(grid), grid=grid)
     kwarg = Dict(fieldname=>value)
     set!(model; kwarg...)
 
@@ -15,7 +13,7 @@ function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
 end
 
 function initial_conditions_correctly_set(arch, FT)
-    model = Model(N=(16, 16, 8), L=(1, 2, 3), arch=arch, float_type=FT)
+    model = BasicModel(N=(16, 16, 8), L=(1, 2, 3), arch=arch, float_type=FT)
 
     # Set initial condition to some basic function we can easily check for.
     # We offset the functions by an integer so that we don't end up comparing
@@ -53,7 +51,7 @@ end
     @testset "Doubly periodic model" begin
         println("  Testing doubly periodic model construction...")
         for arch in archs, FT in float_types
-            model = Model(N=(4, 5, 6), L=(1, 2, 3), arch=arch, float_type=FT)
+            model = BasicModel(N=(4, 5, 6), L=(1, 2, 3), arch=arch, float_type=FT)
 
             # Just testing that a Model was constructed with no errors/crashes.
             @test true
@@ -63,7 +61,7 @@ end
     @testset "Reentrant channel model" begin
         println("  Testing reentrant channel model construction...")
         for arch in archs, FT in float_types
-            model = ChannelModel(N=(6, 5, 4), L=(3, 2, 1), arch=arch, float_type=FT)
+            model = BasicChannelModel(N=(6, 5, 4), L=(3, 2, 1), arch=arch, float_type=FT)
 
             # Just testing that a ChannelModel was constructed with no errors/crashes.
             @test true

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -1,5 +1,5 @@
 function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
-    model = Model(arch=arch, float_type=eltype(grid), grid=grid)
+    model = Model(architecture=arch, float_type=eltype(grid), grid=grid)
     kwarg = Dict(fieldname=>value)
     set!(model; kwarg...)
 
@@ -13,7 +13,7 @@ function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
 end
 
 function initial_conditions_correctly_set(arch, FT)
-    model = BasicModel(N=(16, 16, 8), L=(1, 2, 3), arch=arch, float_type=FT)
+    model = BasicModel(N=(16, 16, 8), L=(1, 2, 3), architecture=arch, float_type=FT)
 
     # Set initial condition to some basic function we can easily check for.
     # We offset the functions by an integer so that we don't end up comparing
@@ -51,7 +51,7 @@ end
     @testset "Doubly periodic model" begin
         println("  Testing doubly periodic model construction...")
         for arch in archs, FT in float_types
-            model = BasicModel(N=(4, 5, 6), L=(1, 2, 3), arch=arch, float_type=FT)
+            model = BasicModel(N=(4, 5, 6), L=(1, 2, 3), architecture=arch, float_type=FT)
 
             # Just testing that a Model was constructed with no errors/crashes.
             @test true
@@ -61,7 +61,7 @@ end
     @testset "Reentrant channel model" begin
         println("  Testing reentrant channel model construction...")
         for arch in archs, FT in float_types
-            model = BasicChannelModel(N=(6, 5, 4), L=(3, 2, 1), arch=arch, float_type=FT)
+            model = BasicChannelModel(N=(6, 5, 4), L=(3, 2, 1), architecture=arch, float_type=FT)
 
             # Just testing that a ChannelModel was constructed with no errors/crashes.
             @test true

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -10,7 +10,7 @@ function run_thermal_bubble_netcdf_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), architecture=arch, ν=4e-2, κ=4e-2)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.
@@ -85,7 +85,7 @@ function run_thermal_bubble_checkpointer_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    true_model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, arch=arch)
+    true_model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, architecture=arch)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -10,7 +10,7 @@ function run_thermal_bubble_netcdf_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.
@@ -38,7 +38,7 @@ function run_thermal_bubble_netcdf_tests(arch)
 end
 
 function run_jld2_file_splitting_tests(arch)
-    model = Model(N=(16, 16, 16), L=(1, 1, 1))
+    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1))
 
     u(model) = Array(model.velocities.u.data.parent)
     fields = Dict(:u => u)
@@ -85,7 +85,7 @@ function run_thermal_bubble_checkpointer_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    true_model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, arch=arch)
+    true_model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, arch=arch)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -15,7 +15,10 @@ function run_thermal_bubble_regression_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), architecture=arch, ν=4e-2, κ=4e-2)
+
+    model.tracers.T.data.parent .= model.eos.T₀
+    model.tracers.S.data.parent .= model.eos.S₀
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.
@@ -89,7 +92,7 @@ function run_rayleigh_benard_regression_test(arch)
     FS(i, j, k, grid, time, U, Φ, params) = 1/10 * (S★(grid.xC[i], grid.zC[k]) - Φ.S[i, j, k])
 
     model = Model(
-                       arch = arch,
+               architecture = arch,
                        grid = RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
                     closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ),
                         eos = LinearEquationOfState(βT=1., βS=0.),

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -15,7 +15,7 @@ function run_thermal_bubble_regression_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, ν=4e-2, κ=4e-2)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.
@@ -62,9 +62,9 @@ end
 
 function run_rayleigh_benard_regression_test(arch)
 
-    #
-    # Parameters
-    #
+    #####
+    ##### Parameters
+    #####
           α = 2                 # aspect ratio
           n = 1                 # resolution multiple
          Ra = 1e6               # Rayleigh number
@@ -80,27 +80,23 @@ function run_rayleigh_benard_regression_test(arch)
     ν = sqrt(Δb * Pr * Lz^3 / Ra)
     κ = ν / Pr
 
-    #
-    # Model setup
-    #
+    #####
+    ##### Model setup
+    #####
 
     # Force salinity as a passive tracer (βS=0)
     S★(x, z) = exp(4z) * sin(2π/Lx * x)
     FS(i, j, k, grid, time, U, Φ, params) = 1/10 * (S★(grid.xC[i], grid.zC[k]) - Φ.S[i, j, k])
 
     model = Model(
-         arch = arch,
-            N = (Nx, Ny, Nz),
-            L = (Lx, Ly, Lz),
-            ν = ν,
-            κ = κ,
-          eos = LinearEquationOfState(βT=1., βS=0.),
-    constants = PlanetaryConstants(g=1., f=0.),
-          bcs = BoundaryConditions(T=HorizontallyPeriodicBCs(
-                       top = BoundaryCondition(Value, 0.0),
-                    bottom = BoundaryCondition(Value, Δb)
-                )),
-      forcing = Forcing(FS=FS)
+                       arch = arch,
+                       grid = RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
+                    closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ),
+                        eos = LinearEquationOfState(βT=1., βS=0.),
+                  constants = PlanetaryConstants(g=1., f=0.),
+        boundary_conditions = BoundaryConditions(T=HorizontallyPeriodicBCs(
+                                top=BoundaryCondition(Value, 0.0), bottom=BoundaryCondition(Value, Δb))),
+                    forcing = Forcing(FS=FS)
     )
 
     ArrayType = typeof(model.velocities.u.data.parent)  # The type of the underlying data, not the offset array.
@@ -118,9 +114,9 @@ function run_rayleigh_benard_regression_test(arch)
     outputwriter = JLD2OutputWriter(model, outputfields; dir=".", prefix=prefix,
                                     frequency=test_steps, including=[])
 
-    #
-    # Initial condition and spinup steps for creating regression test data
-    #
+    #####
+    ##### Initial condition and spinup steps for creating regression test data
+    #####
 
     #=
     @warn ("Generating new data for the Rayleigh-Benard regression test.
@@ -136,9 +132,9 @@ function run_rayleigh_benard_regression_test(arch)
     time_step!(model, 2test_steps, Δt)
     =#
 
-    #
-    # Regression test
-    #
+    #####
+    ##### Regression test
+    #####
 
     # Load initial state
     u₀, v₀, w₀ = get_output_tuple(outputwriter, spinup_steps, :U)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -1,7 +1,7 @@
 using Oceananigans: velocity_div!, compute_w_from_continuity!
 
 function time_stepping_works(arch, FT, Closure)
-    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
+    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), architecture=arch, float_type=FT,
                        closure=Closure(FT))
     time_step!(model, 1, 1)
     return true # test that no errors/crashes happen when time stepping.
@@ -9,7 +9,7 @@ end
 
 function run_first_AB2_time_step_tests(arch, FT)
     add_ones(args...) = 1.0
-    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
+    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), architecture=arch, float_type=FT,
                        forcing=Forcing(FT=add_ones))
     time_step!(model, 1, 1)
 
@@ -71,7 +71,7 @@ function incompressible_in_time(arch, FT, Nt)
     Nx, Ny, Nz = 32, 32, 32
     Lx, Ly, Lz = 10, 10, 10
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=FT)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), architecture=arch, float_type=FT)
 
     grid = model.grid
     u, v, w = model.velocities.u, model.velocities.v, model.velocities.w
@@ -116,7 +116,7 @@ function tracer_conserved_in_channel(arch, FT, Nt)
     νv, κv = α*νh, α*κh
 
     model = ChannelModel(grid=RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
-                         arch=arch, float_type=FT,
+                         architecture=arch, float_type=FT,
                          closure=ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -1,16 +1,16 @@
 using Oceananigans: velocity_div!, compute_w_from_continuity!
 
 function time_stepping_works(arch, FT, Closure)
-    model = Model(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
-                  closure=Closure(FT))
+    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
+                       closure=Closure(FT))
     time_step!(model, 1, 1)
     return true # test that no errors/crashes happen when time stepping.
 end
 
 function run_first_AB2_time_step_tests(arch, FT)
     add_ones(args...) = 1.0
-    model = Model(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
-                  forcing=Forcing(FT=add_ones))
+    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), arch=arch, float_type=FT,
+                       forcing=Forcing(FT=add_ones))
     time_step!(model, 1, 1)
 
     # Test that GT = 1 after first time step and that AB2 actually reduced to forward Euler.
@@ -71,7 +71,7 @@ function incompressible_in_time(arch, FT, Nt)
     Nx, Ny, Nz = 32, 32, 32
     Lx, Ly, Lz = 10, 10, 10
 
-    model = Model(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=FT)
+    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), arch=arch, float_type=FT)
 
     grid = model.grid
     u, v, w = model.velocities.u, model.velocities.v, model.velocities.w
@@ -115,9 +115,9 @@ function tracer_conserved_in_channel(arch, FT, Nt)
     νh, κh = 20.0, 20.0
     νv, κv = α*νh, α*κh
 
-    model = ChannelModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz),
+    model = ChannelModel(grid=RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
                          arch=arch, float_type=FT,
-                         νh=νh, νv=νv, κh=κh, κv=κv)
+                         closure=ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].
     Tz = 5e-3  # Vertical temperature gradient [K/m].


### PR DESCRIPTION
This PR simplifies and generalizes the model constructor, which is a major change to the API. Except for `initialize_tracers` and `float_type`, all of the keyword arguments to `Model` now correspond semantically to the fields of model. In addition to clarifying the arguments of the model constructor, this will make checkpointing easier. 

In addition, model fields that contain arrays, and thus are involved with large amounts of memory allocation, can be initialized through the model constructor. This should enable upgrades to the checkpointer that make it possible to checkpoint very large models that fill GPU memory.

Finally, we add three new convenience constructors that retain the legacy behavior of model, and provide convenient ways to initialize particular models: `BasicModel`, `BasicChannelModel`, and `NonDimensionalModel`. `BasicModel` and `BasicChannelModel` closely resembles the original model constructor, while `NonDimensionalModel` allow parameters to be set by specifying non-dimensional numbers, rather than dimensional constants.

Resolves #372.