### PR TITLE
Update `NetCDFOutputWriter` docstring and clobber default

### DIFF
--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -117,7 +117,7 @@ Keyword arguments
     - `filename::String`         : Directory to save output to. Default: "." (current working directory).
     - `frequency::Int`           : Save output every `n` model iterations.
     - `interval::Int`            : Save output every `t` units of model clock time.
-    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `false`.
+    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `true`.
     - `compression::Int`         : Determines the compression level of data (0-9, default 0)
     - `global_attributes::Dict`  : Dict of model properties to save with every file (deafult: Dict())
     - `output_attributes::Dict`  : Dict of attributes to be saved with each field variable (reasonable

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -105,7 +105,7 @@ end
 
 """
     NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing, filename=".",
-                                   clobber=true, global_attributes=Dict(), output_attributes=nothing, slice_kw...)
+                                   clobber=false, global_attributes=Dict(), output_attributes=nothing, slice_kw...)
 
 Construct a `NetCDFOutputWriter` that writes `label, field` pairs in `outputs` (which should
 be a `Dict`) to a NC file, where `label` is a symbol that labels the output and `field` is
@@ -132,7 +132,7 @@ Keyword arguments
 """
 
 function NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing, filename=".",
-                        clobber=true, global_attributes=Dict(), output_attributes=nothing, compression=0, slice_kw...)
+                        clobber=false, global_attributes=Dict(), output_attributes=nothing, compression=0, slice_kw...)
 
     validate_interval(interval, frequency)
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -117,7 +117,7 @@ Keyword arguments
     - `filename::String`         : Directory to save output to. Default: "." (current working directory).
     - `frequency::Int`           : Save output every `n` model iterations.
     - `interval::Int`            : Save output every `t` units of model clock time.
-    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `true`.
+    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `false`.
     - `compression::Int`         : Determines the compression level of data (0-9, default 0)
     - `global_attributes::Dict`  : Dict of model properties to save with every file (deafult: Dict())
     - `output_attributes::Dict`  : Dict of attributes to be saved with each field variable (reasonable

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -105,7 +105,7 @@ end
 
 """
     NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing, filename=".",
-                                   clobber=false, global_attributes=Dict(), output_attributes=nothing, slice_kw...)
+                                   clobber=true, global_attributes=Dict(), output_attributes=nothing, slice_kw...)
 
 Construct a `NetCDFOutputWriter` that writes `label, field` pairs in `outputs` (which should
 be a `Dict`) to a NC file, where `label` is a symbol that labels the output and `field` is
@@ -117,7 +117,7 @@ Keyword arguments
     - `filename::String`         : Directory to save output to. Default: "." (current working directory).
     - `frequency::Int`           : Save output every `n` model iterations.
     - `interval::Int`            : Save output every `t` units of model clock time.
-    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `false`.
+    - `clobber::Bool`            : Remove existing files if their filenames conflict. Default: `true`.
     - `compression::Int`         : Determines the compression level of data (0-9, default 0)
     - `global_attributes::Dict`  : Dict of model properties to save with every file (deafult: Dict())
     - `output_attributes::Dict`  : Dict of attributes to be saved with each field variable (reasonable
@@ -132,7 +132,7 @@ Keyword arguments
 """
 
 function NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing, filename=".",
-                        clobber=false, global_attributes=Dict(), output_attributes=nothing, compression=0, slice_kw...)
+                        clobber=true, global_attributes=Dict(), output_attributes=nothing, compression=0, slice_kw...)
 
     validate_interval(interval, frequency)
 

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -139,8 +139,7 @@ function NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing,
     mode = clobber ? "c" : "a"
 
     # Initiates the output file with dimensions
-    write_grid(model; filename=filename, mode=mode,
-               compression=compression, attrib=global_attributes, slice_kw...)
+    write_grid(model; filename=filename, compression=compression, attrib=global_attributes, slice_kw...)
 
     # Opens the same output file for writing fields from the user-supplied variable outputs
     dataset = Dataset(filename, "a")

--- a/src/OutputWriters/netcdf_output_writer.jl
+++ b/src/OutputWriters/netcdf_output_writer.jl
@@ -107,9 +107,9 @@ end
     NetCDFOutputWriter(model, outputs; interval=nothing, frequency=nothing, filename=".",
                                    clobber=true, global_attributes=Dict(), output_attributes=nothing, slice_kw...)
 
-Construct a `NetCDFOutputWriter` that writes `label, field` pairs in `outputs` (which can be a
-`Dict` or `NamedTuple`) to a NC file, where `label` is a symbol that labels the output and
-`field` is a field from the model (e.g. `model.velocities.u`).
+Construct a `NetCDFOutputWriter` that writes `label, field` pairs in `outputs` (which should
+be a `Dict`) to a NC file, where `label` is a symbol that labels the output and `field` is
+a field from the model (e.g. `model.velocities.u`).
 
 Keyword arguments
 =================


### PR DESCRIPTION
Docstring did not match the actual constructor. They do now.

@suyashbire1 Do you think `clobber` should be true or false by default?

Also updated the docstring to make it clear that `outputs` needs to be a `Dict` for now.

Resolves #553