### PR TITLE
Pre-documentation cleanup

### DIFF
--- a/benchmark/benchmark_utils.jl
+++ b/benchmark/benchmark_utils.jl
@@ -7,7 +7,7 @@ benchmark_name(N, ft::DataType) = benchmark_name(N, "", nothing, ft)
 
 function benchmark_name(N, id, arch, ft; npad=3)
     Nx, Ny, Nz = N
-    print_arch = typeof(arch) <: Architecture ? true : false
+    print_arch = typeof(arch) <: AbstractArchitecture ? true : false
     print_ft   = typeof(ft) == DataType && ft <: AbstractFloat ? true : false
 
     bn = ""

--- a/examples/internal_wave.jl
+++ b/examples/internal_wave.jl
@@ -102,8 +102,8 @@ T₀(x, y, z) = T(x, y, z, 0)
 
 # Create a model where temperature = buoyancy.
 model = BasicModel(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
-                    eos=LinearEquationOfState(βT=1.),
-                    constants=PlanetaryConstants(f=f, g=1.))
+                    eos=LinearEquationOfState(βT=1.0),
+                    constants=PlanetaryConstants(f=f, g=1.0))
 
 set_ic!(model, u=u₀, v=v₀, w=w₀, T=T₀)
 println(informative_message(model, u, w, ℕ))

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -85,9 +85,10 @@ using CUDAapi: has_cuda
 using GPUifyLoops: @launch, @loop, @unroll
 
 import Base:
-    size, length,
+    +, -, *,
+    size, length, eltype,
+    iterate, similar, show,
     getindex, lastindex, setindex!,
-    iterate, similar, *, +, -
 
 macro hascuda(ex)
     return has_cuda() ? :($(esc(ex))) : :(nothing)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -88,7 +88,7 @@ import Base:
     +, -, *,
     size, length, eltype,
     iterate, similar, show,
-    getindex, lastindex, setindex!,
+    getindex, lastindex, setindex!
 
 macro hascuda(ex)
     return has_cuda() ? :($(esc(ex))) : :(nothing)

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -110,7 +110,6 @@ struct GPU <: Architecture end
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()
 
-abstract type ConstantsCollection end
 abstract type EquationOfState end
 abstract type Grid{T} end
 abstract type AbstractModel end
@@ -141,6 +140,5 @@ include("time_steppers.jl")
 
 include("output_writers.jl")
 include("diagnostics.jl")
-
 
 end # module

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -103,21 +103,21 @@ end
     end
 end
 
-abstract type Architecture end
-struct CPU <: Architecture end
-struct GPU <: Architecture end
+abstract type AbstractArchitecture end
+struct CPU <: AbstractArchitecture end
+struct GPU <: AbstractArchitecture end
 
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()
 
-abstract type EquationOfState end
-abstract type Grid{T} end
+abstract type AbstractEquationOfState end
+abstract type AbstractGrid{T} end
 abstract type AbstractModel end
-abstract type Field{A, G} end
-abstract type FaceField{A, G} <: Field{A, G} end
-abstract type OutputWriter end
-abstract type Diagnostic end
-abstract type PoissonSolver end
+abstract type AbstractField{A, G} end
+abstract type AbstractFaceField{A, G} <: AbstractField{A, G} end
+abstract type AbstractOutputWriter end
+abstract type AbstractDiagnostic end
+abstract type AbstractPoissonSolver end
 
 function buoyancy_perturbation end
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -34,7 +34,7 @@ export
     Periodic, Flux, Gradient, Value, Dirchlet, Neumann,
     CoordinateBoundaryConditions,
     FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
-    BoundaryConditions, ModelBoundaryConditions, HorizontallyPeriodicModelBCs, ChannelModelBCs,
+    BoundaryConditions, SolutionBoundaryConditions, HorizontallyPeriodicSolutionBCs, ChannelSolutionBCs,
     getbc, setbc!,
 
     # Time stepping

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -27,13 +27,13 @@ struct BoundaryCondition{C<:BCType, T}
     condition :: T
 end
 
-# Some abbreviations to make our life easier.
-const BC = BoundaryCondition
-const FBC = BoundaryCondition{<:Flux}
-const PBC = BoundaryCondition{<:Periodic}
+# Some abbreviations to make life easier.
+const BC   = BoundaryCondition
+const FBC  = BoundaryCondition{<:Flux}
+const PBC  = BoundaryCondition{<:Periodic}
 const NPBC = BoundaryCondition{<:NoPenetration}
-const VBC = BoundaryCondition{<:Value}
-const GBC = BoundaryCondition{<:Gradient}
+const VBC  = BoundaryCondition{<:Value}
+const GBC  = BoundaryCondition{<:Gradient}
 const NFBC = BoundaryCondition{Flux, Nothing}
 
 BoundaryCondition(Tbc, c) = BoundaryCondition{Tbc, typeof(c)}(c)
@@ -95,7 +95,6 @@ getbc(cbc::CBC, ::Val{:bottom}) = getfield(cbc, :right)
 getbc(cbc::CBC, ::Val{:top}) = getfield(cbc, :left)
 
 
-
 #####
 ##### Boundary conditions for Fields
 #####
@@ -104,16 +103,17 @@ getbc(cbc::CBC, ::Val{:top}) = getfield(cbc, :left)
     FieldBoundaryConditions(x, y, z)
 
 Construct `FieldBoundaryConditions` for a field.
-A FieldBoundaryCondition has `CoordinateBoundaryConditions` in
+Field boundary conditions have `CoordinateBoundaryCondition`s in
 `x`, `y`, and `z`.
 """
-FieldBoundaryConditions(x, y, z) = (x=x, y=y, z=z)
+const FieldBoundaryConditions = NamedTuple{(:x, :y, :z)}
+
+FieldBoundaryConditions(x, y, z) = FieldBoundaryConditions((x, y, z))
 
 function FieldBoundaryConditions(;
     x = CoordinateBoundaryConditions(),
     y = CoordinateBoundaryConditions(),
-    z = CoordinateBoundaryConditions()
-    )
+    z = CoordinateBoundaryConditions())
     return FieldBoundaryConditions(x, y, z)
 end
 
@@ -160,49 +160,55 @@ function ChannelBCs(;  north = BoundaryCondition(Flux, nothing),
 end
 
 
-
 #####
-##### Boundary conditions for entire models
+##### Boundary conditions for solutions to systems of equations
 #####
 
 """
-    ModelBoundaryConditions(u, v, w, T, S)
+    SolutionBoundaryConditions(u, v, w, T, S)
 
-Construct a NamedTuple of boundary conditions for a model
-with solution fields `u`, `v`, `w`, `T`, and `S`.
+Construct a NamedTuple of boundary conditions for a system of
+equations with solution fields `u`, `v`, `w`, `T`, and `S`.
 """
-ModelBoundaryConditions(u, v, w, T, S) = (u=u, v=v, w=w, T=T, S=S)
+SolutionBoundaryConditions(u, v, w, T, S) = (u=u, v=v, w=w, T=T, S=S)
 
 """
-    HorizontallyPeriodicModelBCs(u=HorizontallyPeriodicBCs, ...)
+    HorizontallyPeriodicSolutionBCs(u=HorizontallyPeriodicBCs, ...)
 
 Construct a NamedTuple of boundary conditions for a horizontally-periodic
-model with solution fields `u`, `v`, `w`, `T`, and `S`. Non-default
+system of equations with solution fields `u`, `v`, `w`, `T`, and `S`. Non-default
 boundary conditions for any field must be horizontally-periodic.
 """
-function HorizontallyPeriodicModelBCs(;
+function HorizontallyPeriodicSolutionBCs(;
     u = HorizontallyPeriodicBCs(),
     v = HorizontallyPeriodicBCs(),
     w = HorizontallyPeriodicBCs(top=NoPenetrationBC(), bottom=NoPenetrationBC()),
     T = HorizontallyPeriodicBCs(),
     S = HorizontallyPeriodicBCs()
    )
-    return ModelBoundaryConditions(u, v, w, T, S)
+    return SolutionBoundaryConditions(u, v, w, T, S)
 end
 
-function ChannelModelBCs(;
+"""
+    ChannelSolutionBCs(u=ChannelBCs, ...)
+
+Construct a NamedTuple of boundary conditions for a system of equations
+with solution fields `u`, `v`, `w`, `T`, and `S` in a re-entrant 
+channel geometry with rigid top, bottom, north, and south boundaries (y, z),
+and periodic boundary conditions in east and west (x).
+"""
+function ChannelSolutionBCs(;
     u = ChannelBCs(),
     v = ChannelBCs(north=NoPenetrationBC(), south=NoPenetrationBC()),
     w = ChannelBCs(top=NoPenetrationBC(), bottom=NoPenetrationBC()),
     T = ChannelBCs(),
     S = ChannelBCs()
    )
-    return ModelBoundaryConditions(u, v, w, T, S)
+    return SolutionBoundaryConditions(u, v, w, T, S)
 end
 
-# Default
-const BoundaryConditions = HorizontallyPeriodicModelBCs
-
+# Default semantics
+const BoundaryConditions = HorizontallyPeriodicSolutionBCs
 
 
 #####
@@ -221,11 +227,11 @@ TendencyBC(::NPBC) = NoPenetrationBC()
 
 TendencyCoordinateBCs(bcs) = CoordinateBoundaryConditions(TendencyBC(bcs.left), TendencyBC(bcs.right))
 
-TendencyFieldBoundaryConditions(fieldbcs) = 
-    NamedTuple{(:x, :y, :z)}(Tuple(TendencyCoordinateBCs(bcs) for bcs in fieldbcs))
+TendencyFieldBoundaryConditions(field_bcs) = 
+    FieldBoundaryConditions(Tuple(TendencyCoordinateBCs(bcs) for bcs in field_bcs))
 
-TendenciesBoundaryConditions(modelbcs) =
-    NamedTuple{propertynames(modelbcs)}(Tuple(TendencyFieldBoundaryConditions(bcs) for bcs in modelbcs))
+TendenciesBoundaryConditions(solution_bcs) =
+    NamedTuple{propertynames(solution_bcs)}(Tuple(TendencyFieldBoundaryConditions(bcs) for bcs in solution_bcs))
 
 # Pressure boundary conditions are either zero flux (Neumann) or Periodic.
 # Note that a zero flux boundary condition is simpler than a zero gradient boundary condition.
@@ -238,6 +244,22 @@ function PressureBoundaryConditions(vbcs)
     z = CoordinateBoundaryConditions(PressureBC(vbcs.z.left), PressureBC(vbcs.z.right))
     return (x=x, y=y, z=z)
 end
+
+#####
+##### Model boundary conditions for pressure, and solution, and tendency solutions
+#####
+
+const ModelBoundaryConditions = NamedTuple{(:solution, :tendency, :pressure)}
+
+function ModelBoundaryConditions(solution_boundary_conditions::NamedTuple)
+    model_boundary_conditions = (solution = solution_boundary_conditions, 
+                                 tendency = TendenciesBoundaryConditions(solution_boundary_conditions),
+                                 pressure = PressureBoundaryConditions(solution_boundary_conditions.v))
+    return model_boundary_conditions
+end
+
+ModelBoundaryConditions(model_boundary_conditions::ModelBoundaryConditions) =
+    model_boundary_conditions
 
 #####
 ##### Algorithm for adding fluxes associated with non-trivial flux boundary conditions.

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -19,7 +19,7 @@ end
 #### Horizontally averaged vertical profiles
 ####
 
-mutable struct HorizontalAverage{F, R, P, I, T} <: Diagnostic
+mutable struct HorizontalAverage{F, R, P, I, T} <: AbstractDiagnostic
         profile :: P
          fields :: F
       frequency :: I
@@ -85,7 +85,7 @@ end
 #### NaN checker
 ####
 
-struct NaNChecker{D} <: Diagnostic
+struct NaNChecker{D} <: AbstractDiagnostic
     frequency :: Int
        fields :: D
 end

--- a/src/equation_of_state.jl
+++ b/src/equation_of_state.jl
@@ -1,34 +1,16 @@
 """
-    LinearEquationOfState(; kwargs...)
+    LinearEquationOfState
 
 Linear equation of state for seawater. Constants taken from Table 1.2 (page 33)
 and functional form taken from Eq. (1.57) of Vallis, "Atmospheric and Oceanic
 Fluid Dynamics: Fundamentals and Large-Scale Circulation" (2ed, 2017).
 """
-struct LinearEquationOfState{T<:AbstractFloat} <: EquationOfState
-    ρ₀::T  # Reference density [kg/m³]
-    βT::T  # First thermal expansion coefficient [1/K]
-    βS::T  # Haline contraction coefficient [1/ppt]
-    βp::T  # Compressibility coefficient [ms²/kg]
-    T₀::T  # Reference temperature [°C]
-    S₀::T  # Reference salinity [g/kg]
-    p₀::T  # Reference pressure [Pa].
-    cᵥ::T  # Isobaric mass heat capacity [J / kg·K].
-    αᵥ::T  # Volumetric coefficient of thermal expansion for water [K⁻¹].
-end
-
-function LinearEquationOfState(T=Float64;
-    ρ₀ = 1.027e3,
-    βT = 1.67e-4,
-    βS = 0.78e-3,
-    βp = 4.39e-10,
-    T₀ = 9.85,
-    S₀ = 35,
-    p₀ = 1e5,
-    cᵥ = 4181.3,
-    αᵥ = 2.07e-4)
-
-    LinearEquationOfState{T}(ρ₀, βT, βS, βp, T₀, S₀, p₀, cᵥ, αᵥ)
+Base.@kwdef struct LinearEquationOfState{T<:AbstractFloat} <: AbstractEquationOfState
+    ρ₀ :: T = 1027.0  # Reference density [kg/m³]
+    T₀ :: T = 9.85    # Reference temperature [°C]
+    S₀ :: T = 35.0    # Reference salinity [g/kg]
+    βT :: T = 1.67e-4 # First thermal expansion coefficient [1/K]
+    βS :: T = 0.78e-3 # Haline contraction coefficient [1/ppt]
 end
 
 @inline δρ(eos::LinearEquationOfState, T, S, i, j, k) =
@@ -38,4 +20,4 @@ end
 @inline buoyancy_perturbation(i, j, k, grid, eos::LinearEquationOfState, grav, T, S) =
     @inbounds eos.βT * (T[i, j, k] - eos.T₀) - eos.βS * (S[i, j, k] - eos.S₀)
 
-NoEquationOfState() = LinearEquationOfState(βT=0, βS=0)
+NoEquationOfState() = LinearEquationOfState(βT=0.0, βS=0.0)

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,39 +1,39 @@
 """
-    CellField{A<:AbstractArray, G<:Grid} <: Field
+    CellField{A<:AbstractArray, G<:AbstractGrid} <: Field
 
 A cell-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct CellField{A<:AbstractArray, G<:Grid} <: Field{A, G}
+struct CellField{A<:AbstractArray, G<:AbstractGrid} <: AbstractField{A, G}
     data::A
     grid::G
 end
 
 """
-    FaceFieldX{A<:AbstractArray, G<:Grid} <: FaceField
+    FaceFieldX{A<:AbstractArray, G<:AbstractGrid} <: FaceField
 
 An x-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldX{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
+struct FaceFieldX{A<:AbstractArray, G<:AbstractGrid} <: AbstractFaceField{A, G}
     data::A
     grid::G
 end
 
 """
-    FaceFieldY{A<:AbstractArray, G<:Grid} <: FaceField
+    FaceFieldY{A<:AbstractArray, G<:AbstractGrid} <: FaceField
 
 A y-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldY{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
+struct FaceFieldY{A<:AbstractArray, G<:AbstractGrid} <: AbstractFaceField{A, G}
     data::A
     grid::G
 end
 
 """
-    FaceFieldZ{A<:AbstractArray, G<:Grid} <: Field
+    FaceFieldZ{A<:AbstractArray, G<:AbstractGrid} <: Field
 
 A z-face-centered field defined on a grid `G` whose values are stored in an `A`.
 """
-struct FaceFieldZ{A<:AbstractArray, G<:Grid} <: FaceField{A, G}
+struct FaceFieldZ{A<:AbstractArray, G<:AbstractGrid} <: AbstractFaceField{A, G}
     data::A
     grid::G
 end
@@ -77,28 +77,28 @@ FaceFieldX(arch, grid) = FaceFieldX(zeros(arch, grid), grid)
 FaceFieldY(arch, grid) = FaceFieldY(zeros(arch, grid), grid)
 FaceFieldZ(arch, grid) = FaceFieldZ(zeros(arch, grid), grid)
 
-fieldtype(f::Field) = typeof(f).name.wrapper
+fieldtype(f::AbstractField) = typeof(f).name.wrapper
 
-@inline size(f::Field) = size(f.grid)
-@inline length(f::Field) = length(f.data)
+@inline size(f::AbstractField) = size(f.grid)
+@inline length(f::AbstractField) = length(f.data)
 
-@inline getindex(f::Field, inds...) = getindex(f.data, inds...)
-@inline lastindex(f::Field) = lastindex(f.data)
-@inline lastindex(f::Field, dim) = lastindex(f.data, dim)
-@inline setindex!(f::Field, v, inds...) = setindex!(f.data, v, inds...)
+@inline getindex(f::AbstractField, inds...) = getindex(f.data, inds...)
+@inline lastindex(f::AbstractField) = lastindex(f.data)
+@inline lastindex(f::AbstractField, dim) = lastindex(f.data, dim)
+@inline setindex!(f::AbstractField, v, inds...) = setindex!(f.data, v, inds...)
 
 "Returns a view over the interior points of the `field.data`."
-@inline data(f::Field) = view(f.data, 1:f.grid.Nx, 1:f.grid.Ny, 1:f.grid.Nz)
+@inline data(f::AbstractField) = view(f.data, 1:f.grid.Nx, 1:f.grid.Ny, 1:f.grid.Nz)
 
 "Returns a reference to the interior points of `field.data.parent.`"
-@inline parentdata(f::Field) = f.data.parent[1+f.grid.Hx:f.grid.Nx+f.grid.Hx,
+@inline parentdata(f::AbstractField) = f.data.parent[1+f.grid.Hx:f.grid.Nx+f.grid.Hx,
                                              1+f.grid.Hy:f.grid.Ny+f.grid.Hy,
                                              1+f.grid.Hz:f.grid.Nz+f.grid.Hz]
 
-@inline underlying_data(f::Field) = f.data.parent
+@inline underlying_data(f::AbstractField) = f.data.parent
 
-show(io::IO, f::Field) = show(io, f.data)
-iterate(f::Field, state=1) = iterate(f.data, state)
+show(io::IO, f::AbstractField) = show(io, f.data)
+iterate(f::AbstractField, state=1) = iterate(f.data, state)
 
 # Define +, -, and * on fields as element-wise calculations on their data. This
 # is only true for fields of the same type, e.g. when adding a FaceFieldY to
@@ -128,9 +128,9 @@ for ft in (:CellField, :FaceFieldX, :FaceFieldY, :FaceFieldZ)
     end
 end
 
-xnodes(ϕ::Field) = reshape(ϕ.grid.xC, ϕ.grid.Nx, 1, 1)
-ynodes(ϕ::Field) = reshape(ϕ.grid.yC, 1, ϕ.grid.Ny, 1)
-znodes(ϕ::Field) = reshape(ϕ.grid.zC, 1, 1, ϕ.grid.Nz)
+xnodes(ϕ::AbstractField) = reshape(ϕ.grid.xC, ϕ.grid.Nx, 1, 1)
+ynodes(ϕ::AbstractField) = reshape(ϕ.grid.yC, 1, ϕ.grid.Ny, 1)
+znodes(ϕ::AbstractField) = reshape(ϕ.grid.zC, 1, 1, ϕ.grid.Nz)
 
 xnodes(ϕ::FaceFieldX) = reshape(ϕ.grid.xF[1:end-1], ϕ.grid.Nx, 1, 1)
 ynodes(ϕ::FaceFieldY) = reshape(ϕ.grid.yF[1:end-1], 1, ϕ.grid.Ny, 1)
@@ -140,11 +140,11 @@ nodes(ϕ) = (xnodes(ϕ), ynodes(ϕ), znodes(ϕ))
 
 zerofunk(args...) = 0
 
-set!(u::Field, v::Number) = @. u.data = v
-set!(u::Field{A}, v::Field{A}) where A = @. u.data.parent = v.data.parent
+set!(u::AbstractField, v::Number) = @. u.data = v
+set!(u::AbstractField{A}, v::AbstractField{A}) where A = @. u.data.parent = v.data.parent
 
 "Set the CPU field `u` to the array `v`."
-function set!(u::Field{A}, v::Array) where {
+function set!(u::AbstractField{A}, v::Array) where {
     A <: OffsetArray{T, D, <:Array} where {T, D}}
     for k in 1:u.grid.Nz, j in 1:u.grid.Ny, i in 1:u.grid.Nx
         u[i, j, k] = v[i, j, k]
@@ -153,7 +153,7 @@ function set!(u::Field{A}, v::Array) where {
 end
 
 "Set the GPU field `u` to the array `v`."
-@hascuda function set!(u::Field{A}, v::Array) where {
+@hascuda function set!(u::AbstractField{A}, v::Array) where {
     A <: OffsetArray{T, D, <:CuArray} where {T, D}}
 
     FieldType = fieldtype(u)
@@ -164,7 +164,7 @@ end
 end
 
 "Set the GPU field `u` to the CuArray `v`."
-@hascuda function set!(u::Field{A}, v::CuArray) where {
+@hascuda function set!(u::AbstractField{A}, v::CuArray) where {
     A <: OffsetArray{T, D, <:CuArray} where {T, D}}
     @launch device(GPU()) config=launch_config(u.grid, 3) _set_gpu!(u.data, v, u.grid)
 end
@@ -181,7 +181,7 @@ function _set_gpu!(u, v, grid)
 end
 
 "Set the GPU field `u` data to the CPU field data of `v`."
-@hascuda function set!(u::Field{Au}, v::Field{Av}) where {
+@hascuda function set!(u::AbstractField{Au}, v::AbstractField{Av}) where {
     Au<:OffsetArray{T1, D, <:CuArray}, Av<:OffsetArray{T2, D, <:Array}} where {T1, T2, D}
 
     copyto!(u.data.parent, v.data.parent)
@@ -189,7 +189,7 @@ end
 end
 
 "Set the CPU field `u` data to the GPU field data of `v`."
-@hascuda function set!(u::Field{Au}, v::Field{Av}) where {
+@hascuda function set!(u::AbstractField{Au}, v::AbstractField{Av}) where {
     Au<:OffsetArray{T1, D, <:Array}, Av<:OffsetArray{T2, D, <:CuArray}} where {T1, T2, D}
 
     u.data.parent .= Array(v.data.parent)
@@ -197,10 +197,10 @@ end
 end
 
 "Set the CPU field `u` data to the function `f(x, y, z)`."
-set!(u::Field, f::Function) = data(u) .= f.(nodes(u)...)
+set!(u::AbstractField, f::Function) = data(u) .= f.(nodes(u)...)
 
 "Set the GPU field `u` data to the function `f(x, y, z)`."
-@hascuda function set!(u::Field{A1}, f::Function) where {
+@hascuda function set!(u::AbstractField{A1}, f::Function) where {
     A1 <: OffsetArray{T, D, <:CuArray} where {T, D}}
 
     FieldType = fieldtype(u)
@@ -218,7 +218,7 @@ Set velocity and tracer fields of `model`. The keyword arguments
 `kwargs...` take the form `name=data`, where `name` refers to one of the
 fields of `model.velocities` or `model.tracers`, and the `data` may be an array,
 a function with arguments `(x, y, z)`, or any data type for which a
-`set!(ϕ::Field, data)` function exists.
+`set!(ϕ::AbstractField, data)` function exists.
 
 Example
 =======

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -7,7 +7,6 @@ and \$Δz\$ are constants. Fields are stored using floating-point values of type
 of type `A`.
 """
 struct RegularCartesianGrid{T<:AbstractFloat, R<:AbstractRange} <: AbstractGrid{T}
-    dim::Int
     # Number of grid points in (x,y,z).
     Nx::Int
     Ny::Int
@@ -58,31 +57,17 @@ julia> g = RegularCartesianGrid((16, 16, 8), (2π, 2π, 2π))
 ```
 """
 function RegularCartesianGrid(T, N, L)
-    !(length(N) == 3) && throw(ArgumentError("N=$N must be a tuple of length 3."))
-    !(length(L) == 3) && throw(ArgumentError("L=$L must be a tuple of length 3."))
+    length(N) == 3 || throw(ArgumentError("N=$N must be a tuple of length 3."))
+    length(L) == 3 || throw(ArgumentError("L=$L must be a tuple of length 3."))
 
-    !all(isa.(N, Integer)) && throw(ArgumentError("N=$N should contain integers."))
-    !all(isa.(L, Number))  && throw(ArgumentError("L=$L should contain numbers."))
+    all(isa.(N, Integer)) || throw(ArgumentError("N=$N should contain integers."))
+    all(isa.(L, Number))  || throw(ArgumentError("L=$L should contain numbers."))
 
-    !all(N .>= 1) && throw(ArgumentError("N=$N must be nonzero and positive!"))
-    !all(L .> 0)  && throw(ArgumentError("L=$L must be nonzero and positive!"))
-
-    !(T in [Float32, Float64]) && throw(ArgumentError("T=$T but only Float32 and Float64 grids are supported."))
-
-    # Count the number of dimensions with 1 grid point, i.e. the number of flat
-    # dimensions, and use it to determine the dimension of the model.
-    num_flat_dims = count(i->(i==1), N)
-    dim = 3 - num_flat_dims
-    !(1 <= dim <= 3) && throw(ArgumentError("N=$N has dimension $dim. Only 1D, 2D, and 3D grids are supported."))
+    all(N .>= 1) || throw(ArgumentError("N=$N must be nonzero and positive!"))
+    all(L .> 0)  || throw(ArgumentError("L=$L must be nonzero and positive!"))
 
     Nx, Ny, Nz = N
     Lx, Ly, Lz = L
-
-    dim == 2 && !(Nx == 1 || Ny == 1 || Nz == 1) &&
-        throw(ArgumentError("For 2D grids, Nx, Ny, or Nz must be 1."))
-
-    dim == 3 && !(Nx != 1 && Ny != 1 && Nz != 1) &&
-        throw(ArgumentError("For 3D grids, cannot have dimensions of size 1."))
 
     # Right now we only support periodic horizontal boundary conditions and
     # usually use second-order advection schemes so halos of size Hx, Hy = 1 are
@@ -93,19 +78,15 @@ function RegularCartesianGrid(T, N, L)
     Ty = Ny + 2*Hy
     Tz = Nz + 2*Hz
 
-    Lx = convert(T, Lx)
-    Ly = convert(T, Ly)
-    Lz = convert(T, Lz)
+    Δx = Lx / Nx
+    Δy = Ly / Ny
+    Δz = Lz / Nz
 
-    Δx = convert(T, Lx / Nx)
-    Δy = convert(T, Ly / Ny)
-    Δz = convert(T, Lz / Nz)
+    Ax = Δy*Δz
+    Ay = Δx*Δz
+    Az = Δx*Δy
 
-    Ax = convert(T, Δy*Δz)
-    Ay = convert(T, Δx*Δz)
-    Az = convert(T, Δx*Δy)
-
-    V = convert(T, Δx*Δy*Δz)
+    V = Δx*Δy*Δz
 
     xC = Δx/2:Δx:Lx
     yC = Δy/2:Δy:Ly
@@ -115,11 +96,7 @@ function RegularCartesianGrid(T, N, L)
     yF = 0:Δy:Ly
     zF = 0:-Δz:-Lz
 
-    # Make sure all the coordinate ranges have the same type.
-    !all(typeof.([xC, yC, zC, xF, yF, zF]) .== typeof(xC)) &&
-        throw(ArgumentError("At least one coordinate range type did not match."))
-
-    RegularCartesianGrid{T, typeof(xC)}(dim, Nx, Ny, Nz, Hx, Hy, Hz, Tx, Ty, Tz,
+    RegularCartesianGrid{T, typeof(xC)}(Nx, Ny, Nz, Hx, Hy, Hz, Tx, Ty, Tz,
                                         Lx, Ly, Lz, Δx, Δy, Δz, Ax, Ay, Az, V,
                                         xC, yC, zC, xF, yF, zF)
 end
@@ -129,7 +106,7 @@ RegularCartesianGrid(N, L) = RegularCartesianGrid(Float64, N, L)
 RegularCartesianGrid(T=Float64; N, L) = RegularCartesianGrid(T, N, L)
 
 size(g::RegularCartesianGrid) = (g.Nx, g.Ny, g.Nz)
-Base.eltype(g::RegularCartesianGrid{T}) where T = T
+eltype(g::RegularCartesianGrid{T}) where T = T
 
 show(io::IO, g::RegularCartesianGrid) =
     print(io, "$(g.dim)-dimensional ($(typeof(g.Lx))) regular Cartesian grid\n",

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,5 +1,3 @@
-import Base: size, show
-
 """
     RegularCartesianGrid{T<:AbstractFloat, R<:AbstractRange} <: Grid
 

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -8,7 +8,7 @@ and \$Δz\$ are constants. Fields are stored using floating-point values of type
 `T`. The cell-centered and face-centered coordinate ranges are stored as ranges
 of type `A`.
 """
-struct RegularCartesianGrid{T<:AbstractFloat, R<:AbstractRange} <: Grid{T}
+struct RegularCartesianGrid{T<:AbstractFloat, R<:AbstractRange} <: AbstractGrid{T}
     dim::Int
     # Number of grid points in (x,y,z).
     Nx::Int

--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -2,9 +2,9 @@
 ##### Halo filling for flux, periodic, and no-penetration boundary conditions.
 #####
 
-# For flux boundary conditions we fill halos as for a *no-flux* boundary condition, and add the 
-# flux divergence associated with the flux boundary condition in a separate step. Note that 
-# ranges are used to reference the data copied into halos, as this produces views of the correct 
+# For flux boundary conditions we fill halos as for a *no-flux* boundary condition, and add the
+# flux divergence associated with the flux boundary condition in a separate step. Note that
+# ranges are used to reference the data copied into halos, as this produces views of the correct
 # dimension (eg size = (1, Ny, Nz) for the west halos).
 
  _fill_west_halo!(c, ::FBC, H, N) = @views @. c.parent[1:H, :, :] = c.parent[1+H:1+H,  :, :]
@@ -24,7 +24,7 @@ _fill_south_halo!(c, ::PBC, H, N) = @views @. c.parent[:, 1:H, :] = c.parent[:, 
  _fill_north_halo!(c, ::PBC, H, N) = @views @. c.parent[:, N+H+1:N+2H, :] = c.parent[:, 1+H:2H, :]
 _fill_bottom_halo!(c, ::PBC, H, N) = @views @. c.parent[:, :, N+H+1:N+2H] = c.parent[:, :, 1+H:2H]
 
-# Recall that, by convention, the first grid point in an array with no penetration boundary 
+# Recall that, by convention, the first grid point in an array with no penetration boundary
 # condition lies on the boundary, where as the final grid point lies in the domain.
 
  _fill_west_halo!(c, ::NPBC, H, N) = @views @. c.parent[1:H+1, :, :] = 0
@@ -45,7 +45,7 @@ for (x, side) in zip(coords, sides)
     H = Symbol(:H, x)
     N = Symbol(:N, x)
     @eval begin
-        $outername(c, bc::Union{FBC, PBC, NPBC}, arch::Architecture, grid::Grid, args...) = 
+        $outername(c, bc::Union{FBC, PBC, NPBC}, arch::AbstractArchitecture, grid::AbstractGrid, args...) =
             $innername(c, bc, grid.$(H), grid.$(N))
     end
 end
@@ -72,7 +72,7 @@ function _fill_top_halo!(c, bc::Union{VBC, GBC}, grid, args...)
             end
         end
     end
-    return 
+    return
 end
 
 function _fill_bottom_halo!(c, bc::Union{VBC, GBC}, grid, args...)
@@ -85,7 +85,7 @@ function _fill_bottom_halo!(c, bc::Union{VBC, GBC}, grid, args...)
             end
         end
     end
-    return 
+    return
 end
 
 function fill_top_halo!(c, bc::Union{VBC, GBC}, arch, grid, args...)
@@ -93,7 +93,7 @@ function fill_top_halo!(c, bc::Union{VBC, GBC}, arch, grid, args...)
     return
 end
 
-function fill_bottom_halo!(c, bc::Union{VBC, GBC}, arch::Architecture, grid::Grid, args...)
+function fill_bottom_halo!(c, bc::Union{VBC, GBC}, arch::AbstractArchitecture, grid::AbstractGrid, args...)
     @launch device(arch) config=launch_config(grid, 2) _fill_bottom_halo!(c, bc, grid, args...)
     return
 end

--- a/src/halo_regions.jl
+++ b/src/halo_regions.jl
@@ -136,7 +136,7 @@ end
 Fill halo regions for each field in the tuple `fields` according
 to the single instances of `FieldBoundaryConditions` in `bcs`.
 """
-function fill_halo_regions!(fields::NamedTuple, bcs::NamedTuple{(:x, :y, :z)}, arch, grid, args...)
+function fill_halo_regions!(fields::NamedTuple, bcs::FieldBoundaryConditions, arch, grid, args...)
     for field in fields
         fill_halo_regions!(field, bcs, arch, grid, args...)
     end

--- a/src/models.jl
+++ b/src/models.jl
@@ -53,8 +53,7 @@ function Model(;
                 tracers = TracerFields(architecture, grid),
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, closure),
-            timestepper = AdamsBashforthTimestepper(float_type, architecture, grid, 0.125,
-                                                    boundary_conditions),
+            timestepper = AdamsBashforthTimestepper(float_type, architecture, grid, 0.125, boundary_conditions),
     # Solver for Poisson's equation
          poisson_solver = PoissonSolver(architecture, PoissonBCs(boundary_conditions), grid)
     )

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -211,42 +211,6 @@ function start_next_file(model::Model, fw::JLD2OutputWriter)
 end
 
 ####
-#### Binary output writer
-####
-
-"A type for writing Binary output."
-Base.@kwdef mutable struct BinaryOutputWriter <: AbstractOutputWriter
-          dir :: AbstractString = "."
-       prefix :: AbstractString = ""
-    frequency :: Int = 1
-      padding :: Int = 9
-end
-
-function write_output(model::Model, fw::BinaryOutputWriter)
-    for (field, field_name) in zip(fw.fields, fw.field_names)
-        filepath = joinpath(fw.dir, filename(fw, field_name, model.clock.iteration))
-
-        println("[BinaryOutputWriter] Writing $field_name to disk: $filepath")
-        if model.metadata == :CPU
-            write(filepath, field.data)
-        elseif model.metadata == :GPU
-            write(filepath, Array(field.data))
-        end
-    end
-end
-
-function read_output(model::Model, fw::BinaryOutputWriter, field_name, time)
-    filepath = joinpath(fw.dir, filename(fw, field_name, time_step))
-    arr = zeros(model.metadata.float_type, model.grid.Nx, model.grid.Ny, model.grid.Nz)
-
-    open(filepath, "r") do fio
-        read!(fio, arr)
-    end
-
-    return arr
-end
-
-####
 #### NetCDF output writer
 ####
 

--- a/src/planetary_constants.jl
+++ b/src/planetary_constants.jl
@@ -1,5 +1,5 @@
 
-struct PlanetaryConstants{T<:AbstractFloat} <: ConstantsCollection
+struct PlanetaryConstants{T<:AbstractFloat}
     Ω::T  # Rotation rate of the planet [rad/s].
     f::T  # Nominal value for the Coriolis frequency [rad/s].
     g::T  # Standard acceleration due to gravity [m/s²].

--- a/src/planetary_constants.jl
+++ b/src/planetary_constants.jl
@@ -1,46 +1,10 @@
-
 struct PlanetaryConstants{T<:AbstractFloat}
     Ω::T  # Rotation rate of the planet [rad/s].
     f::T  # Nominal value for the Coriolis frequency [rad/s].
     g::T  # Standard acceleration due to gravity [m/s²].
 end
 
-PlanetaryConstants(T=Float64; Ω=1.0, f=0.0, g=1.0) = PlanetaryConstants{T}(Ω, f, g)
-
 function choose_f(Ω, f, lat)
-end
-
-function Earth(T=Float64; f=nothing, lat=nothing)
-    Ω = 7.2921150e-5
-    g = 9.80665
-
-    if isnothing(f) && isnothing(lat)
-        f′ = 1e-4  # Corresponds to a latitude of 43.29°N.
-    elseif isnothing(lat)
-        f′ = f
-    elseif isnothing(f)
-        f′ = 2*Ω*sind(lat)
-    else
-        throw(ArgumentError("Cannot specify both f and lat!"))
-    end
-
-    abs(f′) <= 2Ω || throw(ArgumentError("Coriolis parameter |f| cannot be larger than 2Ω!"))
-
-    PlanetaryConstants{T}(Ω, f′, g)
-end
-
-function EarthStationary(T=Float64)
-    Ω = 0
-    f = 0
-    g = 9.80665
-    PlanetaryConstants{T}(Ω, f, g)
-end
-
-function Europa(T=Float64; f=nothing, lat=nothing)
-    # Values taken from Soderlund (Table 1, 2019) [arXiv:1901.04093].
-    Ω = 2.1e-5
-    g = 1.3
-
     if isnothing(f) && isnothing(lat)
         throw(ArgumentError("Must specify Coriolis parameter f or latitude!"))
     elseif isnothing(lat)
@@ -53,25 +17,18 @@ function Europa(T=Float64; f=nothing, lat=nothing)
 
     abs(f′) <= 2Ω || throw(ArgumentError("Coriolis parameter |f| cannot be larger than 2Ω!"))
 
-    PlanetaryConstants{T}(Ω, f′, g)
+    return f′
 end
 
-function Enceladus(T=Float64; f=nothing, lat=nothing)
-    # Values taken from Soderlund (Table 1, 2019) [arXiv:1901.04093].
-    Ω = 5.3e-5
-    g = 0.1
+PlanetaryConstants(T=Float64; Ω, g, f=nothing, latitude=nothing) =
+    PlanetaryConstants{T}(Ω, choose_f(Ω, f, latitude), g)
 
-    if isnothing(f) && isnothing(lat)
-        throw(ArgumentError("Must specify Coriolis parameter f or latitude!"))
-    elseif isnothing(lat)
-        f′ = f
-    elseif isnothing(f)
-        f′ = 2*Ω*sind(lat)
-    else
-        throw(ArgumentError("Cannot specify both f and lat!"))
-    end
+PlanetaryConstants(T=Float64; f, g) = PlanetaryConstants{T}(0, f, g)
 
-    abs(f′) <= 2Ω || throw(ArgumentError("Coriolis parameter |f| cannot be larger than 2Ω!"))
+const Ω_Earth = 7.2921150e-5
+const g_Earth = 9.80665
 
-    PlanetaryConstants{T}(Ω, f′, g)
+function Earth(T=Float64; f=nothing, latitude=nothing)
+    isnothing(f) && isnothing(latitude) && (f = 1e-4)
+    return PlanetaryConstants{T}(Ω_Earth, choose_f(Ω_Earth, f, latitude), g_Earth)
 end

--- a/src/poisson_solvers.jl
+++ b/src/poisson_solvers.jl
@@ -32,10 +32,10 @@ function PoissonBCs(bcs)
     return eval(Expr(:call, Symbol(x, y, z)))
 end
 
-PoissonSolver(::CPU, pbcs::PoissonBCs, grid::Grid) = PoissonSolverCPU(pbcs, grid)
-PoissonSolver(::GPU, pbcs::PoissonBCs, grid::Grid) = PoissonSolverGPU(pbcs, grid)
+PoissonSolver(::CPU, pbcs::PoissonBCs, grid::AbstractGrid) = PoissonSolverCPU(pbcs, grid)
+PoissonSolver(::GPU, pbcs::PoissonBCs, grid::AbstractGrid) = PoissonSolverGPU(pbcs, grid)
 
-unpack_grid(grid::Grid) = grid.Nx, grid.Ny, grid.Nz, grid.Lx, grid.Ly, grid.Lz
+unpack_grid(grid::AbstractGrid) = grid.Nx, grid.Ny, grid.Nz, grid.Lx, grid.Ly, grid.Lz
 
 """
     ω(M, k)
@@ -45,48 +45,48 @@ Return the `M`th root of unity raised to the `k`th power.
 @inline ω(M, k) = exp(-2im*π*k/M)
 
 """
-    λi(grid::Grid, ::PoissonBCs)
+    λi(grid::AbstractGrid, ::PoissonBCs)
 
 Return an Nx×1×1 array of eigenvalues satisfying the discrete form of Poisson's
 equation with periodic boundary conditions in the x-dimension on `grid`.
 """
-function λi(grid::Grid, ::PoissonBCs)
+function λi(grid::AbstractGrid, ::PoissonBCs)
     Nx, Ny, Nz, Lx, Ly, Lz = unpack_grid(grid)
     is = reshape(1:Nx, Nx, 1, 1)
     @. (2sin((is-1)*π/Nx) / (Lx/Nx))^2
 end
 
 """
-    λj(grid::Grid, ::PPN)
+    λj(grid::AbstractGrid, ::PPN)
 
 Return an 1×Ny×1 array of eigenvalues satisfying the discrete form of Poisson's
 equation with periodic boundary conditions in the y-dimension on `grid`.
 """
-function λj(grid::Grid, ::PPN)
+function λj(grid::AbstractGrid, ::PPN)
     Nx, Ny, Nz, Lx, Ly, Lz = unpack_grid(grid)
     js = reshape(1:Ny, 1, Ny, 1)
     @. (2sin((js-1)*π/Ny) / (Ly/Ny))^2
 end
 
 """
-    λj(grid::Grid, ::PNN)
+    λj(grid::AbstractGrid, ::PNN)
 
 Return an 1×Ny×1 array of eigenvalues satisfying the discrete form of Poisson's
 equation with staggered Neumann boundary conditions in the y-dimension on `grid`.
 """
-function λj(grid::Grid, ::PNN)
+function λj(grid::AbstractGrid, ::PNN)
     Nx, Ny, Nz, Lx, Ly, Lz = unpack_grid(grid)
     js = reshape(1:Ny, 1, Ny, 1)
     @. (2sin((js-1)*π/(2Ny)) / (Ly/Ny))^2
 end
 
 """
-    λk(grid::Grid, ::PoissonBCs)
+    λk(grid::AbstractGrid, ::PoissonBCs)
 
 Return an 1×1×Nz array of eigenvalues satisfying the discrete form of Poisson's
 equation with staggered Neumann boundary conditions in the y-dimension on `grid`.
 """
-function λk(grid::Grid, ::PoissonBCs)
+function λk(grid::AbstractGrid, ::PoissonBCs)
     Nx, Ny, Nz, Lx, Ly, Lz = unpack_grid(grid)
     ks = reshape(1:Nz, 1, 1, Nz)
     @. (2sin((ks-1)*π/(2Nz)) / (Lz/Nz))^2
@@ -132,7 +132,7 @@ function plan_transforms(::PNN, A::Array, planner_flag=FFTW.PATIENT)
     return FFT!, IFFT!, DCT!, IDCT!
 end
 
-struct PoissonSolverCPU{BC, AAR, AAC, FFTT, DCTT, IFFTT, IDCTT} <: PoissonSolver
+struct PoissonSolverCPU{BC, AAR, AAC, FFTT, DCTT, IFFTT, IDCTT} <: AbstractPoissonSolver
         bcs :: BC
         kx² :: AAR
         ky² :: AAR
@@ -144,7 +144,7 @@ struct PoissonSolverCPU{BC, AAR, AAC, FFTT, DCTT, IFFTT, IDCTT} <: PoissonSolver
       IDCT! :: IDCTT
 end
 
-function PoissonSolverCPU(pbcs::PoissonBCs, grid::Grid, planner_flag=FFTW.PATIENT)
+function PoissonSolverCPU(pbcs::PoissonBCs, grid::AbstractGrid, planner_flag=FFTW.PATIENT)
     Nx, Ny, Nz, _ = unpack_grid(grid)
 
     # The eigenvalues of the discrete form of Poisson's equation correspond
@@ -164,8 +164,8 @@ function PoissonSolverCPU(pbcs::PoissonBCs, grid::Grid, planner_flag=FFTW.PATIEN
     PoissonSolverCPU(pbcs, kx², ky², kz², storage, FFT!, DCT!, IFFT!, IDCT!)
 end
 
-normalize_idct_output(::PPN, grid::Grid, ϕ::Array) = (@. ϕ = ϕ / (2grid.Nz))
-normalize_idct_output(::PNN, grid::Grid, ϕ::Array) = (@. ϕ = ϕ / (4grid.Ny*grid.Nz))
+normalize_idct_output(::PPN, grid::AbstractGrid, ϕ::Array) = (@. ϕ = ϕ / (2grid.Nz))
+normalize_idct_output(::PNN, grid::AbstractGrid, ϕ::Array) = (@. ϕ = ϕ / (4grid.Ny*grid.Nz))
 
 """
     solve_poisson_3d!(solver::PoissonSolverCPU, grid::RegularCartesianGrid)
@@ -222,7 +222,7 @@ function plan_transforms(::PNN, A)
     return FFT!, FFT_DCT!, IFFT!, IFFT_DCT!
 end
 
-struct PoissonSolverGPU{BC, AAR, AAC, AAI, FFT, FFTD, IFFT, IFFTD} <: PoissonSolver
+struct PoissonSolverGPU{BC, AAR, AAC, AAI, FFT, FFTD, IFFT, IFFTD} <: AbstractPoissonSolver
           bcs :: BC
           kx² :: AAR
           ky² :: AAR
@@ -245,7 +245,7 @@ struct PoissonSolverGPU{BC, AAR, AAC, AAI, FFT, FFTD, IFFT, IFFTD} <: PoissonSol
     IFFT_DCT! :: IFFTD
 end
 
-function PoissonSolverGPU(pbcs::PoissonBCs, grid::Grid)
+function PoissonSolverGPU(pbcs::PoissonBCs, grid::AbstractGrid)
     Nx, Ny, Nz, _ = unpack_grid(grid)
 
     # The eigenvalues of the discrete form of Poisson's equation correspond

--- a/src/poisson_solvers.jl
+++ b/src/poisson_solvers.jl
@@ -32,6 +32,8 @@ function PoissonBCs(bcs)
     return eval(Expr(:call, Symbol(x, y, z)))
 end
 
+PoissonBCs(model_bcs::ModelBoundaryConditions) = PoissonBCs(model_bcs.solution)
+
 PoissonSolver(::CPU, pbcs::PoissonBCs, grid::AbstractGrid) = PoissonSolverCPU(pbcs, grid)
 PoissonSolver(::GPU, pbcs::PoissonBCs, grid::AbstractGrid) = PoissonSolverGPU(pbcs, grid)
 

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -20,14 +20,12 @@ function time_step!(model, Nt, Δt; init_with_euler=true)
     RHS = model.poisson_solver.storage
     U, Φ, Gⁿ, G⁻, K, p = datatuples(model.velocities, model.tracers, model.timestepper.Gⁿ,
                                     model.timestepper.G⁻, model.diffusivities, model.pressures)
-    pressure_bcs = PressureBoundaryConditions(model.boundary_conditions.v)
 
     for n in 1:Nt
         χ = ifelse(init_with_euler && n==1, FT(-0.5), model.timestepper.χ)
 
         adams_bashforth_time_step!(model, model.architecture, model.grid, model.constants, model.eos, model.closure,
-                                   model.forcing, model.boundary_conditions, pressure_bcs, U, Φ, p, K, RHS, Gⁿ, 
-                                   G⁻, Δt, χ)
+                                   model.forcing, model.boundary_conditions, U, Φ, p, K, RHS, Gⁿ,  G⁻, Δt, χ)
 
         [ time_to_run(model.clock, diag) && run_diagnostic(model, diag) for diag in model.diagnostics ]
         [ time_to_run(model.clock, out) && write_output(model, out) for out in model.output_writers ]
@@ -41,7 +39,7 @@ end
 
 Step forward one time step with a 2nd-order Adams-Bashforth method and pressure-correction substep.
 """
-function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, forcing, bcs, pressure_bcs,
+function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, forcing, bcs,
                                     U, Φ, p, K, RHS, Gⁿ, G⁻, Δt, χ)
 
     # Arguments for user-defined boundary condition functions:
@@ -49,34 +47,34 @@ function adams_bashforth_time_step!(model, arch, grid, constants, eos, closure, 
 
     # Pre-computations:
     @launch device(arch) config=launch_config(grid, 3) store_previous_source_terms!(grid, Gⁿ, G⁻)
-    fill_halo_regions!(merge(U, Φ), bcs, arch, grid, boundary_condition_args...)
+    fill_halo_regions!(merge(U, Φ), bcs.solution, arch, grid, boundary_condition_args...)
 
     @launch device(arch) config=launch_config(grid, 3) calc_diffusivities!(K, grid, closure, eos, constants.g, U, Φ)
-    fill_halo_regions!(K, pressure_bcs, arch, grid) # diffusivities share bcs with pressure.
+    fill_halo_regions!(K, bcs.pressure, arch, grid) # diffusivities share bcs with pressure.
     @launch device(arch) config=launch_config(grid, 2) update_hydrostatic_pressure!(p.pHY′, grid, constants, eos, Φ)
-    fill_halo_regions!(p.pHY′, pressure_bcs, arch, grid)
+    fill_halo_regions!(p.pHY′, bcs.pressure, arch, grid)
 
     # Calculate tendency terms (minus non-hydrostatic pressure, which is updated in a pressure correction step):
     calculate_interior_source_terms!(Gⁿ, arch, grid, constants, eos, closure, U, Φ, p.pHY′, K, forcing, 
                                      model.parameters, model.clock.time)
-    calculate_boundary_source_terms!(Gⁿ, arch, grid, bcs, boundary_condition_args...)
+    calculate_boundary_source_terms!(Gⁿ, arch, grid, bcs.solution, boundary_condition_args...)
 
     # Complete explicit substep:
     @launch device(arch) config=launch_config(grid, 3) adams_bashforth_update_source_terms!(grid, Gⁿ, G⁻, χ)
 
     # Start pressure correction substep with a pressure solve:
-    fill_halo_regions!(Gⁿ[1:3], bcs[1:3], arch, grid)
+    fill_halo_regions!(Gⁿ[1:3], bcs.tendency[1:3], arch, grid)
     @launch device(arch) config=launch_config(grid, 3) calculate_poisson_right_hand_side!(arch, grid, 
                                                                                           model.poisson_solver.bcs,
                                                                                           Δt, U, Gⁿ, RHS)
     solve_for_pressure!(arch, model)
-    fill_halo_regions!(p.pNHS, pressure_bcs, arch, grid)
+    fill_halo_regions!(p.pNHS, bcs.pressure, arch, grid)
 
     # Complete pressure correction step:
     @launch device(arch) config=launch_config(grid, 3) update_velocities_and_tracers!(grid, U, Φ, p.pNHS, Gⁿ, Δt)
 
     # Recompute vertical velocity w from continuity equation to ensure incompressibility
-    fill_halo_regions!(U, bcs[1:3], arch, grid, boundary_condition_args...)
+    fill_halo_regions!(U, bcs.solution[1:3], arch, grid, boundary_condition_args...)
     @launch device(arch) config=launch_config(grid, 2) compute_w_from_continuity!(grid, U)
 
     model.clock.time += Δt

--- a/src/time_steppers.jl
+++ b/src/time_steppers.jl
@@ -103,7 +103,7 @@ function solve_for_pressure!(::GPU, model::Model)
 end
 
 """Store previous source terms before updating them."""
-function store_previous_source_terms!(grid::Grid, Gⁿ, G⁻)
+function store_previous_source_terms!(grid::AbstractGrid, Gⁿ, G⁻)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -216,7 +216,7 @@ function calculate_interior_source_terms!(G, arch, grid, constants, eos, closure
                                                                             K, F, parameters, time)
 end
 
-function adams_bashforth_update_source_terms!(grid::Grid{FT}, Gⁿ, G⁻, χ) where FT
+function adams_bashforth_update_source_terms!(grid::AbstractGrid{FT}, Gⁿ, G⁻, χ) where FT
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -231,7 +231,7 @@ function adams_bashforth_update_source_terms!(grid::Grid{FT}, Gⁿ, G⁻, χ) wh
 end
 
 "Store previous value of the source term and calculate current source term."
-function calculate_poisson_right_hand_side!(::CPU, grid::Grid, ::PoissonBCs, Δt, U, G, RHS)
+function calculate_poisson_right_hand_side!(::CPU, grid::AbstractGrid, ::PoissonBCs, Δt, U, G, RHS)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -244,12 +244,12 @@ function calculate_poisson_right_hand_side!(::CPU, grid::Grid, ::PoissonBCs, Δt
 end
 
 """
-    calculate_poisson_right_hand_side!(::GPU, grid::Grid, ::PPN, Δt, u, v, w, Gu, Gv, Gw, RHS)
+    calculate_poisson_right_hand_side!(::GPU, grid::AbstractGrid, ::PPN, Δt, u, v, w, Gu, Gv, Gw, RHS)
 
 Calculate divergence of the RHS source terms (Gu, Gv, Gw) and applying a permutation
 which is the first step in the DCT.
 """
-function calculate_poisson_right_hand_side!(::GPU, grid::Grid, ::PPN, Δt, U, G, RHS)
+function calculate_poisson_right_hand_side!(::GPU, grid::AbstractGrid, ::PPN, Δt, U, G, RHS)
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     @loop for k in (1:Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
@@ -266,7 +266,7 @@ function calculate_poisson_right_hand_side!(::GPU, grid::Grid, ::PPN, Δt, U, G,
     end
 end
 
-function calculate_poisson_right_hand_side!(::GPU, grid::Grid, ::PNN, Δt, U, G, RHS)
+function calculate_poisson_right_hand_side!(::GPU, grid::AbstractGrid, ::PNN, Δt, U, G, RHS)
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
@@ -290,7 +290,7 @@ function calculate_poisson_right_hand_side!(::GPU, grid::Grid, ::PNN, Δt, U, G,
     end
 end
 
-function idct_permute!(grid::Grid, ::PPN, ϕ, pNHS)
+function idct_permute!(grid::AbstractGrid, ::PPN, ϕ, pNHS)
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     @loop for k in (1:Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
@@ -305,7 +305,7 @@ function idct_permute!(grid::Grid, ::PPN, ϕ, pNHS)
     end
 end
 
-function idct_permute!(grid::Grid, ::PNN, ϕ, pNHS)
+function idct_permute!(grid::AbstractGrid, ::PNN, ϕ, pNHS)
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
@@ -329,7 +329,7 @@ function idct_permute!(grid::Grid, ::PNN, ϕ, pNHS)
 end
 
 
-function update_velocities_and_tracers!(grid::Grid, U, Φ, pNHS, Gⁿ, Δt)
+function update_velocities_and_tracers!(grid::AbstractGrid, U, Φ, pNHS, Gⁿ, Δt)
     @loop for k in (1:grid.Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
@@ -343,7 +343,7 @@ function update_velocities_and_tracers!(grid::Grid, U, Φ, pNHS, Gⁿ, Δt)
 end
 
 "Compute the vertical velocity w from the continuity equation."
-function compute_w_from_continuity!(grid::Grid, U)
+function compute_w_from_continuity!(grid::AbstractGrid, U)
     @loop for j in (1:grid.Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
         @loop for i in (1:grid.Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
             @inbounds U.w[i, j, 1] = 0

--- a/src/turbulence_closures/TurbulenceClosures.jl
+++ b/src/turbulence_closures/TurbulenceClosures.jl
@@ -29,7 +29,7 @@ using
   Oceananigans.Operators,
   GPUifyLoops
 
-using Oceananigans: Architecture, Grid, buoyancy_perturbation
+using Oceananigans: AbstractArchitecture, AbstractGrid, buoyancy_perturbation
 
 @hascuda using CUDAdrv, CUDAnative
 
@@ -41,7 +41,7 @@ abstract type TensorDiffusivity{T} <: TurbulenceClosure{T} end
 @inline ∇_κ_∇S(args...) = ∇_κ_∇c(args...)
 
 # Approximate viscosities and thermal diffusivities for seawater
-# at 20ᵒC and 35 psu, according to Sharqawy et al., "Thermophysical 
+# at 20ᵒC and 35 psu, according to Sharqawy et al., "Thermophysical
 # properties of seawater: A review of existing correlations and data" (2010).
 const ν₀ = 1.05e-6
 const κ₀ = 1.46e-7
@@ -87,6 +87,6 @@ function Base.convert(::TurbulenceClosure{T2}, closure::TurbulenceClosure{T1}) w
 end
 
 # Fallback constructor for diffusivity types withotu precomputed diffusivities:
-TurbulentDiffusivities(arch::Architecture, grid::Grid, args...) = nothing
+TurbulentDiffusivities(arch::AbstractArchitecture, grid::AbstractGrid, args...) = nothing
 
 end # module

--- a/src/turbulence_closures/closure_operators.jl
+++ b/src/turbulence_closures/closure_operators.jl
@@ -107,7 +107,7 @@ Differentiate the function or callable object
 
 located at `aac` in `z`, across `aaf`.
 """
-@inline ∂z_aaf(i, j, k, grid::Grid, F::TF, args...) where TF<:Function =
+@inline ∂z_aaf(i, j, k, grid::AbstractGrid, F::TF, args...) where TF<:Function =
     (F(i, j, k-1, grid, args...) - F(i, j, k, grid, args...)) / grid.Δz
 
 """
@@ -148,7 +148,7 @@ Interpolate the function or callable object
 
 from `caa` to `faa`."
 """
-@inline ▶x_faa(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶x_faa(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     T(0.5) * (F(i, j, k, grid, args...) + F(i-1, j, k, grid, args...))
 
 """
@@ -160,7 +160,7 @@ Interpolate the function or callable object
 
 from `faa` to `caa`."
 """
-@inline ▶x_caa(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶x_caa(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     return T(0.5) * (F(i+1, j, k, grid, args...) + F(i, j, k, grid, args...))
 
 """
@@ -172,7 +172,7 @@ Interpolate the function or callable object
 
 from `aca` to `afa`.
 """
-@inline ▶y_afa(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶y_afa(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     return T(0.5) * (F(i, j, k, grid, args...) + F(i, j-1, k, grid, args...))
 
 """
@@ -184,7 +184,7 @@ Interpolate the function or callable object
 
 from `afa` to `aca`."
 """
-@inline ▶y_aca(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶y_aca(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     T(0.5) * (F(i, j+1, k, grid, args...) + F(i, j, k, grid, args...))
 
 """
@@ -196,11 +196,11 @@ Interpolate the function or callable object
 
 from `aac` to `aaf`.
 """
-@inline ▶z_aaf(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶z_aaf(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     T(0.5) * (F(i, j, k, grid, args...) + F(i, j, k-1, grid, args...))
 
 """
-    ▶z_aac(i, j, k, grid::Grid{T}, F, args...) where T
+    ▶z_aac(i, j, k, grid::RegularCartesianGrid{T}, F, args...) where T
 
 Interpolate the function or callable object
 
@@ -208,7 +208,7 @@ Interpolate the function or callable object
 
 from `aaf` to `aac`.
 """
-@inline ▶z_aac(i, j, k, grid::Grid{T}, F::TF, args...) where {T, TF<:Function} =
+@inline ▶z_aac(i, j, k, grid::RegularCartesianGrid{T}, F::TF, args...) where {T, TF<:Function} =
     T(0.5) * (F(i, j, k+1, grid, args...) + F(i, j, k, grid, args...))
 
 # Convenience operators for "interpolating constants"
@@ -219,22 +219,22 @@ from `aaf` to `aac`.
 @inline ▶z_aaf(i, j, k, grid, F::Number, args...) = F
 @inline ▶z_aac(i, j, k, grid, F::Number, args...) = F
 
-@inline ▶x_faa(i, j, k, grid::Grid{T}, F::AbstractArray, args...) where T =
+@inline ▶x_faa(i, j, k, grid::RegularCartesianGrid{T}, F::AbstractArray, args...) where T =
     @inbounds T(0.5) * (F[i, j, k] + F[i-1, j, k])
 
-@inline ▶x_caa(i, j, k, grid::Grid{T}, F::AbstractArray, args...) where T =
+@inline ▶x_caa(i, j, k, grid::RegularCartesianGrid{T}, F::AbstractArray, args...) where T =
     @inbounds T(0.5) * (F[i, j, k] + F[i+1, j, k])
 
-@inline ▶y_afa(i, j, k, grid::Grid{T}, F::AbstractArray, args...) where T =
+@inline ▶y_afa(i, j, k, grid::RegularCartesianGrid{T}, F::AbstractArray, args...) where T =
     @inbounds T(0.5) * (F[i, j, k] + F[i, j-1, k])
 
-@inline ▶y_aca(i, j, k, grid::Grid{T}, F::AbstractArray, args...) where T =
+@inline ▶y_aca(i, j, k, grid::RegularCartesianGrid{T}, F::AbstractArray, args...) where T =
     @inbounds T(0.5) * (F[i, j, k] + F[i, j+1, k])
 
-@inline ▶z_aaf(i, j, k, grid::Grid{T}, F::AbstractArray, args...) where T =
+@inline ▶z_aaf(i, j, k, grid::RegularCartesianGrid{T}, F::AbstractArray, args...) where T =
     @inbounds T(0.5) * (F[i, j, k] + F[i, j, k-1])
 
-@inline ▶z_aac(i, j, k, grid::Grid{T}, w::AbstractArray, args...) where T =
+@inline ▶z_aac(i, j, k, grid::RegularCartesianGrid{T}, w::AbstractArray, args...) where T =
     @inbounds T(0.5) * (w[i, j, k] + w[i, j, k+1])
 
 #####

--- a/src/turbulence_closures/rozema_anisotropic_minimum_dissipation.jl
+++ b/src/turbulence_closures/rozema_anisotropic_minimum_dissipation.jl
@@ -41,14 +41,14 @@ const Δx_ccf = Δx
 const Δy_ccf = Δy
 const Δz_ccf = Δz
 
-function TurbulentDiffusivities(arch::Architecture, grid::Grid, ::RAMD)
+function TurbulentDiffusivities(arch::AbstractArchitecture, grid::AbstractGrid, ::RAMD)
      νₑ = CellField(arch, grid)
     κTₑ = CellField(arch, grid)
     κSₑ = CellField(arch, grid)
     return (νₑ=νₑ, κₑ=(T=κTₑ, S=κSₑ))
 end
 
-@inline function ν_ccc(i, j, k, grid::Grid{FT}, closure::RAMD, c,
+@inline function ν_ccc(i, j, k, grid::AbstractGrid{FT}, closure::RAMD, c,
                        eos, grav, u, v, w, T, S) where FT
 
     q = tr_∇u_ccc(i, j, k, grid, u, v, w)
@@ -64,7 +64,7 @@ end
     return max(zero(FT), νˢᶠˢ) + closure.ν
 end
 
-@inline function ν_ccf(i, j, k, grid::Grid{FT}, closure::RAMD, c,
+@inline function ν_ccf(i, j, k, grid::AbstractGrid{FT}, closure::RAMD, c,
                        eos, grav, u, v, w, T, S) where FT
 
     q = tr_∇u_ccf(i, j, k, grid, u, v, w)
@@ -80,9 +80,9 @@ end
     return max(zero(FT), νˢᶠˢ) + closure.ν
 end
 
-@inline function κ_ccc(i, j, k, grid::Grid{FT}, closure::RAMD, c,
+@inline function κ_ccc(i, j, k, grid::AbstractGrid{FT}, closure::RAMD, c,
                        eos, grav, u, v, w, T, S) where FT
-    
+
     σ = θᵢ²_ccc(i, j, k, grid, c) # Tracer variance
 
     if σ == 0
@@ -95,9 +95,9 @@ end
     return max(zero(FT), κˢᶠˢ) + closure.κ
 end
 
-@inline function κ_ccf(i, j, k, grid::Grid{FT}, closure::RAMD, c,
+@inline function κ_ccf(i, j, k, grid::AbstractGrid{FT}, closure::RAMD, c,
                        eos, grav, u, v, w, T, S) where FT
-    
+
     σ = θᵢ²_ccf(i, j, k, grid, c) # Tracer variance
 
     if σ == 0

--- a/src/turbulence_closures/smagorinsky.jl
+++ b/src/turbulence_closures/smagorinsky.jl
@@ -1,6 +1,6 @@
 abstract type AbstractSmagorinsky{T} <: IsotropicDiffusivity{T} end
 
-@inline geo_mean_Δᶠ(i, j, k, grid::RegularCartesianGrid{T}) where T = 
+@inline geo_mean_Δᶠ(i, j, k, grid::RegularCartesianGrid{T}) where T =
     (grid.Δx * grid.Δy * grid.Δz)^T(1/3)
 
 #####
@@ -26,7 +26,7 @@ Base.@kwdef struct DeardorffSmagorinsky{T} <: AbstractSmagorinsky{T}
      κ :: T = κ₀
 end
 
-DeardorffSmagorinsky(T; kwargs...) = 
+DeardorffSmagorinsky(T; kwargs...) =
     typed_keyword_constructor(T, DeardorffSmagorinsky; kwargs...)
 
 """
@@ -38,10 +38,10 @@ Return the stability function
 
 when ``N^2 > 0``, and 1 otherwise.
 """
-@inline stability(N²::T, Σ²::T, Pr::T, Cb::T) where T = 
+@inline stability(N²::T, Σ²::T, Pr::T, Cb::T) where T =
     ifelse(Σ²==0, zero(T), one(T) - sqrt(stability_factor(N², Σ², Pr, Cb)))
 
-@inline stability_factor(N²::T, Σ²::T, Pr::T, Cb::T) where T = 
+@inline stability_factor(N²::T, Σ²::T, Pr::T, Cb::T) where T =
     min(one(T), max(zero(T), Cb * N² / (Pr*Σ²)))
 
 """
@@ -84,15 +84,15 @@ struct BlasiusSmagorinsky{ML, T} <: AbstractSmagorinsky{T}
    mixing_length :: ML
 end
 
-BlasiusSmagorinsky(T=Float64; Pr=1.0, ν=ν₀, κ=κ₀, mixing_length=1.0) = 
+BlasiusSmagorinsky(T=Float64; Pr=1.0, ν=ν₀, κ=κ₀, mixing_length=1.0) =
     BlasiusSmagorinsky{typeof(mixing_length), T}(Pr, ν, κ, mixing_length)
 
 const BS = BlasiusSmagorinsky
 
-@inline Lm²(i, j, k, grid, closure::BS{<:AbstractFloat}, args...) = 
+@inline Lm²(i, j, k, grid, closure::BS{<:AbstractFloat}, args...) =
     closure.mixing_length^2
 
-@inline Lm²(i, j, k, grid, closure::BS{<:Nothing}, args...) = 
+@inline Lm²(i, j, k, grid, closure::BS{<:Nothing}, args...) =
     geo_mean_Δᶠ(i, j, k, grid)^2
 
 #####
@@ -116,11 +116,11 @@ struct MoninObukhovMixingLength{L, T, U, B}
     Cκ :: T
     z₀ :: T
     L₀ :: L
-    Qu :: U 
+    Qu :: U
     Qb :: U
 end
 
-MoninObukhovMixingLength(T=Float64; Qu, Qb, Cκ=0.4, z₀=0.0, L₀=nothing) = 
+MoninObukhovMixingLength(T=Float64; Qu, Qb, Cκ=0.4, z₀=0.0, L₀=nothing) =
     MoninObukhovMixingLength(T(Cκ), T(z₀), L₀, Qu, Qb)
 
 const MO = MoninObukhovMixingLength
@@ -131,7 +131,7 @@ const MO = MoninObukhovMixingLength
     ϕm(z, Qu, Qb, Cκ)
 
 Return the stability function for monentum at height
-`z` in terms of the velocity flux `Qu`, buoyancy flux 
+`z` in terms of the velocity flux `Qu`, buoyancy flux
 `Qb`, and von Karman constant `Cκ`.
 """
 @inline function ϕm(z::T, Qu, Qb, Cκ) where T
@@ -147,8 +147,8 @@ end
 @inline function Lm²(i, j, k, grid, clo::BlasiusSmagorinsky{<:MO, T}, Σ², N²) where T
     Lm = clo.mixing_length
     z = @inbounds grid.zC[i, j, k]
-    Lm⁻² = ( 
-             ( ϕm(z + Lm.z₀, Lm) * buoyancy_factor(Σ², N²)^T(0.25) / (Lm.Cκ * (z + Lm.z₀)) )^2 
+    Lm⁻² = (
+             ( ϕm(z + Lm.z₀, Lm) * buoyancy_factor(Σ², N²)^T(0.25) / (Lm.Cκ * (z + Lm.z₀)) )^2
             + 1 / L₀(i, j, k, grid, Lm)^2
            )
     return 1 / Lm⁻²
@@ -156,10 +156,10 @@ end
 
 @inline L₀(i, j, k, grid, mixing_length::MO{<:Number}) = mixing_length.L₀
 
-@inline L₀(i, j, k, grid, mixing_length::MO{<:Nothing}) = 
+@inline L₀(i, j, k, grid, mixing_length::MO{<:Nothing}) =
     geo_mean_Δᶠ(i, j, k, grid)
 
-@inline buoyancy_factor(Σ², N²::T) where T = 
+@inline buoyancy_factor(Σ², N²::T) where T =
     ifelse(Σ²==0, zero(T), max(zero(T), (one(T) - N² / Σ²)))
 
 """
@@ -184,7 +184,7 @@ end
 ##### Abstract Smagorinsky functionality
 #####
 
-TurbulentDiffusivities(arch::Architecture, grid::Grid, ::AbstractSmagorinsky) =
+TurbulentDiffusivities(arch::AbstractArchitecture, grid::AbstractGrid, ::AbstractSmagorinsky) =
     (νₑ=CellField(arch, grid),)
 
 "Return the filter width for Constant Smagorinsky on a Regular Cartesian grid."
@@ -326,4 +326,3 @@ end
             + 2 *   ▶y_aca(i, j, k, grid, Σ₂₃², u, v, w)
             )
 end
-

--- a/src/turbulence_closures/velocity_tracer_gradients.jl
+++ b/src/turbulence_closures/velocity_tracer_gradients.jl
@@ -30,15 +30,15 @@
     Σ₁₁(i, j, k, grid, u) + Σ₂₂(i, j, k, grid, v) + Σ₃₃(i, j, k, grid, w)
 
 # ffc
-@inline Σ₁₂(i, j, k, grid::Grid{T}, u, v) where T =
+@inline Σ₁₂(i, j, k, grid::RegularCartesianGrid{T}, u, v) where T =
     T(0.5) * (∂y_afa(i, j, k, grid, u) + ∂x_faa(i, j, k, grid, v))
 
 # fcf
-@inline Σ₁₃(i, j, k, grid::Grid{T}, u, w) where T =
+@inline Σ₁₃(i, j, k, grid::RegularCartesianGrid{T}, u, w) where T =
     T(0.5) * (∂z_aaf(i, j, k, grid, u) + ∂x_faa(i, j, k, grid, w))
 
 # cff
-@inline Σ₂₃(i, j, k, grid::Grid{T}, v, w) where T =
+@inline Σ₂₃(i, j, k, grid::RegularCartesianGrid{T}, v, w) where T =
     T(0.5) * (∂z_aaf(i, j, k, grid, v) + ∂y_afa(i, j, k, grid, w))
 
 @inline Σ₁₂²(i, j, k, grid, u, v) = Σ₁₂(i, j, k, grid, u, v)^2
@@ -166,15 +166,15 @@ const norm_∂z_w = ∂z_w
     norm_Σ₁₁(i, j, k, grid, u) + norm_Σ₂₂(i, j, k, grid, v) + norm_Σ₃₃(i, j, k, grid, w)
 
 # ffc
-@inline norm_Σ₁₂(i, j, k, grid::Grid{T}, u, v) where T =
+@inline norm_Σ₁₂(i, j, k, grid::RegularCartesianGrid{T}, u, v) where T =
     T(0.5) * (norm_∂y_u(i, j, k, grid, u) + norm_∂x_v(i, j, k, grid, v))
 
 # fcf
-@inline norm_Σ₁₃(i, j, k, grid::Grid{T}, u, w) where T =
+@inline norm_Σ₁₃(i, j, k, grid::RegularCartesianGrid{T}, u, w) where T =
     T(0.5) * (norm_∂z_u(i, j, k, grid, u) + norm_∂x_w(i, j, k, grid, w))
 
 # cff
-@inline norm_Σ₂₃(i, j, k, grid::Grid{T}, v, w) where T =
+@inline norm_Σ₂₃(i, j, k, grid::RegularCartesianGrid{T}, v, w) where T =
     T(0.5) * (norm_∂z_v(i, j, k, grid, v) + norm_∂y_w(i, j, k, grid, w))
 
 @inline norm_Σ₁₂²(i, j, k, grid, u, v) = norm_Σ₁₂(i, j, k, grid, u, v)^2

--- a/src/turbulence_closures/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/turbulence_closures/verstappen_anisotropic_minimum_dissipation.jl
@@ -17,13 +17,13 @@ Returns a `VerstappenAnisotropicMinimumDissipation` closure object of type `T` w
 
 Based on the version of the anisotropic minimum dissipation closure proposed by:
 
- - Verstappen, R., "How much eddy dissipation is needed to counterbalance the 
-    "nonlinear production of small, unresolved scales in a large-eddy simulation 
+ - Verstappen, R., "How much eddy dissipation is needed to counterbalance the
+    "nonlinear production of small, unresolved scales in a large-eddy simulation
     of turbulence?", 2018
 
 and described by
 
- - Vreugdenhil C., and Taylor J., "Large-eddy simulations of stratified plane Couette 
+ - Vreugdenhil C., and Taylor J., "Large-eddy simulations of stratified plane Couette
  flow using the anisotropic minimum-dissipation model", (2018).
 """
 function VerstappenAnisotropicMinimumDissipation(FT=Float64;
@@ -37,14 +37,14 @@ end
 
 const VAMD = VerstappenAnisotropicMinimumDissipation
 
-function TurbulentDiffusivities(arch::Architecture, grid::Grid, ::VAMD)
+function TurbulentDiffusivities(arch::AbstractArchitecture, grid::AbstractGrid, ::VAMD)
      νₑ = CellField(arch, grid)
     κTₑ = CellField(arch, grid)
     κSₑ = CellField(arch, grid)
     return (νₑ=νₑ, κₑ=(T=κTₑ, S=κSₑ))
 end
 
-@inline function ν_ccc(i, j, k, grid::Grid{FT}, closure::VAMD, c,
+@inline function ν_ccc(i, j, k, grid::AbstractGrid{FT}, closure::VAMD, c,
                        eos, grav, u, v, w, T, S) where FT
 
     ijk = (i, j, k, grid)
@@ -62,7 +62,7 @@ end
     return max(zero(FT), νˢᵍˢ) + closure.ν
 end
 
-@inline function κ_ccc(i, j, k, grid::Grid{FT}, closure::VAMD, c,
+@inline function κ_ccc(i, j, k, grid::AbstractGrid{FT}, closure::VAMD, c,
                        eos, grav, u, v, w, T, S) where FT
 
     ijk = (i, j, k, grid)
@@ -95,7 +95,7 @@ end
 
       +  2 * norm_∂x_u(ijkuvw...) * ▶xy_cca(ijk..., norm_∂x_v_Σ₁₂, uvw...)
       +  2 * norm_∂x_u(ijkuvw...) * ▶xz_cac(ijk..., norm_∂x_w_Σ₁₃, uvw...)
-      +  2 * ▶xy_cca(ijk..., norm_∂x_v, uvw...) * ▶xz_cac(ijk..., norm_∂x_w, uvw...) 
+      +  2 * ▶xy_cca(ijk..., norm_∂x_v, uvw...) * ▶xz_cac(ijk..., norm_∂x_w, uvw...)
            * ▶yz_acc(ijk..., norm_Σ₂₃, uvw...)
     )
 
@@ -105,7 +105,7 @@ end
       + norm_Σ₃₃(ijkuvw...) * ▶yz_acc(ijk..., norm_∂y_w², uvw...)
 
       +  2 * norm_∂y_v(ijkuvw...) * ▶xy_cca(ijk..., norm_∂y_u_Σ₁₂, uvw...)
-      +  2 * ▶xy_cca(ijk..., norm_∂y_u, uvw...) * ▶yz_acc(ijk..., norm_∂y_w, uvw...) 
+      +  2 * ▶xy_cca(ijk..., norm_∂y_u, uvw...) * ▶yz_acc(ijk..., norm_∂y_w, uvw...)
            * ▶xz_cac(ijk..., norm_Σ₁₃, uvw...)
       +  2 * norm_∂y_v(ijkuvw...) * ▶yz_acc(ijk..., norm_∂y_w_Σ₂₃, uvw...)
     )
@@ -115,7 +115,7 @@ end
       + norm_Σ₂₂(ijkuvw...) * ▶yz_acc(ijk..., norm_∂z_v², uvw...)
       + norm_Σ₃₃(ijkuvw...) * norm_∂z_w(ijk..., w)^2
 
-      +  2 * ▶xz_cac(ijk..., norm_∂z_u, uvw...) * ▶yz_acc(ijk..., norm_∂z_v, uvw...) 
+      +  2 * ▶xz_cac(ijk..., norm_∂z_u, uvw...) * ▶yz_acc(ijk..., norm_∂z_v, uvw...)
            * ▶xy_cca(ijk..., norm_Σ₁₂, uvw...)
       +  2 * norm_∂z_w(ijkuvw...) * ▶xz_cac(ijk..., norm_∂z_u_Σ₁₃, uvw...)
       +  2 * norm_∂z_w(ijkuvw...) * ▶yz_acc(ijk..., norm_∂z_v_Σ₂₃, uvw...)
@@ -136,7 +136,7 @@ end
 
       +  2 *   ▶z_aaf(ijk..., norm_∂x_u, uvw...) * ▶xyz_ccf(ijk..., norm_∂x_v_Σ₁₂, uvw...)
       +  2 *   ▶z_aaf(ijk..., norm_∂x_u, uvw...) *   ▶x_caa(ijk..., norm_∂x_w_Σ₁₃, uvw...)
-      +  2 * ▶xyz_ccf(ijk..., norm_∂x_v, uvw...) *   ▶x_caa(ijk..., norm_∂x_w, uvw...) 
+      +  2 * ▶xyz_ccf(ijk..., norm_∂x_v, uvw...) *   ▶x_caa(ijk..., norm_∂x_w, uvw...)
            *   ▶y_aca(ijk..., norm_Σ₂₃, uvw...)
     )
 
@@ -146,7 +146,7 @@ end
       + ▶z_aaf(ijk..., norm_Σ₃₃, uvw...) *   ▶y_aca(ijk..., norm_∂y_w², uvw...)
 
       +  2 *  ▶z_aaf(ijk..., norm_∂y_v, uvw...) * ▶xyz_ccf(ijk..., norm_∂y_u_Σ₁₂, uvw...)
-      +  2 * ▶xy_cca(ijk..., norm_∂y_u, uvw...) *   ▶y_aca(ijk..., norm_∂y_w, uvw...) 
+      +  2 * ▶xy_cca(ijk..., norm_∂y_u, uvw...) *   ▶y_aca(ijk..., norm_∂y_w, uvw...)
            *  ▶x_caa(ijk..., norm_Σ₁₃, uvw...)
       +  2 *  ▶z_aaf(ijk..., norm_∂y_v, uvw...) *   ▶y_aca(ijk..., norm_∂y_w_Σ₂₃, uvw...)
     )
@@ -156,7 +156,7 @@ end
       + ▶z_aaf(ijk..., norm_Σ₂₂, uvw...) * ▶y_aca(ijk..., norm_∂z_v², uvw...)
       + ▶z_aaf(ijk..., norm_Σ₃₃, uvw...) * ▶z_aaf(ijk..., norm_∂z_w², uvw...)
 
-      +  2 *   ▶x_caa(ijk..., norm_∂z_u, uvw...) * ▶y_aca(ijk..., norm_∂z_v, uvw...) 
+      +  2 *   ▶x_caa(ijk..., norm_∂z_u, uvw...) * ▶y_aca(ijk..., norm_∂z_v, uvw...)
            * ▶xyz_ccf(ijk..., norm_Σ₁₂, uvw...)
       +  2 *   ▶z_aaf(ijk..., norm_∂z_w, uvw...) * ▶x_caa(ijk..., norm_∂z_u_Σ₁₃, uvw...)
       +  2 *   ▶z_aaf(ijk..., norm_∂z_w, uvw...) * ▶y_aca(ijk..., norm_∂z_v_Σ₂₃, uvw...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,8 +76,8 @@ Base.zeros(T, ::CPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz)
 Base.zeros(T, ::GPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz) |> CuArray
 
 # Default to type of Grid
-Base.zeros(arch, grid::Grid{T}) where T = zeros(T, arch, grid)
-Base.zeros(arch, grid::Grid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, Ny, Nz)
+Base.zeros(arch, grid::AbstractGrid{T}) where T = zeros(T, arch, grid)
+Base.zeros(arch, grid::AbstractGrid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, Ny, Nz)
 
 ####
 #### Courant–Friedrichs–Lewy (CFL) condition number calculation
@@ -161,7 +161,7 @@ parenttuple(obj) = Tuple(f.data.parent for f in obj)
 
 @inline datatuple(obj::Nothing) = nothing
 @inline datatuple(obj::AbstractArray) = obj
-@inline datatuple(obj::Field) = obj.data
+@inline datatuple(obj::AbstractField) = obj.data
 @inline datatuple(obj::NamedTuple) = NamedTuple{propertynames(obj)}(datatuple(o) for o in obj)
 @inline datatuples(objs...) = (datatuple(obj) for obj in objs)
 
@@ -235,7 +235,7 @@ end
 frequency_is_ripe(clock, obj) = has_frequency(obj) && clock.iteration % obj.frequency == 0
 
 function time_to_run(clock, output_writer)
-    
+
     interval_is_ripe(clock, output_writer) && return true
     frequency_is_ripe(clock, output_writer) && return true
 

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -22,7 +22,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), architecture=arch,
                        float_type=FT, boundary_conditions=modelbcs)
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
 
     time_step!(model, 1, 1e-16)
 
@@ -45,7 +45,7 @@ function test_z_boundary_condition_array(arch, FT, fldname)
     model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch,
                        float_type=FT, boundary_conditions=modelbcs)
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
 
     time_step!(model, 1, 1e-16)
 
@@ -72,7 +72,7 @@ function test_flux_budget(arch, FT, fldname)
 
     @. field.data = 0
 
-    bcs = getfield(model.boundary_conditions, fldname)
+    bcs = getfield(model.boundary_conditions.solution, fldname)
     mean_init = mean(data(field))
 
     τκ = Lz^2 / κ   # Diffusion time-scale

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -4,7 +4,7 @@ function test_z_boundary_condition_simple(arch, T, fldname, bctype, bc, Nx, Ny)
     fieldbcs = HorizontallyPeriodicBCs(top=bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch, 
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch,
                        float_type=T, boundary_conditions=modelbcs)
 
     time_step!(model, 1, 1e-16)
@@ -19,7 +19,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=top_bc, bottom=bottom_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), architecture=arch, 
+    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), architecture=arch,
                        float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
@@ -42,7 +42,7 @@ function test_z_boundary_condition_array(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=value_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch, 
+    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch,
                        float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions, fldname)
@@ -60,10 +60,10 @@ function test_flux_budget(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(bottom=flux_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, architecture=arch, 
-                       float_type=FT, eos=LinearEquationOfState(βS=0, βT=0), 
+    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, architecture=arch,
+                       float_type=FT, eos=LinearEquationOfState(βS=0.0, βT=0.0), 
                        boundary_conditions=modelbcs)
-                       
+
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)
     else

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -118,8 +118,8 @@ function internal_wave_test(; N=128, Nt=10)
 
     # Create a model where temperature = buoyancy.
     model = BasicModel(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ,
-                       eos=LinearEquationOfState(βT=1.),
-                       constants=PlanetaryConstants(f=f, g=1.))
+                       eos=LinearEquationOfState(βT=1.0),
+                       constants=PlanetaryConstants(f=f, g=1.0))
 
     set_ic!(model, u=u₀, v=v₀, w=w₀, T=T₀)
 
@@ -171,11 +171,11 @@ function pearson_vortex_test(arch; FT=Float64, N=64, Nt=10)
     vbcs = HorizontallyPeriodicBCs(   top = BoundaryCondition(Gradient, 0),
                                    bottom = BoundaryCondition(Gradient, 0))
 
-    model = Model(        architecture = arch, 
-                                  grid = RegularCartesianGrid(FT; N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)), 
+    model = Model(        architecture = arch,
+                                  grid = RegularCartesianGrid(FT; N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
                              constants = PlanetaryConstants(f=0, g=0),  # Turn off rotation and gravity.
                                closure = ConstantIsotropicDiffusivity(FT; ν=1, κ=0),  # Turn off diffusivity.
-                                   eos = LinearEquationOfState(βT=0, βS=0),  # Turn off buoyancy.
+                                   eos = LinearEquationOfState(βT=0.0, βS=0.0),  # Turn off buoyancy.
                    boundary_conditions = BoundaryConditions(u=ubcs, v=vbcs))
 
     u₀(x, y, z) = u(x, y, z, 0)

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -13,7 +13,7 @@ end
     test_set_field(N, L, ftf, val)
 
 Test that the field initialized by the field type function `ftf` on the grid g
-can be correctly filled with the value `val` using the `set!(f::Field, v)`
+can be correctly filled with the value `val` using the `set!(f::AbstractField, v)`
 function.
 """
 function correct_field_value_was_set(arch, grid, fieldtype, val::Number)

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -47,17 +47,8 @@ end
         for FT in float_types
             @test isbitstype(typeof(RegularCartesianGrid(FT, (16, 16, 16), (1, 1, 1))))
 
-            @test RegularCartesianGrid(FT, (25, 25, 25), L).dim == 3
-            @test RegularCartesianGrid(FT, (5, 25, 125), L).dim == 3
-            @test RegularCartesianGrid(FT, (64, 64, 64), L).dim == 3
-            @test RegularCartesianGrid(FT, (32, 32,  1), L).dim == 2
-            @test RegularCartesianGrid(FT, (32,  1, 32), L).dim == 2
-            @test RegularCartesianGrid(FT, (1,  32, 32), L).dim == 2
-            @test RegularCartesianGrid(FT, (1,  1,  64), L).dim == 1
-
             @test_throws ArgumentError RegularCartesianGrid(FT, (32,), L)
             @test_throws ArgumentError RegularCartesianGrid(FT, (32, 64), L)
-            @test_throws ArgumentError RegularCartesianGrid(FT, (1, 1, 1), L)
             @test_throws ArgumentError RegularCartesianGrid(FT, (32, 32, 32, 16), L)
             @test_throws ArgumentError RegularCartesianGrid(FT, (32, 32, 32), (100,))
             @test_throws ArgumentError RegularCartesianGrid(FT, (32, 32, 32), (100, 100))

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -95,7 +95,7 @@ function run_rayleigh_benard_regression_test(arch)
                architecture = arch,
                        grid = RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
                     closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ),
-                        eos = LinearEquationOfState(βT=1., βS=0.),
+                        eos = LinearEquationOfState(βT=1.0, βS=0.0),
                   constants = PlanetaryConstants(g=1., f=0.),
         boundary_conditions = BoundaryConditions(T=HorizontallyPeriodicBCs(
                                 top=BoundaryCondition(Value, 0.0), bottom=BoundaryCondition(Value, Δb))),

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -96,7 +96,7 @@ function run_rayleigh_benard_regression_test(arch)
                        grid = RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
                     closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ),
                         eos = LinearEquationOfState(βT=1.0, βS=0.0),
-                  constants = PlanetaryConstants(g=1., f=0.),
+                  constants = PlanetaryConstants(g=1.0, f=0.0),
         boundary_conditions = BoundaryConditions(T=HorizontallyPeriodicBCs(
                                 top=BoundaryCondition(Value, 0.0), bottom=BoundaryCondition(Value, Δb))),
                     forcing = Forcing(FS=FS)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -32,7 +32,7 @@ function compute_w_from_continuity(arch, FT)
     Lx, Ly, Lz = 16, 16, 16
 
     grid = RegularCartesianGrid(FT, (Nx, Ny, Nz), (Lx, Ly, Lz))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
 
     u = FaceFieldX(FT, arch, grid)
     v = FaceFieldY(FT, arch, grid)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -105,7 +105,7 @@ end
     tracer_conserved_in_channel(arch, FT, Nt)
 
 Create a super-coarse eddying channel model with walls in the y and test that
-temperature and salinity are conserved after `Nt` time steps.
+temperature is conserved after `Nt` time steps.
 """
 function tracer_conserved_in_channel(arch, FT, Nt)
     Nx, Ny, Nz = 16, 32, 16
@@ -115,9 +115,9 @@ function tracer_conserved_in_channel(arch, FT, Nt)
     νh, κh = 20.0, 20.0
     νv, κv = α*νh, α*κh
 
-    model = ChannelModel(grid=RegularCartesianGrid(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz)),
-                         architecture=arch, float_type=FT,
-                         closure=ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
+    model = ChannelModel(architecture = arch, float_type = FT,
+                         grid = RegularCartesianGrid(N = (Nx, Ny, Nz), L = (Lx, Ly, Lz)),
+                         closure = ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].
     Tz = 5e-3  # Vertical temperature gradient [K/m].

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -58,7 +58,7 @@ function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64;
     arch = CPU()
     closure = ConstantIsotropicDiffusivity(FT, κ=κ, ν=ν)
     grid = RegularCartesianGrid(FT, (3, 1, 4), (3, 1, 4))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
     eos = LinearEquationOfState()
     grav = one(FT)
 
@@ -90,7 +90,7 @@ function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.
     arch = CPU()
     closure = ConstantAnisotropicDiffusivity(FT, κh=κh, νh=νh, κv=κv, νv=νv)
     grid = RegularCartesianGrid(FT, (3, 1, 4), (3, 1, 4))
-    bcs = HorizontallyPeriodicModelBCs()
+    bcs = HorizontallyPeriodicSolutionBCs()
     eos = LinearEquationOfState()
     grav = one(FT)
     velocities = Oceananigans.VelocityFields(arch, grid)

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -1,7 +1,7 @@
 using Oceananigans.TurbulenceClosures: ∂x_caa, ∂x_faa, ∂x²_caa, ∂x²_faa,
                                        ∂y_aca, ∂y_afa, ∂y²_aca, ∂y²_afa,
                                        ∂z_aac, ∂z_aaf, ∂z²_aac, ∂z²_aaf,
-                                       ▶x_caa, ▶x_faa, ▶y_aca, ▶y_afa, 
+                                       ▶x_caa, ▶x_faa, ▶y_aca, ▶y_afa,
                                        ▶z_aac, ▶z_aaf
 
 using GPUifyLoops: @launch
@@ -34,7 +34,7 @@ function test_calc_diffusivities(arch, closurename, FT=Float64; kwargs...)
     closure = getproperty(TurbulenceClosures, closurename)(FT; kwargs...)
     grid = RegularCartesianGrid(FT, (3, 3, 3), (3, 3, 3))
     diffusivities = TurbulentDiffusivities(arch, grid, closure)
-    eos = LinearEquationOfState(FT)
+    eos = LinearEquationOfState{FT}()
     grav = one(FT)
     velocities = Oceananigans.VelocityFields(arch, grid)
     tracers = Oceananigans.TracerFields(arch, grid)
@@ -52,7 +52,7 @@ function test_constant_isotropic_diffusivity_basic(T=Float64; ν=T(0.3), κ=T(0.
     return closure.ν == ν && closure.κ == κ
 end
 
-function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64; 
+function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64;
                                                      ν=FT(0.3), κ=FT(0.7))
 
     arch = CPU()
@@ -84,7 +84,7 @@ function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64;
             )
 end
 
-function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.7), 
+function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.7),
                                               νv=FT(0.1), κv=FT(0.5))
 
     arch = CPU()


### PR DESCRIPTION
Started to write documentation and docstrings but some parts of the code were a little too messy to be documented easily, so I ended up doing some cleanup that seems to deserve its own PR.

I mainly renamed all the abstract types to have the `Abstract` prefix (following the Julia style guide) and simplified `LinearEquationOfState`, `PlanetaryConstants`, and `RegularCartesianGrid` where I removed properties that weren't being used or that were redundant/useless.

Resolves #190 (because the constants in question have been removed)
Resolves #285 