### PR TITLE
Get rid of docs replacement warnings on CPU

### DIFF
--- a/src/fields.jl
+++ b/src/fields.jl
@@ -185,10 +185,7 @@ function set!(u::AbstractCPUField, v::Array)
     return nothing
 end
 
-"Set the GPU field `u` to the array `v`."
-#@hascuda function set!(u::AbstractField{A}, v::Array) where {
-#    A <: OffsetArray{T, D, <:CuArray} where {T, D}}
-
+# Set the GPU field `u` to the array `v`.
 @hascuda function set!(u::AbstractGPUField, v::Array)
     FieldType = fieldtype(u)
     v_field = FieldType(location(u), CPU(), u.grid)
@@ -197,7 +194,7 @@ end
     return nothing
 end
 
-"Set the GPU field `u` to the CuArray `v`."
+# Set the GPU field `u` to the CuArray `v`.
 @hascuda function set!(u::AbstractGPUField, v::CuArray)
     @launch device(GPU()) config=launch_config(u.grid, 3) _set_gpu!(u.data, v, u.grid)
     return nothing
@@ -214,16 +211,16 @@ function _set_gpu!(u, v, grid)
     return nothing
 end
 
-"Set the GPU field `u` data to the CPU field data of `v`."
+# Set the GPU field `u` data to the CPU field data of `v`.
 @hascuda set!(u::AbstractGPUField, v::AbstractCPUField) = copyto!(u.data.parent, v.data.parent)
 
-"Set the CPU field `u` data to the GPU field data of `v`."
+# Set the CPU field `u` data to the GPU field data of `v`.
 @hascuda set!(u::AbstractCPUField, v::AbstractGPUField) = u.data.parent .= Array(v.data.parent)
 
 "Set the CPU field `u` data to the function `f(x, y, z)`."
 set!(u::AbstractField, f::Function) = data(u) .= f.(nodes(u)...)
 
-"Set the GPU field `u` data to the function `f(x, y, z)`."
+# Set the GPU field `u` data to the function `f(x, y, z)`.
 @hascuda function set!(u::AbstractGPUField, f::Function)
     FieldType = fieldtype(u)
     u_cpu = FieldType(location(u), CPU(), u.grid)


### PR DESCRIPTION
We used docstrings above the `@hascuda` macro to document the `set!` function for GPUs, but on CPUs `@hascuda` evaluates to `nothing` and Julia thinks we're trying to override the docstring for `nothing`.

```
┌ Warning: Replacing docs for `Core.nothing :: Union{}` in module `Oceananigans`
└ @ Base.Docs docs/Docs.jl:223
┌ Warning: Replacing docs for `Core.nothing :: Union{}` in module `Oceananigans`
└ @ Base.Docs docs/Docs.jl:223
┌ Warning: Replacing docs for `Core.nothing :: Union{}` in module `Oceananigans`
└ @ Base.Docs docs/Docs.jl:223
```

Since the main `set!` function is public and documented, these backend GPU `set!` functions can live with comments instead of docstrings.

These warnings would show up whenever someone imported or ran `using Oceananigans` so they were very public and we should get rid of them.