### PR TITLE
Fix example test

### DIFF
--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -32,11 +32,11 @@ ubcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fu))
 Tbcs = HorizontallyPeriodicBCs(top=BoundaryCondition(Flux, Fθ), bottom=BoundaryCondition(Gradient, dTdz))
 
 # Instantiate the model
-model = Model(      
+model = Model(
            architecture = CPU(), # GPU() # this example will run on the GPU if cuda is available.
                    grid = RegularCartesianGrid(N = (N, N, N), L = (N*Δ, N*Δ, N*Δ)),
-                    eos = LinearEquationOfState(βT=βT, βS=0.0),
-              constants = PlanetaryConstants(f=f, g=g),
+               coriolis = FPlane(f=f),
+               buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=βT)),
                 closure = AnisotropicMinimumDissipation(), # closure = ConstantSmagorinsky(),
     boundary_conditions = BoundaryConditions(u=ubcs, T=Tbcs)
 )

--- a/examples/deepening_mixed_layer.jl
+++ b/examples/deepening_mixed_layer.jl
@@ -43,10 +43,10 @@ model = Model(
 
 # Set initial condition. Initial velocity and salinity fluctuations needed for AMD.
 Ξ(z) = randn() * z / model.grid.Lz * (1 + z / model.grid.Lz) # noise
-T₀(x, y, z) = 20 + dTdz * z + dTdz * model.grid.Lz * 1e-6 * Ξ(z)
+T0(x, y, z) = 20 + dTdz * z + dTdz * model.grid.Lz * 1e-6 * Ξ(z)
 ϵ₀(x, y, z) = 1e-4 * Ξ(z)
 
-set!(model, u=ϵ₀, w=ϵ₀, T=T₀, S=ϵ₀)
+set!(model, u=ϵ₀, w=ϵ₀, T=T0, S=ϵ₀)
 
 ####
 #### Set up output

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -17,7 +17,7 @@ function run_deepening_mixed_layer_example(arch)
 
     try
         include(test_script_filepath)
-    catch e
+    catch err
         @error sprint(showerror, err)
         rm(test_script_filepath)
         return false


### PR DESCRIPTION
Cherry picked some commits from PR #381 to fix the example test.

One thing that's going to be annoying about testing example scripts is that they evaluate in global scope when including them, so it's going to be easy to get variable name conflicts...

Not sure how to get around this as we agreed not to use functions for examples.