### PR TITLE
BoundaryFunction wrapper for simple boundary condition functions

### DIFF
--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -33,10 +33,9 @@ export
     # Boundary conditions
     BoundaryCondition,
     Periodic, Flux, Gradient, Value, Dirchlet, Neumann,
-    CoordinateBoundaryConditions,
-    FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
+    CoordinateBoundaryConditions, FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
     BoundaryConditions, SolutionBoundaryConditions, HorizontallyPeriodicSolutionBCs, ChannelSolutionBCs,
-    getbc, setbc!,
+    BoundaryFunction, getbc, setbc!,
 
     # Time stepping
     TimeStepWizard,

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -120,6 +120,49 @@ getbc(bc::BC{C, <:Function}, args...)            where C = bc.condition(args...)
 Base.getindex(bc::BC{C, <:AbstractArray}, inds...) where C = getindex(bc.condition, inds...)
 
 #####
+##### Wrapper for user-defined boundary condition functions
+#####
+
+"""
+    BoundaryFunction{B, X1, X2, F}
+
+A wrapper for user-defined boundary condition functions.
+"""
+struct BoundaryFunction{B, X1, X2, F} <: Function
+    func :: F
+
+    """
+        BoundaryFunction{B, X1, X2}(func)
+
+    A wrapper for user-defined boundary condition functions on the
+    boundary specified by symbol `B` and at location `(X1, X2)`.
+
+    Example
+    =======
+    julia> using Oceananigans: BoundaryCondition, BoundaryFunction, Flux, Cell
+
+    julia> top_tracer_flux = BoundaryFunction{:z, Cell, Cell}((x, y, t) -> cos(2π*x) * cos(t))
+    (::BoundaryFunction{:z,Cell,Cell,getfield(Main, Symbol("##7#8"))}) (generic function with 1 method)
+
+    julia> top_tracer_bc = BoundaryCondition(Flux, top_tracer_flux);
+    """
+    function BoundaryFunction{B, X1, X2}(func) where {B, X1, X2}
+        B ∈ (:x, :y, :z) || throw(ArgumentError("The boundary B at which the BoundaryFunction is
+                                                to be applied must be either :x, :y, or :z."))
+        new{B, X1, X2, typeof(func)}(func)
+    end
+end
+
+@inline (bc::BoundaryFunction{:x, Y, Z})(j, k, grid, time, args...) where {Y, Z} =
+    bc.func(ynode(Y, j, grid), znode(Z, k, grid), time)
+
+@inline (bc::BoundaryFunction{:y, X, Z})(i, k, grid, time, args...) where {X, Z} =
+    bc.func(xnode(X, i, grid), znode(Z, k, grid), time)
+
+@inline (bc::BoundaryFunction{:z, X, Y})(i, j, grid, time, args...) where {X, Y} =
+    bc.func(xnode(X, i, grid), ynode(Y, j, grid), time)
+
+#####
 ##### Boundary conditions along particular coordinates
 #####
 

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,3 +1,8 @@
+function test_boundary_function(B, X1, X2, func)
+    boundary_function = BoundaryFunction{B, X1, X2}(func)
+    return true
+end
+
 function test_z_boundary_condition_simple(arch, FT, fldname, bctype, bc, Nx, Ny)
     Nz = 16
     bc = BoundaryCondition(bctype, bc)
@@ -9,7 +14,7 @@ function test_z_boundary_condition_simple(arch, FT, fldname, bctype, bc, Nx, Ny)
 
     time_step!(model, 1, 1e-16)
 
-    typeof(model) <: Model
+    return typeof(model) <: Model
 end
 
 function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
@@ -26,7 +31,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
 
     time_step!(model, 1, 1e-16)
 
-    getbc(bcs.z.top) == val && getbc(bcs.z.bottom) == -val
+    return getbc(bcs.z.top) == val && getbc(bcs.z.bottom) == -val
 end
 
 function test_z_boundary_condition_array(arch, FT, fldname)
@@ -49,7 +54,7 @@ function test_z_boundary_condition_array(arch, FT, fldname)
 
     time_step!(model, 1, 1e-16)
 
-    bcs.z.top[1, 2] == bcarray[1, 2]
+    return bcs.z.top[1, 2] == bcarray[1, 2]
 end
 
 function test_flux_budget(arch, FT, fldname)
@@ -84,32 +89,45 @@ function test_flux_budget(arch, FT, fldname)
 
     # budget: Lz*∂<ϕ>/∂t = -Δflux = -top_flux/Lz (left) + bottom_flux/Lz (right)
     # therefore <ϕ> = bottom_flux * t / Lz
-    isapprox(mean(interior(field)) - mean_init, bottom_flux * model.clock.time / Lz)
+    return isapprox(mean(interior(field)) - mean_init, bottom_flux * model.clock.time / Lz)
 end
 
 @testset "Boundary conditions" begin
     println("Testing boundary conditions...")
 
+    @testset "Boundary functions" begin
+        simple_bc(ξ, η, t) = exp(ξ) * cos(η) * sin(t)
+        for B in (:x, :y, :z)
+            for X1 in (:Face, :Cell)
+                @test test_boundary_function(B, X1, Cell, simple_bc)
+            end
+        end
+    end
+
     funbc(args...) = π
+    boundaryfunbc = BoundaryFunction{:z, Face, Cell}((ξ, η, t) -> exp(ξ) * cos(η) * sin(t))
 
-    Nx = Ny = 16
-    for arch in archs
-        for FT in float_types
-            for fld in (:u, :v, :T, :S)
-                for bctype in (Gradient, Flux, Value)
+    @testset "Boundary condition instatiation and time-stepping" begin
+        Nx = Ny = 16
+        for arch in archs
+            for FT in float_types
+                for fld in (:u, :v, :T, :S)
+                    for bctype in (Gradient, Flux, Value)
 
-                    arraybc = rand(FT, Nx, Ny)
-                    if arch == GPU()
-                        arraybc = CuArray(arraybc)
+                        arraybc = rand(FT, Nx, Ny)
+                        if arch == GPU()
+                            arraybc = CuArray(arraybc)
+                        end
+
+                        for bc in (FT(0.6), arraybc, funbc, boundaryfunbc)
+                            @test test_z_boundary_condition_simple(arch, FT, fld, bctype, bc, Nx, Ny)
+                        end
                     end
 
-                    for bc in (FT(0.6), arraybc, funbc)
-                        @test test_z_boundary_condition_simple(arch, FT, fld, bctype, bc, Nx, Ny)
-                    end
+                    @test test_z_boundary_condition_top_bottom_alias(arch, FT, fld)
+                    @test test_z_boundary_condition_array(arch, FT, fld)
+                    @test test_flux_budget(arch, FT, fld)
                 end
-                @test test_z_boundary_condition_top_bottom_alias(arch, FT, fld)
-                @test test_z_boundary_condition_array(arch, FT, fld)
-                @test test_flux_budget(arch, FT, fld)
             end
         end
     end


### PR DESCRIPTION
This PR adds a wrapper for boundary-conditions-as-functions called `BoundaryFunction`.

From the docstring:

```julia
""" 
    BoundaryFunction{B, X1, X2}(func)

A wrapper for user-defined boundary condition functions on the
boundary specified by symbol `B` and at location `(X1, X2)`.

Example
=======
julia> using Oceananigans: BoundaryCondition, BoundaryFunction, Flux, Cell

julia> top_tracer_flux = BoundaryFunction{:z, Cell, Cell}((x, y, t) -> cos(2π*x) * cos(t))
(::BoundaryFunction{:z,Cell,Cell,getfield(Main, Symbol("##7#8"))}) (generic function with 1 method)

julia> top_tracer_bc = BoundaryCondition(Flux, top_tracer_flux);
```