### PR TITLE
Allow v1.3 GPU tests to fail on GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ test:v1.2:
 
 test:v1.3:
   extends: .test:v1.3
+  allow_failure: true
 
 test:dev:
   extends: .test:dev


### PR DESCRIPTION
Until we figure out why v1.3 and DEV jobs time out on GitLab CI we can just allow v1.3 to fail.

v1.3 hasn't been released yet so makes sense to allow failures anyways.