### PR TITLE
Timeseries diagnostic and CFL utilities

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -106,14 +106,14 @@ abstract type AbstractPoissonSolver end
 abstract type AbstractModel{TS, E, A} end
 abstract type AbstractOutputWriter end
 abstract type AbstractDiagnostic end
-abstract type AbstractTimeseriesDiagnostic <: Diagnostic end
+abstract type AbstractTimeseriesDiagnostic <: AbstractDiagnostic end
 
 #####
 ##### All the code
 #####
 
-struct CPU <: Architecture end
-struct GPU <: Architecture end
+struct CPU <: AbstractArchitecture end
+struct GPU <: AbstractArchitecture end
 
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -53,8 +53,8 @@ export
     JLD2OutputWriter, FieldOutput, FieldOutputs,
 
     # Model diagnostics
-    HorizontalAverage, NaNChecker, CFLDiagnostic, AdvectiveCFLDiagnostic, DiffusiveCFLDiagnostic,
-    MaxAbsFieldDiagnostic
+    HorizontalAverage, NaNChecker, 
+    Timeseries, CFL, AdvectiveCFL, DiffusiveCFL, FieldMaximum,
 
     # Package utilities
     prettytime, pretty_filesize, KiB, MiB, GiB, TiB,
@@ -100,12 +100,12 @@ abstract type Architecture end
 abstract type ConstantsCollection end
 abstract type EquationOfState end
 abstract type Grid{T} end
-abstract type AbstractModel end
+abstract type AbstractModel{TS, E, A} end
 abstract type Field{A, G} end
 abstract type FaceField{A, G} <: Field{A, G} end
 abstract type OutputWriter end
 abstract type Diagnostic end
-abstract type AbstractTimeseriesDiagnostic end
+abstract type AbstractTimeseriesDiagnostic <: Diagnostic end
 abstract type PoissonSolver end
 
 #####

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -52,7 +52,8 @@ export
     restore_from_checkpoint, read_output,
 
     # Model diagnostics
-    HorizontalAverage, NaNChecker,
+    HorizontalAverage, NaNChecker, CFLDiagnostic, AdvectiveCFLDiagnostic, DiffusiveCFLDiagnostic,
+    MaxAbsFieldDiagnostic
 
     # Package utilities
     prettytime, pretty_filesize, KiB, MiB, GiB, TiB,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -48,8 +48,9 @@ export
     Model, ChannelModel,
 
     # Model output writers
-    NetCDFOutputWriter, JLD2OutputWriter, Checkpointer,
-    restore_from_checkpoint, read_output,
+    NetCDFOutputWriter, 
+    Checkpointer, restore_from_checkpoint, read_output,
+    JLD2OutputWriter, FieldOutput, FieldOutputs,
 
     # Model diagnostics
     HorizontalAverage, NaNChecker, CFLDiagnostic, AdvectiveCFLDiagnostic, DiffusiveCFLDiagnostic,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -81,6 +81,7 @@ import
     CUDAapi,
     GPUifyLoops
 
+using Statistics: mean
 using CUDAapi: has_cuda
 using GPUifyLoops: @launch, @loop, @unroll
 
@@ -88,6 +89,32 @@ import Base:
     size, length,
     getindex, lastindex, setindex!,
     iterate, similar, *, +, -
+
+#####
+##### Abstract types 
+#####
+
+abstract type Architecture end
+abstract type ConstantsCollection end
+abstract type EquationOfState end
+abstract type Grid{T} end
+abstract type AbstractModel end
+abstract type Field{A, G} end
+abstract type FaceField{A, G} <: Field{A, G} end
+abstract type OutputWriter end
+abstract type Diagnostic end
+abstract type AbstractTimeseriesDiagnostic end
+abstract type PoissonSolver end
+
+#####
+##### All the code
+#####
+
+struct CPU <: Architecture end
+struct GPU <: Architecture end
+
+device(::CPU) = GPUifyLoops.CPU()
+device(::GPU) = GPUifyLoops.CUDA()
 
 macro hascuda(ex)
     return has_cuda() ? :($(esc(ex))) : :(nothing)
@@ -102,23 +129,6 @@ end
         println(dev)
     end
 end
-
-abstract type Architecture end
-struct CPU <: Architecture end
-struct GPU <: Architecture end
-
-device(::CPU) = GPUifyLoops.CPU()
-device(::GPU) = GPUifyLoops.CUDA()
-
-abstract type ConstantsCollection end
-abstract type EquationOfState end
-abstract type Grid{T} end
-abstract type AbstractModel end
-abstract type Field{A, G} end
-abstract type FaceField{A, G} <: Field{A, G} end
-abstract type OutputWriter end
-abstract type Diagnostic end
-abstract type PoissonSolver end
 
 function buoyancy_perturbation end
 
@@ -141,6 +151,5 @@ include("time_steppers.jl")
 
 include("output_writers.jl")
 include("diagnostics.jl")
-
 
 end # module

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,6 +1,3 @@
-using Statistics: mean
-using Printf
-
 ####
 #### Useful kernels
 ####
@@ -19,20 +16,18 @@ end
 #### Horizontally averaged vertical profiles
 ####
 
-mutable struct HorizontalAverage{F, R, P, I, T} <: Diagnostic
+mutable struct HorizontalAverage{F, R, P, I, Ω} <: Diagnostic
         profile :: P
          fields :: F
-      frequency :: I
-       interval :: T
+      frequency :: Ω
+       interval :: I
        previous :: Float64
     return_type :: R
 end
 
 
-function HorizontalAverage(model, fields; frequency=nothing, interval=nothing,
-                           return_type=nothing)
+function HorizontalAverage(model, fields; frequency=nothing, interval=nothing, return_type=nothing)
     fields = parenttuple(tupleit(fields))
-    validate_interval(frequency, interval)
     profile = zeros(model.arch, model.grid, 1, 1, model.grid.Tz)
     return HorizontalAverage(profile, fields, frequency, interval, 0.0, return_type)
 end
@@ -80,7 +75,6 @@ function (havg::HorizontalAverage)(model)
     return havg.return_type(havg.profile)
 end
 
-
 ####
 #### NaN checker
 ####
@@ -91,7 +85,7 @@ struct NaNChecker{D} <: Diagnostic
 end
 
 function NaNChecker(model; frequency=1000, fields=Dict(:w => model.velocities.w.data.parent))
-    NaNChecker(frequency, fields)
+    return NaNChecker(frequency, fields)
 end
 
 function run_diagnostic(model::Model, nc::NaNChecker)
@@ -102,3 +96,107 @@ function run_diagnostic(model::Model, nc::NaNChecker)
         end
     end
 end
+
+####
+#### Timeseries diagnostics
+####
+
+function run_diagnostic(model, diag::AbstractTimeseriesDiagnostic) 
+    push!(diag.data, diag(model))
+    push!(diag.time, model.clock.time)
+    return nothing
+end
+
+"""
+    TimeseriesDiagnostic(calculate, model; frequency=nothing, interval=nothing)
+
+A generic AbstractTimeseriesDiagnostic that records a timeseries of `calculate(model)`.
+"""
+struct TimeseriesDiagnostic{Ω, I, C, TD, TT}
+    calculate :: C
+    frequency :: Ω
+     interval :: I
+         data :: Vector{TD}
+         time :: Vector{TT}
+end
+
+function TimeseriesDiagnostic(calculate, model; frequency=nothing, interval=nothing)
+    TT = typeof(model.clock.time)
+    TD = typeof(calculate(model))
+    return TimeseriesDiagnostic(calculate, frequency, interval, TD[], TT[])
+end
+
+@inline (timeseries::TimeseriesDiagnostic)(model) = timeseries.calculate(model)
+
+"""
+    MaxAbsFieldDiagnostic(field, frequency=nothing, interval=nothing) <: AbstractTimeseriesDiagnostic
+
+A diagnostic for recording timeseries of the maximum absolute value of a field.
+"""
+struct MaxAbsFieldDiagnostic{Ω, I, T, F} <: AbstractTimeseriesDiagnostic
+        field :: F
+    frequency :: Ω
+     interval :: I
+         data :: Vector{T}
+         time :: Vector{T}
+end
+
+function MaxAbsFieldDiagnostic(field; frequency=nothing, interval=nothing) 
+    T = typeof(maximum(abs, field.data.parent))
+    return MaxAbsFieldDiagnostic(field, frequency, interval, T[], T[]) 
+end
+
+(m::MaxAbsFieldDiagnostic)(model) = maximum(abs, m.field.data.parent)
+
+"""
+    CFLDiagnostic([T=Float64], Δt; frequency=nothing, interval=nothing, 
+                  timescale=Oceananigans.cell_advection_timescale)
+
+A diagnostic for computing timeseries of type `T` of the 
+Courant-Freidrichs-Lewis (CFL) number, associated with time-step `Δt` 
+and a characteristic `timescale`. If `Δt` is `TimeStepWizard` object, 
+the current `Δt` associated with the wizard is used.
+
+See also `AdvectiveCFLDiagnostic` and `DiffusiveCFLDiagnostic`.
+"""
+struct CFLDiagnostic{D, Ω, I, T, S} <: AbstractTimeseriesDiagnostic
+           Δt :: D
+    frequency :: Ω
+     interval :: I
+         data :: Vector{T}
+         time :: Vector{T}
+    timescale :: S
+end
+
+function CFLDiagnostic(T, Δt; frequency=nothing, interval=nothing, 
+                       timescale=cell_advection_timescale)
+
+    return CFLDiagnostic(Δt, frequency, interval, T[], T[], timescale)
+end
+
+CFLDiagnostic(Δt; kwargs...) = CFLDiagnostic(Float64, Δt; kwargs...)
+
+(c::CFLDiagnostic{<:Number})(model) = c.Δt / c.timescale(model)
+(c::CFLDiagnostic{<:TimeStepWizard})(model) = c.Δt.Δt / c.timescale(model)
+
+"""
+    AdvectiveCFLDiagnostic([T=Float64], Δt; frequency=nothing, interval=nothing)
+
+A diagnostic for computing timeseries of the advective CFL number.
+"""
+AdvectiveCFLDiagnostic(T, Δt; kwargs...) = 
+    CFLDiagnostic(T, Δt; timescale=cell_advection_timescale, kwargs...)
+
+AdvectiveCFLDiagnostic(Δt; kwargs...) = 
+    CFLDiagnostic(Float64, Δt; timescale=cell_advection_timescale, kwargs...)
+
+"""
+    DiffusiveCFLDiagnostic([T=Float64], Δt; frequency=nothing, interval=nothing)
+
+A diagnostic for computing timeseries of the diffusive CFL number.
+"""
+DiffusiveCFLDiagnostic(T, Δt; kwargs...) = 
+    CFLDiagnostic(T, Δt; timescale=cell_diffusion_timescale, kwargs...)
+
+DiffusiveCFLDiagnostic(Δt; kwargs...) = 
+    CFLDiagnostic(Float64, Δt; timescale=cell_diffusion_timescale, kwargs...)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -78,12 +78,12 @@ end
 #### NaN checker
 ####
 
-struct NaNChecker{D} <: Diagnostic
+struct NaNChecker{F} <: Diagnostic
     frequency :: Int
-       fields :: D
+       fields :: F
 end
 
-function NaNChecker(model; frequency=1000, fields=Dict(:w => model.velocities.w.data.parent))
+function NaNChecker(model; frequency, fields)
     return NaNChecker(frequency, fields)
 end
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -2,7 +2,7 @@ using .TurbulenceClosures
 using .TurbulenceClosures: ν₀, κ₀
 
 mutable struct Model{TS, E, A<:Architecture, G, T, EOS<:EquationOfState,
-                     Λ<:PlanetaryConstants, U, C, Φ, F, BCS, S, K, Θ} <: AbstractModel
+                     Λ<:PlanetaryConstants, U, C, Φ, F, BCS, S, K, Θ} <: AbstractModel{TS, E, A}
 
            architecture :: A                      # Computer `Architecture` on which `Model` is run
                    grid :: G                      # Grid of physical points on which `Model` is solved

--- a/src/output_writers.jl
+++ b/src/output_writers.jl
@@ -1,3 +1,7 @@
+####
+#### Output writer utilities
+####
+
 ext(fw::OutputWriter) = throw("Extension for $(typeof(fw)) is not implemented.")
 
 # When saving stuff to disk like a JLD2 file, `saveproperty!` is used, which
@@ -50,6 +54,13 @@ has_reference(T, ::AbstractArray{<:Number}) = false
 has_reference(::Type{Function}, ::Field) = false
 has_reference(::Type{T}, ::NTuple{N, <:T}) where {N, T} = true
 
+"""
+    has_reference(has_type, obj)
+
+Check (or attempt to check) if `obj` contains, somewhere among its 
+subfields and subfields of fields, a reference to an object of type 
+`has_type`. This function doesn't always work.
+"""
 function has_reference(has_type, obj)
     if typeof(obj) <: has_type
         return true
@@ -61,7 +72,6 @@ function has_reference(has_type, obj)
         return typeof(obj) <: has_type
     end
 end
-
 
 ####
 ####  JLD2 output writer
@@ -186,7 +196,6 @@ function jld2output!(path, iter, time, data, kwargs)
     return
 end
 
-
 function start_next_file(model::Model, fw::JLD2OutputWriter)
     verbose = fw.verbose
     sz = filesize(fw.filepath)
@@ -251,7 +260,6 @@ function FieldOutputs(fields)
     nfields = length(fields)
     return Dict((names[i], FieldOutput(fields[i])) for i in 1:nfields)
 end
-
 
 ####
 #### Binary output writer

--- a/src/turbulence_closures/TurbulenceClosures.jl
+++ b/src/turbulence_closures/TurbulenceClosures.jl
@@ -51,7 +51,7 @@ abstract type AbstractAnisotropicMinimumDissipation{T} <: IsotropicDiffusivity{T
 @inline ∇_κ_∇S(args...) = ∇_κ_∇c(args...)
 
 # Fallback constructor for diffusivity types without precomputed diffusivities:
-TurbulentDiffusivities(arch::Architecture, grid::Grid, args...) = nothing
+TurbulentDiffusivities(arch::AbstractArchitecture, grid::AbstractGrid, args...) = nothing
 
 include("turbulence_closure_utils.jl")
 include("closure_operators.jl")

--- a/src/turbulence_closures/TurbulenceClosures.jl
+++ b/src/turbulence_closures/TurbulenceClosures.jl
@@ -22,23 +22,18 @@ export
   ∇_κ_∇S,
   ∂ⱼ_2ν_Σ₁ⱼ,
   ∂ⱼ_2ν_Σ₂ⱼ,
-  ∂ⱼ_2ν_Σ₃ⱼ
+  ∂ⱼ_2ν_Σ₃ⱼ,
+
+  cell_diffusion_timescale
 
 using
   Oceananigans,
   Oceananigans.Operators,
   GPUifyLoops
 
-using Oceananigans: Architecture, Grid, buoyancy_perturbation
+using Oceananigans: Architecture, Grid, AbstractModel, buoyancy_perturbation
 
 @hascuda using CUDAdrv, CUDAnative
-
-abstract type TurbulenceClosure{T} end
-abstract type IsotropicDiffusivity{T} <: TurbulenceClosure{T} end
-abstract type TensorDiffusivity{T} <: TurbulenceClosure{T} end
-
-@inline ∇_κ_∇T(args...) = ∇_κ_∇c(args...)
-@inline ∇_κ_∇S(args...) = ∇_κ_∇c(args...)
 
 # Approximate viscosities and thermal diffusivities for seawater
 # at 20ᵒC and 35 psu, according to Sharqawy et al., "Thermophysical 
@@ -46,47 +41,31 @@ abstract type TensorDiffusivity{T} <: TurbulenceClosure{T} end
 const ν₀ = 1.05e-6
 const κ₀ = 1.46e-7
 
-"""
-    typed_keyword_constructor(T, Closure; kwargs...)
+abstract type TurbulenceClosure{T} end
+abstract type IsotropicDiffusivity{T} <: TurbulenceClosure{T} end
+abstract type TensorDiffusivity{T} <: TurbulenceClosure{T} end
+abstract type AbstractSmagorinsky{T} <: IsotropicDiffusivity{T} end
+abstract type AbstractAnisotropicMinimumDissipation{T} <: IsotropicDiffusivity{T} end
 
-Return an object `Closure` with fields provided by `kwargs`
-converted to type `T`. Mainly provided for converting between
-different float types when working with constructors associated
-with types defined via `Base.@kwdef`.
-"""
-function typed_keyword_constructor(T, Closure; kwargs...)
-    closure = Closure(; kwargs...)
-    names = fieldnames(Closure)
-    vals = [getproperty(closure, name) for name in names]
-    return Closure{T}(vals...)
-end
+@inline ∇_κ_∇T(args...) = ∇_κ_∇c(args...)
+@inline ∇_κ_∇S(args...) = ∇_κ_∇c(args...)
 
-Base.eltype(::TurbulenceClosure{T}) where T = T
+# Fallback constructor for diffusivity types without precomputed diffusivities:
+TurbulentDiffusivities(arch::Architecture, grid::Grid, args...) = nothing
 
+include("turbulence_closure_utils.jl")
 include("closure_operators.jl")
 include("velocity_tracer_gradients.jl")
+
 include("constant_diffusivity_closures.jl")
 include("smagorinsky.jl")
 include("rozema_anisotropic_minimum_dissipation.jl")
 include("verstappen_anisotropic_minimum_dissipation.jl")
 
+include("turbulence_closure_diagnostics.jl")
+
 # Some value judgements here:
 const AnisotropicMinimumDissipation = VerstappenAnisotropicMinimumDissipation
 const ConstantSmagorinsky = DeardorffSmagorinsky
-
-# For easy conversion of the float type associated with a turbulence closure struct:
-basetype(::ConstantSmagorinsky) = ConstantSmagorinsky
-basetype(::BlasiusSmagorinsky) = BlasiusSmagorinsky
-basetype(::ConstantIsotropicDiffusivity) = ConstantIsotropicDiffusivity
-basetype(::AnisotropicMinimumDissipation) = AnisotropicMinimumDissipation
-basetype(::RozemaAnisotropicMinimumDissipation) = RozemaAnisotropicMinimumDissipation
-
-function Base.convert(::TurbulenceClosure{T2}, closure::TurbulenceClosure{T1}) where {T1, T2}
-    paramdict = Dict((p, convert(T2, getproperty(closure, p))) for p in propertynames(closure))
-    return basetype(closure)(T2; paramdict...)
-end
-
-# Fallback constructor for diffusivity types withotu precomputed diffusivities:
-TurbulentDiffusivities(arch::Architecture, grid::Grid, args...) = nothing
 
 end # module

--- a/src/turbulence_closures/rozema_anisotropic_minimum_dissipation.jl
+++ b/src/turbulence_closures/rozema_anisotropic_minimum_dissipation.jl
@@ -1,4 +1,4 @@
-struct RozemaAnisotropicMinimumDissipation{T} <: IsotropicDiffusivity{T}
+struct RozemaAnisotropicMinimumDissipation{T} <: AbstractAnisotropicMinimumDissipation{T}
      C :: T
     Cb :: T
      ν :: T

--- a/src/turbulence_closures/smagorinsky.jl
+++ b/src/turbulence_closures/smagorinsky.jl
@@ -1,5 +1,3 @@
-abstract type AbstractSmagorinsky{T} <: IsotropicDiffusivity{T} end
-
 @inline geo_mean_Δᶠ(i, j, k, grid::RegularCartesianGrid{T}) where T = 
     (grid.Δx * grid.Δy * grid.Δz)^T(1/3)
 

--- a/src/turbulence_closures/turbulence_closure_diagnostics.jl
+++ b/src/turbulence_closures/turbulence_closure_diagnostics.jl
@@ -1,0 +1,31 @@
+# Timescale for diffusion across one cell
+min_Δxyz(grid) = min(grid.Δx, grid.Δy, grid.Δz)
+min_Δxy(grid) = min(grid.Δx, grid.Δy)
+min_Δz(grid) = grid.Δz
+
+"Returns the time-scale for diffusion on a regular grid across a single grid cell."
+function cell_diffusion_timescale(model::AbstractModel{TS, <:IsotropicDiffusivity}) where TS
+    Δ = min_Δxyz(model.grid)
+    return min(Δ^2 / model.closure.ν, Δ^2 / model.closure.κ)
+end
+
+function cell_diffusion_timescale(model::AbstractModel{TS, <:TensorDiffusivity}) where TS
+    Δh = min_Δxy(model.grid)
+    Δz = min_Δz(model.grid)
+    return min(Δz^2 / model.closure.νv, Δh^2 / model.closure.νh,
+               Δz^2 / model.closure.κv, Δh^2 / model.closure.κh)
+end
+
+function cell_diffusion_timescale(model::AbstractModel{TS, <:AbstractSmagorinsky}) where TS
+    Δ = min_Δxyz(model.grid)
+    max_νκ = maximum(model.diffusivities.νₑ.data.parent) * max(1, 1/model.closure.Pr)
+    return min(Δ^2 / max_νκ, Δ^2 / model.closure.κ)
+end
+
+function cell_diffusion_timescale(model::AbstractModel{TS, <:AbstractAnisotropicMinimumDissipation}) where TS
+    Δ = min_Δxyz(model.grid)
+    max_ν = maximum(model.diffusivities.νₑ.data.parent)
+    max_κ = max(Tuple(maximum(κₑ.data.parent) for κₑ in model.diffusivities.κₑ)...)
+    return min(Δ^2 / max_ν, Δ^2 / max_κ)
+end
+

--- a/src/turbulence_closures/turbulence_closure_utils.jl
+++ b/src/turbulence_closures/turbulence_closure_utils.jl
@@ -1,0 +1,24 @@
+Base.eltype(::TurbulenceClosure{T}) where T = T
+
+"""
+    typed_keyword_constructor(T, Closure; kwargs...)
+
+Return an object `Closure` with fields provided by `kwargs`
+converted to type `T`. Mainly provided for converting between
+different float types when working with constructors associated
+with types defined via `Base.@kwdef`.
+"""
+function typed_keyword_constructor(T, Closure; kwargs...)
+    closure = Closure(; kwargs...)
+    names = fieldnames(Closure)
+    vals = [getproperty(closure, name) for name in names]
+    return Closure{T}(vals...)
+end
+
+function Base.convert(::TurbulenceClosure{T2}, closure::TurbulenceClosure{T1}) where {T1, T2}
+    paramdict = Dict((p, convert(T2, getproperty(closure, p))) for p in propertynames(closure))
+    Closure = typeof(closure).name.wrapper
+    return Closure(T2; paramdict...)
+end
+
+

--- a/src/turbulence_closures/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/turbulence_closures/verstappen_anisotropic_minimum_dissipation.jl
@@ -1,4 +1,4 @@
-struct VerstappenAnisotropicMinimumDissipation{T} <: IsotropicDiffusivity{T}
+struct VerstappenAnisotropicMinimumDissipation{T} <: AbstractAnisotropicMinimumDissipation{T}
      C :: T
     Cb :: T
      ν :: T

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,7 +93,7 @@ Base.zeros(arch, grid::Grid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, N
 # Timescale for advection across one cell
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
-function cell_advection_timescale(u, v, w, grid::RegularCartesianGrid)
+function cell_advection_timescale(u, v, w, grid)
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
     wmax = maximum(abs, w)
@@ -113,9 +113,9 @@ cell_advection_timescale(model) =
 
 # Timescale for diffusion across one cell
 
-min_Δxyz(grid::RegularCartesianGrid) = min(grid.Δx, grid.Δy, grid.Δz)
-min_Δxy(grid::RegularCartesianGrid) = min(grid.Δx, grid.Δy)
-min_Δz(grid::RegularCartesianGrid) = grid.Δz
+min_Δxyz(grid) = min(grid.Δx, grid.Δy, grid.Δz)
+min_Δxy(grid) = min(grid.Δx, grid.Δy)
+min_Δz(grid) = grid.Δz
 
 "Returns the time-scale for diffusion on a regular grid across a single grid cell."
 function cell_diffusion_timescale(model::Model{TS, <:ConstantIsotropicDiffusivity}) where TS

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,7 +42,6 @@ function prettytime(t)
     return @sprintf("%.3f", value) * " " * units
 end
 
-
 # Source: https://stackoverflow.com/a/1094933
 function pretty_filesize(s, suffix="B")
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]
@@ -63,7 +62,7 @@ function Base.zeros(T, ::CPU, grid)
     k1, k2 = 1 - grid.Hz, grid.Nz + grid.Hz
 
     underlying_data = zeros(T, grid.Tx, grid.Ty, grid.Tz)
-    OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
+    return OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
 end
 
 function Base.zeros(T, ::GPU, grid)
@@ -74,7 +73,7 @@ function Base.zeros(T, ::GPU, grid)
 
     underlying_data = CuArray{T}(undef, grid.Tx, grid.Ty, grid.Tz)
     underlying_data .= 0  # Gotta do this otherwise you might end up with a few NaN values!
-    OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
+    return OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
 end
 
 Base.zeros(T, ::CPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz)
@@ -89,8 +88,6 @@ Base.zeros(arch, grid::Grid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, N
 ####
 
 # Note: these functions will have to be refactored to work on non-uniform grids.
-
-# Timescale for advection across one cell
 
 "Returns the time-scale for advection on a regular grid across a single grid cell."
 function cell_advection_timescale(u, v, w, grid)
@@ -112,7 +109,6 @@ cell_advection_timescale(model) =
                              model.grid)
 
 # Timescale for diffusion across one cell
-
 min_Δxyz(grid) = min(grid.Δx, grid.Δy, grid.Δz)
 min_Δxy(grid) = min(grid.Δx, grid.Δy)
 min_Δz(grid) = grid.Δz
@@ -197,10 +193,6 @@ tupleit(a::AbstractArray) = Tuple(a)
 tupleit(nt) = tuple(nt)
 
 parenttuple(obj) = Tuple(f.data.parent for f in obj)
-
-####
-#### Data tuples
-####
 
 @inline datatuple(obj::Nothing) = nothing
 @inline datatuple(obj::AbstractArray) = obj

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,11 +29,16 @@ function prettytime(t)
         value, units = t * 1e6, "μs"
     elseif t < 1
         value, units = t * 1e3, "ms"
-    elseif t < 60
+    elseif t < minute
         value, units = t, "s"
+    elseif t < hour
+        value, units = t / minute, "min"
+    elseif t < day
+        value, units = t / hour, "hr"
     else
-        value, units = t / 60, "min"
+        value, units = t / day, "day"
     end
+
     return @sprintf("%.3f", value) * " " * units
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,38 +108,6 @@ cell_advection_timescale(model) =
                              model.velocities.w.data.parent,
                              model.grid)
 
-# Timescale for diffusion across one cell
-min_Δxyz(grid) = min(grid.Δx, grid.Δy, grid.Δz)
-min_Δxy(grid) = min(grid.Δx, grid.Δy)
-min_Δz(grid) = grid.Δz
-
-"Returns the time-scale for diffusion on a regular grid across a single grid cell."
-function cell_diffusion_timescale(model::Model{TS, <:ConstantIsotropicDiffusivity}) where TS
-    Δ = min_Δxyz(model.grid)
-    return min(Δ^2 / model.closure.ν, Δ^2 / model.closure.κ)
-end
-
-function cell_diffusion_timescale(model::Model{TS, <:ConstantAnisotropicDiffusivity}) where TS
-    Δh = min_Δxy(model.grid)
-    Δz = min_Δz(model.grid)
-    return min(Δz^2 / model.closure.νv, Δh^2 / model.closure.νh,
-               Δz^2 / model.closure.κv, Δh^2 / model.closure.κh)
-end
-
-function cell_diffusion_timescale(model::Model{TS, <:AbstractSmagorinsky}) where TS
-    Δ = min_Δxyz(model.grid)
-    max_νκ = maximum(model.diffusivities.νₑ.data.parent) * max(1, 1/model.closure.Pr)
-    return min(Δ^2 / max_νκ, Δ^2 / model.closure.κ)
-end
-
-function cell_diffusion_timescale(model::Model{TS, <:AnisotropicMinimumDissipation}) where TS
-    Δ = min_Δxyz(model.grid)
-    max_ν = maximum(model.diffusivities.νₑ.data.parent)
-    max_κ = max(Tuple(maximum(κₑ.data.parent) for κₑ in model.diffusivities.κₑ)...)
-    return min(Δ^2 / max_ν, Δ^2 / max_κ)
-end
-
-
 ####
 #### Adaptive time stepping
 ####

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,7 +88,12 @@ Base.zeros(arch, grid::Grid{T}, Nx, Ny, Nz) where T = zeros(T, arch, grid, Nx, N
 #### Courant–Friedrichs–Lewy (CFL) condition number calculation
 ####
 
-function cell_advection_timescale(u, v, w, grid)
+# Note: these functions will have to be refactored to work on non-uniform grids.
+
+# Timescale for advection across one cell
+
+"Returns the time-scale for advection on a regular grid across a single grid cell."
+function cell_advection_timescale(u, v, w, grid::RegularCartesianGrid)
     umax = maximum(abs, u)
     vmax = maximum(abs, v)
     wmax = maximum(abs, w)
@@ -105,6 +110,39 @@ cell_advection_timescale(model) =
                              model.velocities.v.data.parent,
                              model.velocities.w.data.parent,
                              model.grid)
+
+# Timescale for diffusion across one cell
+
+min_Δxyz(grid::RegularCartesianGrid) = min(grid.Δx, grid.Δy, grid.Δz)
+min_Δxy(grid::RegularCartesianGrid) = min(grid.Δx, grid.Δy)
+min_Δz(grid::RegularCartesianGrid) = grid.Δz
+
+"Returns the time-scale for diffusion on a regular grid across a single grid cell."
+function cell_diffusion_timescale(model::Model{TS, <:ConstantIsotropicDiffusivity}) where TS
+    Δ = min_Δxyz(model.grid)
+    return min(Δ^2 / model.closure.ν, Δ^2 / model.closure.κ)
+end
+
+function cell_diffusion_timescale(model::Model{TS, <:ConstantAnisotropicDiffusivity}) where TS
+    Δh = min_Δxy(model.grid)
+    Δz = min_Δz(model.grid)
+    return min(Δz^2 / model.closure.νv, Δh^2 / model.closure.νh,
+               Δz^2 / model.closure.κv, Δh^2 / model.closure.κh)
+end
+
+function cell_diffusion_timescale(model::Model{TS, <:AbstractSmagorinsky}) where TS
+    Δ = min_Δxyz(model.grid)
+    max_νκ = maximum(model.diffusivities.νₑ.data.parent) * max(1, 1/model.closure.Pr)
+    return min(Δ^2 / max_νκ, Δ^2 / model.closure.κ)
+end
+
+function cell_diffusion_timescale(model::Model{TS, <:AnisotropicMinimumDissipation}) where TS
+    Δ = min_Δxyz(model.grid)
+    max_ν = maximum(model.diffusivities.νₑ.data.parent)
+    max_κ = max(Tuple(maximum(κₑ.data.parent) for κₑ in model.diffusivities.κₑ)...)
+    return min(Δ^2 / max_ν, Δ^2 / max_κ)
+end
+
 
 ####
 #### Adaptive time stepping

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,7 @@ using
     Oceananigans.TurbulenceClosures
 
 using Oceananigans: PoissonSolver, PPN, PNN, solve_poisson_3d!,
-                    parentdata,
-                    buoyancy_perturbation, fill_halo_regions!, run_diagnostic
+                    parentdata, buoyancy_perturbation, fill_halo_regions!, run_diagnostic
 
 archs = (CPU(),)
 @hascuda archs = (CPU(), GPU())

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -32,7 +32,7 @@ function nan_checker_aborts_simulation(arch, FT)
     model = BasicModel(N = (16, 16, 2), L = (1, 1, 1), architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
-    nc = NaNChecker(model; frequency=1)
+    nc = NaNChecker(model; frequency=1, fields=Dict(:w => model.velocities.w.data.parent))
     push!(model.diagnostics, nc)
 
     model.velocities.w[4, 3, 2] = NaN

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -40,6 +40,58 @@ function nan_checker_aborts_simulation(arch, FT)
     time_step!(model, 1, 1);
 end
 
+TestModel(::GPU, FT, ν=1.0, Δx=0.5) = BasicModel(N=(16, 16, 16), L=(16*Δx, 16*Δx, 16*Δx), 
+                                                 architecture=GPU(), float_type=FT, ν=ν, κ=ν)
+
+TestModel(::CPU, FT, ν=1.0, Δx=0.5) = BasicModel(N=(3, 3, 3), L=(3*Δx, 3*Δx, 3*Δx), 
+                                                 architecture=CPU(), float_type=FT, ν=ν, κ=ν)
+    
+
+function max_abs_field_diagnostic_is_correct(arch, FT)
+    model = TestModel(arch, FT)
+    set!(model.velocities.u, rand(size(model.grid)))
+    u_max = FieldMaximum(abs, model.velocities.u)
+    return u_max(model) == maximum(abs, model.velocities.u.data.parent)
+end
+
+function advective_cfl_diagnostic_is_correct(arch, FT)
+    model = TestModel(arch, FT)
+
+    Δt = FT(1.3e-6)
+    Δx = FT(model.grid.Δx)
+    u₀ = FT(1.2)
+    CFL_by_hand = Δt * u₀ / Δx
+
+    model.velocities.u.data.parent .= u₀
+    cfl = AdvectiveCFL(FT(Δt))
+
+    return cfl(model) ≈ CFL_by_hand
+end
+
+function diffusive_cfl_diagnostic_is_correct(arch, FT)
+    Δt = FT(1.3e-6)
+    Δx = FT(0.5)
+    ν = FT(1.2)
+    CFL_by_hand = Δt * ν / Δx^2
+
+    model = TestModel(arch, FT, ν, Δx)
+    cfl = DiffusiveCFL(FT(Δt))
+
+    return cfl(model) ≈ CFL_by_hand
+end
+
+get_iteration(model) = model.clock.iteration
+
+function timeseries_diagnostic_works(arch, FT)
+    model = TestModel(arch, FT)
+    iter_diag = Timeseries(get_iteration, model; frequency=1)
+    push!(model.diagnostics, iter_diag)
+    Δt = 1e-16
+    time_step!(model, 1, Δt)
+
+    return iter_diag.time[end] == FT(Δt) && iter_diag.data[end] == 1
+end
+
 @testset "Diagnostics" begin
     println("Testing diagnostics...")
 
@@ -58,6 +110,18 @@ end
             println("  Testing NaN Checker [$(typeof(arch))]")
             for FT in float_types
                 @test_throws ErrorException nan_checker_aborts_simulation(arch, FT)
+            end
+        end
+    end
+
+    for arch in archs
+        @testset "Miscellaneous timeseries diagnostics [$(typeof(arch))]" begin
+            println("  Testing miscellaneous timeseries diagnostics [$(typeof(arch))]")
+            for FT in float_types
+                @test timeseries_diagnostic_works(arch, FT)
+                @test diffusive_cfl_diagnostic_is_correct(arch, FT)
+                @test advective_cfl_diagnostic_is_correct(arch, FT)
+                @test max_abs_field_diagnostic_is_correct(arch, FT)
             end
         end
     end


### PR DESCRIPTION
This PR adds a new `Diagnostic` type called `Timeseries`, which takes a function or callable object of model (anything that has a method of the form `obj(model)`), and stores the result in `data` vector and the time-of-collection in a `time` vector.

It also adds an object called `CFL` which computes the Courant-Freidrichs-Lewy number. `CFL` associates with a function `timescale`, which is used to provide convenience constructors `AdvectiveCFL` and `DiffusiveCFL`.

We also add an object for computing `maximum(f, field.data.parent)` for `field`s, for an element wise operation `f`.

The PR includes tests and docstrings for this functionality.