### PR TITLE
A Beta Plane option for Coriolis

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -12,7 +12,7 @@ export
     CPU, GPU,
 
     # Constants
-    FPlane,
+    FPlane, BetaPlane,
     second, minute, hour, day,
 
     # Grids

--- a/src/coriolis.jl
+++ b/src/coriolis.jl
@@ -95,9 +95,9 @@ function BetaPlane(T=Float64; f₀=nothing, β=nothing,
 end
 
 @inline x_f_cross_U(i, j, k, grid, coriolis::BetaPlane, U) =
-    @inbounds (coriolis.f₀ + coriolis.β * grid.yC[j]) * ▶xy_fca(i, j, k, grid, U.v)
+    @inbounds - (coriolis.f₀ + coriolis.β * grid.yC[j]) * ▶xy_fca(i, j, k, grid, U.v)
 
 @inline y_f_cross_U(i, j, k, grid, coriolis::BetaPlane, U) =
-    @inbounds (coriolis.f₀ + coriolis.β * grid.yF[j]) * ▶xy_cfa(i, j, k, grid, U.v) 
+    @inbounds   (coriolis.f₀ + coriolis.β * grid.yF[j]) * ▶xy_cfa(i, j, k, grid, U.u) 
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{T}, ::BetaPlane, U) where T = zero(T)

--- a/src/coriolis.jl
+++ b/src/coriolis.jl
@@ -81,8 +81,10 @@ function BetaPlane(T=Float64; f₀=nothing, β=nothing,
     f_and_β = f₀ != nothing && β != nothing
     planet_parameters = rotation_rate != nothing && latitude != nothing && radius != nothing
 
-    (f_and_β || planet_parameters) && !(f_and_β && planet_parameters) || throw(ArgumentError(
-        "Either keywords f₀ and β must be specified, *or* all of rotation_rate, latitude, and radius."))
+    (f_and_β && all(Tuple(p === nothing for p in (rotation_rate, latitude, radius)))) || 
+    (planet_parameters && all(Tuple(p === nothing for p in (f₀, β)))) ||
+        throw(ArgumentError("Either both keywords f₀ and β must be specified, 
+                            *or* all of rotation_rate, latitude, and radius."))
 
     if planet_parameters
         f₀ = 2rotation_rate * sind(latitude)
@@ -93,9 +95,9 @@ function BetaPlane(T=Float64; f₀=nothing, β=nothing,
 end
 
 @inline x_f_cross_U(i, j, k, grid, coriolis::BetaPlane, U) =
-    @inbounds (coriolis.f₀ + coriolis.β * grid.yC[j]) * ▶xy_fca(i, j, k, grid, v)
+    @inbounds (coriolis.f₀ + coriolis.β * grid.yC[j]) * ▶xy_fca(i, j, k, grid, U.v)
 
 @inline y_f_cross_U(i, j, k, grid, coriolis::BetaPlane, U) =
-    @inbounds (coriolis.f₀ + coriolis.β * grid.yF[j]) * ▶xy_cfa(i, j, k, grid, v) 
+    @inbounds (coriolis.f₀ + coriolis.β * grid.yF[j]) * ▶xy_cfa(i, j, k, grid, U.v) 
 
 @inline z_f_cross_U(i, j, k, grid::AbstractGrid{T}, ::BetaPlane, U) where T = zero(T)

--- a/test/test_coriolis.jl
+++ b/test/test_coriolis.jl
@@ -1,14 +1,27 @@
-function instantiate_coriolis(T)
+function instantiate_fplane(T)
     coriolis = FPlane(T, f=π)
     return coriolis.f == T(π)
 end
+
+function instantiate_betaplane_1(T)
+    coriolis = BetaPlane(T, f₀=π, β=2π)
+    return coriolis.f₀ == T(π)
+end
+
+function instantiate_betaplane_2(T)
+    coriolis = BetaPlane(T, latitude=70, radius=2π, rotation_rate=3π)
+    return coriolis.f₀ == T(6π * sind(70))
+end
+
 
 @testset "Coriolis" begin
     println("Testing Coriolis...")
 
     @testset "Coriolis" begin
         for T in float_types
-            @test instantiate_coriolis(T)
+            @test instantiate_fplane(T)
+            @test instantiate_betaplane_1(T)
+            @test instantiate_betaplane_2(T)
         end
     end
 end

--- a/test/test_coriolis.jl
+++ b/test/test_coriolis.jl
@@ -13,7 +13,6 @@ function instantiate_betaplane_2(T)
     return coriolis.f₀ == T(6π * sind(70))
 end
 
-
 @testset "Coriolis" begin
     println("Testing Coriolis...")
 
@@ -22,6 +21,11 @@ end
             @test instantiate_fplane(T)
             @test instantiate_betaplane_1(T)
             @test instantiate_betaplane_2(T)
+            # Non-exhaustively test that BetaPlane throws an ArgumentError
+            @test_throws ArgumentError BetaPlane(T, f₀=1)
+            @test_throws ArgumentError BetaPlane(T, β=1)
+            @test_throws ArgumentError BetaPlane(T, latitude=70)
+            @test_throws ArgumentError BetaPlane(T, f₀=1e-4, β=1e-11, latitude=70)
         end
     end
 end

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -5,6 +5,17 @@ function time_stepping_works(arch, FT, Closure)
     return true # test that no errors/crashes happen when time stepping.
 end
 
+function time_stepping_works_with_beta_plane(arch, FT)
+    model = Model(
+                    float_type = FT,
+                  architecture = arch,
+                          grid = RegularCartesianGrid(FT, (16, 16, 16), (1, 2, 3)),
+                      coriolis = BetaPlane(FT, f₀=1e-4, β=1e-11)
+                 )
+    time_step!(model, 1, 1)
+    return true # test that no errors/crashes happen when time stepping.
+end
+
 function run_first_AB2_time_step_tests(arch, FT)
     add_ones(args...) = 1.0
     model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), architecture=arch, float_type=FT,
@@ -149,6 +160,10 @@ Closures = (ConstantIsotropicDiffusivity, ConstantAnisotropicDiffusivity,
 
     for arch in archs, FT in float_types, Closure in Closures
         @test time_stepping_works(arch, FT, Closure)
+    end
+
+    for arch in archs, FT in float_types
+        @test time_stepping_works_with_beta_plane(arch, FT)
     end
 
     @testset "2nd-order Adams-Bashforth" begin


### PR DESCRIPTION
This PR introduces a Beta Plane option for Coriolis. If merged, it will replace #438.

We should consider introducing an example (and regression test based on that example) that runs a model on a beta plane, and in a channel to demonstrate / test some currently undemonstrated features.

Co-authored with @suyashbire1.