### PR TITLE
More general and compact Field implementation

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -83,6 +83,7 @@ import
     CUDAapi,
     GPUifyLoops
 
+using Base: @propagate_inbounds
 using Statistics: mean
 using CUDAapi: has_cuda
 using GPUifyLoops: @launch, @loop, @unroll

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -115,9 +115,6 @@ abstract type AbstractTimeseriesDiagnostic <: AbstractDiagnostic end
 struct CPU <: AbstractArchitecture end
 struct GPU <: AbstractArchitecture end
 
-architecture(::Array) = CPU()
-@hascuda architecture(::CuArray) = GPU()
-
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()
 
@@ -134,6 +131,9 @@ end
         println(dev)
     end
 end
+
+architecture(::Array) = CPU()
+@hascuda architecture(::CuArray) = GPU()
 
 function buoyancy_perturbation end
 

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -19,7 +19,7 @@ export
     RegularCartesianGrid,
 
     # Fields
-    CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
+    Field, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
     data, set!, set_ic!,
     nodes, xnodes, ynodes, znodes,
 
@@ -107,6 +107,9 @@ end
 abstract type AbstractArchitecture end
 struct CPU <: AbstractArchitecture end
 struct GPU <: AbstractArchitecture end
+
+architecture(::Array) = CPU()
+@hascuda architecture(::CuArray) = GPU()
 
 device(::CPU) = GPUifyLoops.CPU()
 device(::GPU) = GPUifyLoops.CUDA()

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -109,7 +109,7 @@ size(g::RegularCartesianGrid) = (g.Nx, g.Ny, g.Nz)
 eltype(g::RegularCartesianGrid{T}) where T = T
 
 show(io::IO, g::RegularCartesianGrid) =
-    print(io, "$(g.dim)-dimensional ($(typeof(g.Lx))) regular Cartesian grid\n",
+    print(io, "($(typeof(g.Lx))) regular Cartesian grid\n",
               "(Nx, Ny, Nz) = ", (g.Nx, g.Ny, g.Nz), '\n',
               "(Lx, Ly, Lz) = ", (g.Lx, g.Ly, g.Lz), '\n',
               "(Δx, Δy, Δz) = ", (g.Δx, g.Δy, g.Δz))

--- a/src/models.jl
+++ b/src/models.jl
@@ -166,7 +166,6 @@ end
 ##### Model initialization utilities
 #####
 
-arch(model::Model{A}) where A <: AbstractArchitecture = A
 float_type(m::Model) = eltype(model.grid)
 add_bcs!(model::Model; kwargs...) = add_bcs(model.boundary_conditions; kwargs...)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,8 @@
 # Adapt an offset CuArray to work nicely with CUDA kernels.
 Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(adapt(to, parent(x)), x.offsets)
 
+zerofunk(args...) = 0
+
 # Need to adapt SubArray indices as well.
 # See: https://github.com/JuliaGPU/Adapt.jl/issues/16
 #Adapt.adapt_structure(to, A::SubArray{<:Any,<:Any,AT}) where {AT} =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -51,25 +51,24 @@ end
 #### Creating fields by dispatching on architecture
 ####
 
-function Base.zeros(T, ::CPU, grid)
+function OffsetArray(underlying_data, grid)
     # Starting and ending indices for the offset array.
     i1, i2 = 1 - grid.Hx, grid.Nx + grid.Hx
     j1, j2 = 1 - grid.Hy, grid.Ny + grid.Hy
     k1, k2 = 1 - grid.Hz, grid.Nz + grid.Hz
 
+    return OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
+end
+
+function Base.zeros(T, ::CPU, grid)
     underlying_data = zeros(T, grid.Tx, grid.Ty, grid.Tz)
-    OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
+    return OffsetArray(underlying_data, grid)
 end
 
 function Base.zeros(T, ::GPU, grid)
-    # Starting and ending indices for the offset CuArray.
-    i1, i2 = 1 - grid.Hx, grid.Nx + grid.Hx
-    j1, j2 = 1 - grid.Hy, grid.Ny + grid.Hy
-    k1, k2 = 1 - grid.Hz, grid.Nz + grid.Hz
-
     underlying_data = CuArray{T}(undef, grid.Tx, grid.Ty, grid.Tz)
     underlying_data .= 0  # Gotta do this otherwise you might end up with a few NaN values!
-    OffsetArray(underlying_data, i1:i2, j1:j2, k1:k2)
+    return OffsetArray(underlying_data, grid)
 end
 
 Base.zeros(T, ::CPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz)


### PR DESCRIPTION
This PR refactors the implementation of the Field abstraction. There is now only one type of `Field`,  with the type signature 

```julia
Field{Lx, Ly, Lz, A, G}
```

where `Lx, Ly, Lz` denote the 'locations' of the field within a cell. For example, a `CellField` is now defined via

```julia
const CellField = Field{Cell, Cell, Cell}
```

Let's consider this PR carefully and ensure that it makes sense.

Resolves #298.