### PR TITLE
Refactor boundary conditions container

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -34,7 +34,7 @@ export
     Periodic, Flux, Gradient, Value, Dirchlet, Neumann,
     CoordinateBoundaryConditions,
     FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
-    BoundaryConditions, ModelBoundaryConditions, HorizontallyPeriodicModelBCs, ChannelModelBCs,
+    BoundaryConditions, SolutionBoundaryConditions, HorizontallyPeriodicSolutionBCs, ChannelSolutionBCs,
     getbc, setbc!,
 
     # Time stepping

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -161,7 +161,7 @@ end
 
 
 #####
-##### Boundary conditions for systems of equations
+##### Boundary conditions for solutions to systems of equations
 #####
 
 """
@@ -246,15 +246,15 @@ function PressureBoundaryConditions(vbcs)
 end
 
 #####
-##### Model boundary conditions for pressure, and solution, and tendency systems
+##### Model boundary conditions for pressure, and solution, and tendency solutions
 #####
 
 const ModelBoundaryConditions = NamedTuple{(:solution, :tendency, :pressure)}
 
-function ModelBoundaryConditions(system_boundary_conditions::NamedTuple)
-    model_boundary_conditions = (solution = system_boundary_conditions, 
-                                 tendency = TendenciesBoundaryConditions(system_boundary_conditions),
-                                 pressure = PressureBoundaryConditions(system_boundary_conditions.v))
+function ModelBoundaryConditions(solution_boundary_conditions::NamedTuple)
+    model_boundary_conditions = (solution = solution_boundary_conditions, 
+                                 tendency = TendenciesBoundaryConditions(solution_boundary_conditions),
+                                 pressure = PressureBoundaryConditions(solution_boundary_conditions.v))
     return model_boundary_conditions
 end
 

--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -136,7 +136,7 @@ end
 Fill halo regions for each field in the tuple `fields` according
 to the single instances of `FieldBoundaryConditions` in `bcs`.
 """
-function fill_halo_regions!(fields::NamedTuple, bcs::NamedTuple{(:x, :y, :z)}, arch, grid, args...)
+function fill_halo_regions!(fields::NamedTuple, bcs::FieldBoundaryConditions, arch, grid, args...)
     for field in fields
         fill_halo_regions!(field, bcs, arch, grid, args...)
     end

--- a/src/models.jl
+++ b/src/models.jl
@@ -49,7 +49,7 @@ function Model(;
                 tracers = TracerFields(architecture, grid),
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, closure),
-            timestepper = AdamsBashforthTimestepper(float_type, arch, grid, 0.125),
+            timestepper = AdamsBashforthTimestepper(float_type, architecture, grid, 0.125),
     # Solver for Poisson's equation
          poisson_solver = PoissonSolver(architecture, PoissonBCs(boundary_conditions), grid)
     )

--- a/src/models.jl
+++ b/src/models.jl
@@ -26,9 +26,35 @@ end
 
 
 """
-    Model(; kwargs...)
+    Model(; grid, kwargs...)
 
-Construct an `Oceananigans.jl` model.
+Construct an `Oceananigans.jl` model on `grid`.
+
+Important keyword arguments include
+
+    `grid`                : (required) The resolution and discrete geometry on which `model` is solved.
+                            Currently the only option is `RegularCartesianGrid`.
+
+    `architecture`        : `CPU()` or `GPU()`. The computer architecture used to time-step `model`. 
+
+    `float_type`          : `Float32` or `Float64`. The floating point type used for `model` data.
+
+    `closure`             : The turbulence closure for `model`. See `TurbulenceClosures`.
+
+    `constants`           : `PlanetaryConstants(g=g, f=f)`, determines gravitational acclereation `g` 
+                             and Coriolis parameter `f`.
+
+    `eos`                 : The equation of state that relates tracers `T` and `S` to density perturbations.
+                            See `EquationOfState`.
+
+    `forcing`             : User-defined forcing functions that contribute to solution tendencies.
+
+    `boundary_conditions` : User-defined boundary conditions for model fields. Can be either 
+                            `SolutionBoundaryConditions` or `ModelBoundaryConditions`.
+                            See `BoundaryConditions`, `HorizontallyPeriodicSolutionBCs` and `ChannelSolutionBCs`.
+
+    `parameters`          : User-defined parameters for use in user-defined forcing functions and boundary
+                            condition functions.
 """
 function Model(;
                    grid, # model resolution and domain

--- a/src/poisson_solvers.jl
+++ b/src/poisson_solvers.jl
@@ -32,6 +32,8 @@ function PoissonBCs(bcs)
     return eval(Expr(:call, Symbol(x, y, z)))
 end
 
+PoissonBCs(model_bcs::ModelBoundaryConditions) = PoissonBCs(model_bcs.solution)
+
 PoissonSolver(::CPU, pbcs::PoissonBCs, grid::Grid) = PoissonSolverCPU(pbcs, grid)
 PoissonSolver(::GPU, pbcs::PoissonBCs, grid::Grid) = PoissonSolverGPU(pbcs, grid)
 

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -20,13 +20,12 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
     RHS = model.poisson_solver.storage
     U, Φ, Gⁿ, G⁻, K, p = datatuples(model.velocities, model.tracers, model.timestepper.Gⁿ,
                                     model.timestepper.G⁻, model.diffusivities, model.pressures)
-    pressure_bcs = PressureBoundaryConditions(model.boundary_conditions.v)
 
     for n in 1:Nt
         χ = ifelse(init_with_euler && n==1, FT(-0.5), model.timestepper.χ)
 
         adams_bashforth_time_step!(model, model.arch, model.grid, model.constants, model.eos, model.closure,
-                                   model.forcing, model.boundary_conditions, pressure_bcs, U, Φ, p, K, RHS, Gⁿ, 
+                                   model.forcing, model.boundary_conditions, U, Φ, p, K, RHS, Gⁿ, 
                                    G⁻, Δt, χ)
 
         [ time_to_run(model.clock, diag) && run_diagnostic(model, diag) for diag in model.diagnostics ]
@@ -41,7 +40,7 @@ end
 
 Step forward one time step with a 2nd-order Adams-Bashforth method and pressure-correction substep.
 """
-function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, forcing, bcs, pressure_bcs,
+function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, forcing, bcs,
                                     U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)
 
     # Arguments for user-defined boundary condition functions:
@@ -49,34 +48,34 @@ function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, 
 
     # Pre-computations:
     @launch device(arch) config=launch_config(grid, 3) store_previous_source_terms!(grid, Gⁿ, G⁻)
-    fill_halo_regions!(merge(U, Φ), bcs, arch, grid, boundary_condition_args...)
+    fill_halo_regions!(merge(U, Φ), bcs.solution, arch, grid, boundary_condition_args...)
 
     @launch device(arch) config=launch_config(grid, 3) calc_diffusivities!(K, grid, closure, eos, constants.g, U, Φ)
-    fill_halo_regions!(K, pressure_bcs, arch, grid) # diffusivities share bcs with pressure.
+    fill_halo_regions!(K, bcs.pressure, arch, grid) # diffusivities share bcs with pressure.
     @launch device(arch) config=launch_config(grid, 2) update_hydrostatic_pressure!(p.pHY′, grid, constants, eos, Φ)
-    fill_halo_regions!(p.pHY′, pressure_bcs, arch, grid)
+    fill_halo_regions!(p.pHY′, bcs.pressure, arch, grid)
 
     # Calculate tendency terms (minus non-hydrostatic pressure, which is updated in a pressure correction step):
     calculate_interior_source_terms!(Gⁿ, arch, grid, constants, eos, closure, U, Φ, p.pHY′, K, forcing, 
                                      model.parameters, model.clock.time)
-    calculate_boundary_source_terms!(Gⁿ, arch, grid, bcs, boundary_condition_args...)
+    calculate_boundary_source_terms!(Gⁿ, arch, grid, bcs.solution, boundary_condition_args...)
 
     # Complete explicit substep:
     @launch device(arch) config=launch_config(grid, 3) adams_bashforth_update_source_terms!(grid, Gⁿ, G⁻, χ)
 
     # Start pressure correction substep with a pressure solve:
-    fill_halo_regions!(Gⁿ[1:3], bcs[1:3], arch, grid)
+    fill_halo_regions!(Gⁿ[1:3], bcs.tendency[1:3], arch, grid)
     @launch device(arch) config=launch_config(grid, 3) calculate_poisson_right_hand_side!(arch, grid, 
                                                                                           model.poisson_solver.bcs,
                                                                                           Δt, U, Gⁿ, RHS)
     solve_for_pressure!(arch, model)
-    fill_halo_regions!(p.pNHS, pressure_bcs, arch, grid)
+    fill_halo_regions!(p.pNHS, bcs.pressure, arch, grid)
 
     # Complete pressure correction step:
     @launch device(arch) config=launch_config(grid, 3) update_velocities_and_tracers!(grid, U, Φ, p.pNHS, Gⁿ, Δt)
 
     # Recompute vertical velocity w from continuity equation to ensure incompressibility
-    fill_halo_regions!(U, bcs[1:3], arch, grid, boundary_condition_args...)
+    fill_halo_regions!(U, bcs.solution[1:3], arch, grid, boundary_condition_args...)
     @launch device(arch) config=launch_config(grid, 2) compute_w_from_continuity!(grid, U)
 
     model.clock.time += Δt

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -22,7 +22,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), arch=arch, float_type=FT,
                        boundary_conditions=modelbcs)
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
 
     time_step!(model, 1, 1e-16)
 
@@ -45,7 +45,7 @@ function test_z_boundary_condition_array(arch, T, fldname)
     model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), arch=arch, float_type=T,
                        boundary_conditions=modelbcs)
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
 
     time_step!(model, 1, 1e-16)
 
@@ -61,7 +61,7 @@ function test_flux_budget(arch, FT, fldname)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
     model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, arch=arch, float_type=FT,
-                  eos=LinearEquationOfState(βS=0, βT=0), boundary_conditions=modelbcs)
+                       eos=LinearEquationOfState(βS=0, βT=0), boundary_conditions=modelbcs)
 
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)
@@ -71,7 +71,7 @@ function test_flux_budget(arch, FT, fldname)
 
     @. field.data = 0
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
     mean_init = mean(data(field))
 
     τκ = Lz^2 / κ   # Diffusion time-scale

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -32,7 +32,7 @@ function compute_w_from_continuity(arch, FT)
     Lx, Ly, Lz = 16, 16, 16
 
     grid = RegularCartesianGrid(FT, (Nx, Ny, Nz), (Lx, Ly, Lz))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
 
     u = FaceFieldX(FT, arch, grid)
     v = FaceFieldY(FT, arch, grid)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -58,7 +58,7 @@ function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64;
     arch = CPU()
     closure = ConstantIsotropicDiffusivity(FT, κ=κ, ν=ν)
     grid = RegularCartesianGrid(FT, (3, 1, 4), (3, 1, 4))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
     eos = LinearEquationOfState()
     grav = one(FT)
 
@@ -90,7 +90,7 @@ function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.
     arch = CPU()
     closure = ConstantAnisotropicDiffusivity(FT, κh=κh, νh=νh, κv=κv, νv=νv)
     grid = RegularCartesianGrid(FT, (3, 1, 4), (3, 1, 4))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
     eos = LinearEquationOfState()
     grav = one(FT)
     velocities = Oceananigans.VelocityFields(arch, grid)


### PR DESCRIPTION
This PR refactors the boundary conditions container to reflect the fact that there are three boundary conditions: a tuple of `FieldBoundaryConditions` for the `solution`, a tuple of `FieldBoundaryConditions` for the `tendencies`, and a single `FieldBoundaryConditions` for the `pressures` (which is also used to set boundary conditions on `diffusivities`.

To reflect these facts, this model creates a new tuple called `SolutionBoundaryConditions` to hold the boundary conditions for solution. `ModelBoundaryConditions` then becomes a named tuple with fields `solution`, `tendency`, and `pressure`.

The model constructor may be passed either a `SolutionBoundaryConditions` (preserving existing behavior), or a `ModelBoundaryConditions` (convenient for checkpointing). Ditto for `PoissonBCs` --- though technically we don't need `PoissonBCs` anymore; we simply need to dispatch on the type of `model.boundary_conditions.pressure` (work for the future).

Previously, a new instance of boundary conditions for pressure was created every time-step. This PR avoids that unnecessary cost / allocation. It also moves boundary conditions out of `timestepper`, slightly changing the time stepper struct.

@ali-ramadhan, the tests pass so I think the checkpointer works, but it'd be worth thinking about whether its doing the right thing now.