### PR TITLE
Delete leftover JLD2 files before deploying docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -78,8 +78,6 @@ makedocs(
      ]
 )
 
-deploydocs(repo = "github.com/climate-machine/Oceananigans.jl.git")
-
 ####
 #### Delete leftover JLD2 files.
 #### See: https://github.com/climate-machine/Oceananigans.jl/issues/509
@@ -94,4 +92,6 @@ for fname in leftovers
     rm(fpath, force=true)
     @info "Deleted: $fpath"
 end
+
+deploydocs(repo = "github.com/climate-machine/Oceananigans.jl.git")
 

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -212,6 +212,3 @@ end
 
 makeplot!(axs, model)
 gcf()
-
-# Delete the output file
-rm("ocean_wind_mixing_and_convection.jld2", force=true)

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -212,3 +212,6 @@ end
 
 makeplot!(axs, model)
 gcf()
+
+# Delete the output file
+rm("ocean_wind_mixing_and_convection.jld2", force=true)


### PR DESCRIPTION
Maybe not the cleanest solution but this will resolve #509 which has become a rather annoying issue recently.