### PR TITLE
Nuke `BasicModel` legacy constructor and fix `NonDimensionalModel` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ At this time, updating should be done with care, as Oceananigans is under rapid 
 Let's initialize a 3D model with 100×100×50 grid points on a 2×2×1 km domain and simulate it for 10 time steps using steps of 60 seconds each (for a total of 10 minutes of simulation time).
 ```julia
 using Oceananigans
-model = BasicModel(N=(100, 100, 50), L=(2000, 2000, 1000))
+model = Model(grid = RegularCartesianGrid(size=(100, 100, 50), length = (2000, 2000, 1000)))
 time_step!(model; Δt=60, Nt=10)
 ```
 You just simulated what might have been a 3D patch of ocean, it's that easy! It was a still lifeless ocean so nothing interesting happened but now you can add interesting dynamics and visualize the output.
@@ -94,7 +94,9 @@ using Oceananigans
 
 # We'll set up a 2D model with an xz-slice so there's only 1 grid point in y
 # and use an artificially high viscosity ν and diffusivity κ.
-model = BasicModel(N=(128, 128, 128), L=(2000, 2000, 2000), architecture=CPU(), ν=4e-2, κ=4e-2)
+model = Model(architecture = CPU(),
+                      grid = RegularCartesianGrid(size=(128, 128, 128), length=(2000, 2000, 2000)),
+                   closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2))
 
 # Set a temperature perturbation with a Gaussian profile located at the center
 # of the vertical slice. This will create a buoyant thermal bubble that will

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -45,7 +45,7 @@ export
     Clock,
 
     # Models
-    Model, BasicModel, ChannelModel, BasicChannelModel,
+    Model, ChannelModel, NonDimensionalModel,
 
     # Model output writers
     Checkpointer, restore_from_checkpoint, read_output,

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -165,7 +165,7 @@ A `Timeseries` `Diagnostic` that records a time series of `diagnostic(model)`.
 Example
 =======
 ```julia
-julia> model = BasicModel(N=(16, 16, 16), L=(1, 1, 1));
+julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> max_u = Timeseries(FieldMaximum(abs, model.velocities.u), model; frequency=1)
 
@@ -201,7 +201,7 @@ A `Timeseries` `Diagnostic` that records a `NamedTuple` of time series of
 Example
 =======
 ```julia
-julia> model = BasicModel(N=(16, 16, 16), L=(1, 1, 1)); Δt = 1.0;
+julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))); Δt = 1.0;
 
 julia> cfl = Timeseries((adv=AdvectiveCFL(Δt), diff=DiffusiveCFL(Δt)), model; frequency=1);
 
@@ -259,7 +259,7 @@ element-wise to `field`.
 Examples
 =======
 ```julia
-julia> model = BasicModel(N=(16, 16, 16), L=(1, 1, 1));
+julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> max_abs_u = FieldMaximum(abs, model.velocities.u);
 
@@ -309,7 +309,7 @@ for advection across a cell.
 Example
 =======
 ```julia
-julia> model = BasicModel(N=(16, 16, 16), L=(8, 8, 8));
+julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(8, 8, 8)));
 
 julia> cfl = AdvectiveCFL(1.0);
 
@@ -331,7 +331,7 @@ for diffusion across a cell associated with `model.closure`.
 Example
 =======
 ```julia
-julia> model = BasicModel(N=(16, 16, 16), L=(1, 1, 1));
+julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> cfl = DiffusiveCFL(0.1);
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -113,12 +113,11 @@ Note that `N`, `L`, and `Re` are required.
 
 Additional `kwargs` are passed to the regular `Model` constructor.
 """
-function NonDimensionalModel(; N, L, Re, Pr=0.7, Ro=Inf, float_type=Float64, kwargs...)
-
-         grid = RegularCartesianGrid(float_type; size=N, length=L)
-      closure = ConstantIsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re))
-     coriolis = VerticalRotationAxis(float_type, f=1/Ro)
-     buoyancy = BuoyancyTracer()
+function NonDimensionalModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
+    buoyancy = BuoyancyTracer(),
+    coriolis = FPlane(float_type, f=1/Ro),
+     closure = ConstantIsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re)),
+    kwargs...)
 
     return Model(; float_type=float_type, grid=grid, closure=closure,
                    coriolis=coriolis, tracers=(:b,), buoyancy=buoyancy, kwargs...)

--- a/src/models.jl
+++ b/src/models.jl
@@ -42,25 +42,23 @@ Keyword arguments
 - `parameters`: User-defined parameters for use in user-defined forcing functions and boundary condition functions.
 """
 function Model(;
-                   grid, # model resolution and domain
-           architecture = CPU(), # model architecture
+                   grid,
+           architecture = CPU(),
              float_type = Float64,
                 tracers = (:T, :S),
-                closure = ConstantIsotropicDiffusivity(float_type, ν=ν₀, κ=κ₀), # diffusivity / turbulence closure
-                  clock = Clock{float_type}(0, 0), # clock for tracking iteration number and time-stepping
+                closure = ConstantIsotropicDiffusivity(float_type, ν=ν₀, κ=κ₀),
+                  clock = Clock{float_type}(0, 0),
                buoyancy = SeawaterBuoyancy(float_type),
                coriolis = nothing,
                 forcing = ModelForcing(),
     boundary_conditions = HorizontallyPeriodicSolutionBCs(),
          output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
             diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
-             parameters = nothing, # user-defined container for parameters in forcing and boundary conditions
-    # Velocity fields, tracer fields, pressure fields, and time-stepper initialization
+             parameters = nothing,
              velocities = VelocityFields(architecture, grid),
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, tracernames(tracers), closure),
             timestepper = AdamsBashforthTimestepper(float_type, architecture, grid, tracernames(tracers), 0.125),
-    # Solver for Poisson's equation
          poisson_solver = PoissonSolver(architecture, PoissonBCs(boundary_conditions), grid)
     )
 
@@ -94,30 +92,6 @@ kwargs are passed to the regular `Model` constructor.
 """
 ChannelModel(; boundary_conditions=ChannelSolutionBCs(), kwargs...) =
     Model(; boundary_conditions=boundary_conditions, kwargs...)
-
-function BasicChannelModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64,
-                           boundary_conditions=ChannelSolutionBCs(), kwargs...)
-
-    grid = RegularCartesianGrid(float_type; size=N, length=L)
-    closure = ConstantIsotropicDiffusivity(float_type, ν=ν, κ=κ)
-
-    return Model(; float_type=float_type, grid=grid, closure=closure,
-                 boundary_conditions=boundary_conditions, kwargs...)
-end
-
-"""
-    BasicModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64, kwargs...)
-
-Construct a "Basic" `Model` with resolution `N`, domain extent `L`,
-precision `float_type`, and constant isotropic viscosity and diffusivity `ν`, and `κ`.
-
-Additional `kwargs` are passed to the regular `Model` constructor.
-"""
-function BasicModel(; N, L, ν=ν₀, κ=κ₀, float_type=Float64, kwargs...)
-    grid = RegularCartesianGrid(float_type; size=N, length=L)
-    closure = ConstantIsotropicDiffusivity(float_type, ν=ν, κ=κ)
-    return Model(; float_type=float_type, grid=grid, closure=closure, kwargs...)
-end
 
 """
     NonDimensionalModel(; N, L, Re, Pr=0.7, Ro=Inf, float_type=Float64, kwargs...)

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -3,8 +3,9 @@ function run_thermal_bubble_regression_test(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = BasicModel(architecture = arch, N = (Nx, Ny, Nz), L = (Lx, Ly, Lz),
-                       ν = 4e-2, κ = 4e-2, coriolis = FPlane(f = 1e-4))
+    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
+    model = Model(architecture=arch, grid=grid, closure=closure, coriolis=FPlane(f=1e-4))
 
     model.tracers.T.data.parent .= 9.85
     model.tracers.S.data.parent .= 35.0

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,11 +1,11 @@
-function test_z_boundary_condition_simple(arch, T, fldname, bctype, bc, Nx, Ny)
+function test_z_boundary_condition_simple(arch, FT, fldname, bctype, bc, Nx, Ny)
     Nz = 16
     bc = BoundaryCondition(bctype, bc)
     fieldbcs = HorizontallyPeriodicBCs(top=bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch,
-                       float_type=T, boundary_conditions=modelbcs)
+    model = Model(grid=RegularCartesianGrid(FT; size=(Nx, Ny, Nz), length=(0.1, 0.2, 0.3)), architecture=arch,
+                  float_type=FT, boundary_conditions=modelbcs)
 
     time_step!(model, 1, 1e-16)
 
@@ -19,8 +19,8 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=top_bc, bottom=bottom_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(0.1, 0.2, 0.3), architecture=arch,
-                       float_type=FT, boundary_conditions=modelbcs)
+    model = Model(grid=RegularCartesianGrid(FT; size=(N, N, N), length=(0.1, 0.2, 0.3)), architecture=arch,
+                  float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions.solution, fldname)
 
@@ -42,8 +42,8 @@ function test_z_boundary_condition_array(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(top=value_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(0.1, 0.2, 0.3), architecture=arch,
-                       float_type=FT, boundary_conditions=modelbcs)
+    model = Model(grid=RegularCartesianGrid(FT; size=(Nx, Ny, Nz), length=(0.1, 0.2, 0.3)), architecture=arch,
+                  float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions.solution, fldname)
 
@@ -60,8 +60,10 @@ function test_flux_budget(arch, FT, fldname)
     fieldbcs = HorizontallyPeriodicBCs(bottom=flux_bc)
     modelbcs = BoundaryConditions(; Dict(fldname=>fieldbcs)...)
 
-    model = BasicModel(N=(N, N, N), L=(1, 1, Lz), ν=κ, κ=κ, architecture=arch,
-                       float_type=FT, buoyancy=nothing, boundary_conditions=modelbcs)
+    grid = RegularCartesianGrid(FT; size=(N, N, N), length=(1, 1, Lz))
+    closure = ConstantIsotropicDiffusivity(FT; ν=κ, κ=κ)
+    model = Model(grid=grid, closure=closure, architecture=arch,
+                  float_type=FT, buoyancy=nothing, boundary_conditions=modelbcs)
 
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1,5 +1,6 @@
 function horizontal_average_is_correct(arch, FT)
-    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), architecture=arch, float_type=FT)
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(100, 100, 100))
+    model = Model(grid=grid, architecture=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile.
     T₀(x, y, z) = 20 + 0.01*z
@@ -14,7 +15,8 @@ function horizontal_average_is_correct(arch, FT)
 end
 
 function product_profile_is_correct(arch, FT)
-    model = BasicModel(N = (16, 16, 16), L = (100, 100, 100), architecture=arch, float_type=FT)
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(100, 100, 100))
+    model = Model(grid=grid, architecture=arch, float_type=FT)
 
     # Set a linear stably stratified temperature profile and a sinusoidal u(z) profile.
     u₀(x, y, z) = sin(z)
@@ -29,7 +31,8 @@ function product_profile_is_correct(arch, FT)
 end
 
 function nan_checker_aborts_simulation(arch, FT)
-    model = BasicModel(N = (16, 16, 2), L = (1, 1, 1), architecture=arch, float_type=FT)
+    grid=RegularCartesianGrid(size=(16, 16, 2), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
     nc = NaNChecker(model; frequency=1, fields=Dict(:w => model.velocities.w.data.parent))
@@ -40,12 +43,15 @@ function nan_checker_aborts_simulation(arch, FT)
     time_step!(model, 1, 1);
 end
 
-TestModel(::GPU, FT, ν=1.0, Δx=0.5) = BasicModel(N=(16, 16, 16), L=(16*Δx, 16*Δx, 16*Δx), 
-                                                 architecture=GPU(), float_type=FT, ν=ν, κ=ν)
+TestModel(::GPU, FT, ν=1.0, Δx=0.5) = Model(grid = RegularCartesianGrid(FT; size=(16, 16, 16), length=(16Δx, 16Δx, 16Δx)),
+                                         closure = ConstantIsotropicDiffusivity(FT; ν=ν, κ=ν),
+                                    architecture = GPU(),
+                                      float_type = FT)
 
-TestModel(::CPU, FT, ν=1.0, Δx=0.5) = BasicModel(N=(3, 3, 3), L=(3*Δx, 3*Δx, 3*Δx), 
-                                                 architecture=CPU(), float_type=FT, ν=ν, κ=ν)
-    
+TestModel(::CPU, FT, ν=1.0, Δx=0.5) = Model(grid = RegularCartesianGrid(FT; size=(3, 3, 3), length=(3Δx, 3Δx, 3Δx)),
+                                         closure = ConstantIsotropicDiffusivity(FT; ν=ν, κ=ν),
+                                    architecture = CPU(),
+                                      float_type = FT)
 
 function max_abs_field_diagnostic_is_correct(arch, FT)
     model = TestModel(arch, FT)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -26,7 +26,9 @@ function T_relative_error(model, T)
 end
 
 function test_diffusion_simple(fieldname)
-    model = BasicModel(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, buoyancy=nothing)
+    grid = RegularCartesianGrid(size=(1, 1, 16), length=(1, 1, 1))
+    closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
+    model = Model(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     value = π
     data(field) .= value
@@ -37,7 +39,9 @@ function test_diffusion_simple(fieldname)
 end
 
 function test_diffusion_budget_default(fieldname)
-    model = BasicModel(N=(1, 1, 16), L=(1, 1, 1), ν=1, κ=1, buoyancy=nothing)
+    grid = RegularCartesianGrid(size=(1, 1, 16), length=(1, 1, 1))
+    closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
+    model = Model(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     half_Nz = round(Int, model.grid.Nz/2)
     data(field)[:, :,   1:half_Nz] .= -1
@@ -47,7 +51,9 @@ function test_diffusion_budget_default(fieldname)
 end
 
 function test_diffusion_budget_channel(fieldname)
-    model = BasicChannelModel(N=(1, 16, 4), L=(1, 1, 1), ν=1, κ=1, buoyancy=nothing)
+    grid = RegularCartesianGrid(size=(1, 16, 4), length=(1, 1, 1))
+    closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
+    model = ChannelModel(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     half_Ny = round(Int, model.grid.Ny/2)
     data(field)[:, 1:half_Ny,   :] .= -1
@@ -64,7 +70,9 @@ end
 
 function test_diffusion_cosine(fieldname)
     Nz, Lz, κ, m = 128, π/2, 1, 2
-    model = BasicModel(N=(1, 1, Nz), L=(1, 1, Lz), ν=κ, κ=κ, buoyancy=nothing)
+    grid = RegularCartesianGrid(size=(1, 1, Nz), length=(1, 1, Lz))
+    closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ)
+    model = Model(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
 
     zC = model.grid.zC
@@ -115,8 +123,9 @@ function internal_wave_test(; N=128, Nt=10)
     b₀(x, y, z) = b(x, y, z, 0)
 
     # Create a model where temperature = buoyancy.
-    model = BasicModel(N=(N, 1, N), L=(L, L, L), ν=ν, κ=κ, buoyancy=BuoyancyTracer(), tracers=:b,
-                       coriolis=FPlane(f=f))
+    grid = RegularCartesianGrid(size=(N, 1, N), length=(L, L, L))
+    closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ)
+    model = Model(grid=grid, closure=closure, buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=f))
 
     set_ic!(model, u=u₀, v=v₀, w=w₀, b=b₀)
 
@@ -137,7 +146,9 @@ function passive_tracer_advection_test(; N=128, κ=1e-12, Nt=100)
     v₀(x, y, z) = V
     T₀(x, y, z) = T(x, y, z, 0)
 
-    model = BasicModel(N=(N, N, 2), L=(L, L, L), ν=κ, κ=κ)
+    grid = RegularCartesianGrid(size=(N, N, 2), length=(L, L, L))
+    closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ)
+    model = Model(grid=grid, closure=closure)
 
     set_ic!(model, u=u₀, v=v₀, T=T₀)
     time_step!(model, Nt, Δt)

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -14,7 +14,8 @@ function time_step_with_forcing_functions(arch)
 
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing)
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
@@ -26,7 +27,8 @@ function time_step_with_forcing_functions_params(arch)
 
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing, parameters=(τ=60,))
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, forcing=forcing, parameters=(τ=60,))
     time_step!(model, 1, 1)
     return true
 end
@@ -37,21 +39,24 @@ function time_step_with_forcing_functions_sin_exp(arch)
 
     forcing = ModelForcing(u=Fu, T=FT)
 
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=forcing)
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, 1)
     return true
 end
 
 function time_step_with_simple_forcing(arch)
     u_forcing = SimpleForcing((x, y, z, t) -> sin(x))
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=ModelForcing(u=u_forcing))
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, 1)
     return true
 end
 
 function time_step_with_simple_forcing_parameters(arch)
     u_forcing = SimpleForcing((x, y, z, t, p) -> sin(p.ω * x), parameters=(ω=π,))
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1), architecture=arch, forcing=ModelForcing(u=u_forcing))
+    grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
+    model = Model(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, 1)
     return true
 end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -13,7 +13,7 @@ function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
 end
 
 function initial_conditions_correctly_set(arch, FT)
-    model = BasicModel(N=(16, 16, 8), L=(1, 2, 3), architecture=arch, float_type=FT)
+    model = Model(grid=RegularCartesianGrid(FT; size=(16, 16, 8), length=(1, 2, 3)), architecture=arch, float_type=FT)
 
     # Set initial condition to some basic function we can easily check for.
     # We offset the functions by an integer so that we don't end up comparing
@@ -51,7 +51,7 @@ end
     @testset "Doubly periodic model" begin
         println("  Testing doubly periodic model construction...")
         for arch in archs, FT in float_types
-            model = BasicModel(N=(16, 16, 2), L=(1, 2, 3), architecture=arch, float_type=FT)
+            model = Model(grid=RegularCartesianGrid(FT; size=(16, 16, 2), length=(1, 2, 3)), architecture=arch, float_type=FT)
 
             # Just testing that a Model was constructed with no errors/crashes.
             @test true
@@ -61,9 +61,20 @@ end
     @testset "Reentrant channel model" begin
         println("  Testing reentrant channel model construction...")
         for arch in archs, FT in float_types
-            model = BasicChannelModel(N=(16, 16, 2), L=(3, 2, 1), architecture=arch, float_type=FT)
+            model = ChannelModel(grid=RegularCartesianGrid(FT; size=(16, 16, 2), length=(1, 2, 3)), architecture=arch, float_type=FT)
 
             # Just testing that a ChannelModel was constructed with no errors/crashes.
+            @test true
+        end
+    end
+
+    @testset "Non-dimensional model" begin
+        println("  Testing non-dimensional model construction...")
+        for arch in archs, FT in float_types
+            grid = RegularCartesianGrid(FT; size=(16, 16, 2), length=(3, 2, 1))
+            model = NonDimensionalModel(architecture=arch, float_type=FT, grid=grid, Re=1, Pr=1, Ro=Inf)
+
+            # Just testing that a NonDimensionalModel was constructed with no errors/crashes.
             @test true
         end
     end

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -8,7 +8,9 @@ function run_thermal_bubble_netcdf_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), architecture=arch, ν=4e-2, κ=4e-2)
+    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
+    model = Model(architecture=arch, grid=grid, closure=closure)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.
@@ -71,7 +73,7 @@ function run_thermal_bubble_netcdf_tests(arch)
 end
 
 function run_jld2_file_splitting_tests(arch)
-    model = BasicModel(N=(16, 16, 16), L=(1, 1, 1))
+    model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
 
     u(model) = Array(model.velocities.u.data.parent)
     fields = Dict(:u => u)
@@ -118,7 +120,9 @@ function run_thermal_bubble_checkpointer_tests(arch)
     Lx, Ly, Lz = 100, 100, 100
     Δt = 6
 
-    true_model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), ν=4e-2, κ=4e-2, architecture=arch)
+    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
+    true_model = Model(architecture=arch, grid=grid, closure=closure)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -1,14 +1,14 @@
 function time_stepping_works(arch, FT, Closure)
-    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), architecture=arch, float_type=FT,
-                       closure=Closure(FT))
+    model = Model(grid=RegularCartesianGrid(FT; size=(16, 16, 16), length=(1, 2, 3)),
+                  architecture=arch, float_type=FT, closure=Closure(FT))
     time_step!(model, 1, 1)
-    return true # test that no errors/crashes happen when time stepping.
+    return true  # test that no errors/crashes happen when time stepping.
 end
 
 function run_first_AB2_time_step_tests(arch, FT)
     add_ones(args...) = 1.0
-    model = BasicModel(N=(16, 16, 16), L=(1, 2, 3), architecture=arch, float_type=FT,
-                       forcing=ModelForcing(T=add_ones))
+    model = Model(grid=RegularCartesianGrid(FT; size=(16, 16, 16), length=(1, 2, 3)),
+                  architecture=arch, float_type=FT, forcing=ModelForcing(T=add_ones))
     time_step!(model, 1, 1)
 
     # Test that GT = 1 after first time step and that AB2 actually reduced to forward Euler.
@@ -69,7 +69,7 @@ function incompressible_in_time(arch, FT, Nt)
     Nx, Ny, Nz = 32, 32, 32
     Lx, Ly, Lz = 10, 10, 10
 
-    model = BasicModel(N=(Nx, Ny, Nz), L=(Lx, Ly, Lz), architecture=arch, float_type=FT)
+    model = Model(grid=RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)), architecture=arch, float_type=FT)
 
     grid = model.grid
     u, v, w = model.velocities.u, model.velocities.v, model.velocities.w


### PR DESCRIPTION
This PR nukes the `BasicModel` legacy constructor to avoid potential confusion.

I also made the `NonDimensionalModel` constructor act more like the `Model` constructor. Also fixed a typo there and added a test.

Helps with #429 