### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 authors = ["Ali Ramadhan <ali.hh.ramadhan@gmail.com>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Going to release a new version as quite a bit has been merged since v0.11.0, and arbitrary tracers (PR #452) will probably be the focus of v0.12.0.