### PR TITLE
Fixes a typo in Eady example and in Docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 Oceananigans.jl is a fast and friendly incompressible fluid flow solver written in Julia that can be run in 1-3
 dimensions on CPUs and GPUs. It simulates the rotating Boussinesq equations in rectangular domains with some 
 special features for fluids stratified by both temperature and salinity (oceans!) --- but can also be used without
-rotation, stratification, with aribtrary tracers, and arbitrary user-defined forcing functions.
+rotation, stratification, with arbitrary tracers, and arbitrary user-defined forcing functions.
 
 We strive for a user interface that makes `Oceananigans.jl` as friendly and intuitive to use as possible, 
 allowing users to focus on the science. Internally, we have attempted to write the underlying algorithm
@@ -14,7 +14,7 @@ as possible is shared between the CPU and GPU algorithms.
 
 ## Installation instructions
 You can install the latest version of Oceananigans using the built-in package manager (accessed by pressing `]` in the
-Julia command prompt) to add the package and instantiate/build all depdendencies
+Julia command prompt) to add the package and instantiate/build all dependencies
 ```julia
 julia>]
 (v1.1) pkg> add Oceananigans

--- a/docs/src/manual/large_eddy_simulation.md
+++ b/docs/src/manual/large_eddy_simulation.md
@@ -59,7 +59,7 @@ theory, \citet{Lilly66} was able to derive a value of
 C_s = \left( \frac{3}{2}C_K\pi^\frac{4}{3} \right)^{-\frac{3}{4}} \approx 0.16
 ```
 using an empirical value of $C_K \approx 1.6$ for the Kolmogorov constant. This seems reasonable for isotropic
-turbulence if the grid spacing $\Delta$ falls in the intertial range. In practice, $C_s$ is a tunable parameter.
+turbulence if the grid spacing $\Delta$ falls in the inertial range. In practice, $C_s$ is a tunable parameter.
 
 Due to the presence of the constant $C_s$, the model is sometimes referred to as the \emph{constant Smagorinsky} model
 in contrast to \emph{dynamic Smagorinsky} models that dynamically compute $C_s$ to account for effects such as buoyant

--- a/docs/src/manual/physics.md
+++ b/docs/src/manual/physics.md
@@ -163,7 +163,7 @@ $\bm{\nabla} \bm{\cdot} \bm{q}_c$ in the momentum and tracer conservation equati
 
 ### Constant isotropic diffusivity
 
-In a constant isotropic diffusivity model, the kinematic stress tensor is defned
+In a constant isotropic diffusivity model, the kinematic stress tensor is defined
 ```math
 \tau_{ij} = - \nu \Sigma_{ij} \, ,
 ```

--- a/docs/src/manual/poisson_solvers.md
+++ b/docs/src/manual/poisson_solvers.md
@@ -19,7 +19,7 @@ tridiagonal form. This allows for the matrix to be decomposed and solved efficie
 eigenvectors of the blocks are known \citep[\S2]{Buzbee70}. In the case of Poisson's equation on a rectangle,
 \citet{Hockney65} has taken advantage of the fact that the fast Fourier transform can be used to perform the matrix
 multiplication steps resulting in an even more efficient method. \citet{Schumann88} describe the implementation of such
-an algorithm for Poisson's equation on a staggered grid with Dirchlet, Neumann, and periodic boundary conditions.
+an algorithm for Poisson's equation on a staggered grid with Dirichlet, Neumann, and periodic boundary conditions.
 
 The method can be explained easily by taking the Fourier transform of both sides of \eqref{eq:poisson-pressure} to yield
 ```math
@@ -170,4 +170,4 @@ permutation of \eqref{eq:permutation} must be applied.
 
 Due to the extra steps involved in calculating the cosine transform in 2D, running with two wall-bounded dimensions
 typically slows the model down by a factor of 2. Switching to the FACR algorithm may help here as a 2D cosine transform
-won't be neccessary anymore.
+won't be necessary anymore.

--- a/docs/src/manual/staggered_grid.md
+++ b/docs/src/manual/staggered_grid.md
@@ -32,7 +32,7 @@ The staggered grid was first introduced by \citet{Harlow65} with their \emph{mar
 and oceanography, the staggered grid is usually referred to as the Arakawa C-grid after \citet{Arakawa77}, who
 investigated four different staggered grids and the unstaggered A-grid for use in an atmospheric model.
 
-\citet{Arakawa77} investigated the dispersion relation of intertia-gravity waves[^2] travelling in the $x$-direction
+\citet{Arakawa77} investigated the dispersion relation of inertia-gravity waves[^2] traveling in the $x$-direction
 ```math
   \omega^2 = f^2 + gHk^2
 ```
@@ -49,7 +49,7 @@ wavelength of the shortest resolvable wave is $2\Delta$ with corresponding waven
 sufficient to evaluate the dispersion relation over the range $0 < k\Delta < \pi$. The frequency is monotonically
 increasing for $\lambda/\Delta > \frac{1}{2}$ and monotonically decreasing for $\lambda/\Delta < \frac{1}{2}$. For the
 fourth smallest wave $\lambda/\Delta = \frac{1}{2}$ we get $\omega^2 = f^2$ which matches the $k = 0$ wave. Furthermore,
-the group velocity is zero for all $k$. On the other grids, waves with $k\Delta = \pi$ can behave like pure intertial
+the group velocity is zero for all $k$. On the other grids, waves with $k\Delta = \pi$ can behave like pure inertial
 oscillations or stationary waves, which is bad.
 
 The B and C-grids are less oscillatory than the others and quite faithfully simulate geostrophic adjustment. However,

--- a/docs/src/manual/time_stepping.md
+++ b/docs/src/manual/time_stepping.md
@@ -54,7 +54,7 @@ for any time-dependent function $G(t)$, while a second-order Adams-Bashforth met
 where $\chi$ is a parameter. Ascher et al. (1995) claim that $\chi = \tfrac{1}{8}$ is optimal; 
 $\chi=-\tfrac{1}{2}$ yields the forward Euler scheme.
 
-Combining the equations for $\bm{u}^\star$ and the time integral of the momnentum equation yields
+Combining the equations for $\bm{u}^\star$ and the time integral of the momentum equation yields
 ```math
     \tag{eq:fractional-step}
     \bm{u}^{n+1} - \bm{u}^\star = - \Delta t \bm{\nabla} \phi_{\rm{non}}^{n+1} \, \rm{d} t \, .

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -114,7 +114,7 @@ Fb_eady(i, j, k, grid, time, U, C, p) = @inbounds (- p.α * (grid.zC[k] + p.H) *
 #
 # We use a horizontal biharmonic diffusivity and a Laplacian vertical diffusivity
 # to dissipate energy in the Eady problem.
-# Two use both of these closures at the same time, we set the keyword argument
+# To use both of these closures at the same time, we set the keyword argument
 # `closure` a tuple of two closures. Note that the "2D Leith" parameterization may
 # also be a sensible choice to pair with a Laplacian vertical diffusivity for this problem.
 
@@ -147,10 +147,10 @@ boundary_conditions = BoundaryConditions(u=ubcs, v=vbcs, b=bbcs),
 # For initial conditions we impose a linear stratifificaiton with some
 # random noise.
 
-## A noise function, damped at the boundaries
+# # A noise function, damped at the boundaries
 Ξ(z) = rand() * z/Lz * (z/Lz + 1)
 
-## Buoyancy: linear stratification plus noise
+# # Buoyancy: linear stratification plus noise
 b₀(x, y, z) = N² * z + 1e-2 * Ξ(z) * (N² * Lz + α * f * Lh)
 u₀(x, y, z) = 1e-2 * α * Lz
 

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -147,10 +147,10 @@ boundary_conditions = BoundaryConditions(u=ubcs, v=vbcs, b=bbcs),
 # For initial conditions we impose a linear stratifificaiton with some
 # random noise.
 
-# # A noise function, damped at the boundaries
+## A noise function, damped at the boundaries
 Ξ(z) = rand() * z/Lz * (z/Lz + 1)
 
-# # Buoyancy: linear stratification plus noise
+## Buoyancy: linear stratification plus noise
 b₀(x, y, z) = N² * z + 1e-2 * Ξ(z) * (N² * Lz + α * f * Lh)
 u₀(x, y, z) = 1e-2 * α * Lz
 


### PR DESCRIPTION
What does *non-linearized around a geostrophic flow* mean (line 64)?
Perhaps better *assumes a geostrophic base flow...*?