### PR TITLE
Bugfix in SurfaceWaves module

### DIFF
--- a/src/SurfaceWaves.jl
+++ b/src/SurfaceWaves.jl
@@ -10,6 +10,8 @@ export
 
 using Oceananigans: AbstractGrid, Face, Cell, xnode, ynode, znode
 
+using Oceananigans.Operators: ℑzᵃᵃᶜ, ℑzᵃᵃᶠ
+
 """
     abstract type AbstractStokesDrift end
 
@@ -65,12 +67,15 @@ const USD = UniformStokesDrift
 
 @inline ∂t_wˢ(i, j, k, grid::AbstractGrid{FT}, sw::USD, time) where FT = zero(FT)
 
-@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = @inbounds U.w[i, j, k] * sw.∂z_uˢ(znode(Cell, k, grid), time)
-@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = @inbounds U.w[i, j, k] * sw.∂z_vˢ(znode(Cell, k, grid), time)
+@inline x_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = 
+    @inbounds ℑzᵃᵃᶜ(i, j, k, grid, U.w) * sw.∂z_uˢ(znode(Cell, k, grid), time)
+
+@inline y_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = 
+    @inbounds ℑzᵃᵃᶜ(i, j, k, grid, U.w) * sw.∂z_vˢ(znode(Cell, k, grid), time)
 
 @inline z_curl_Uˢ_cross_U(i, j, k, grid, sw::USD, U, time) = @inbounds begin (
-    - U.u[i, j, k] * sw.∂z_uˢ(znode(Face, k, grid), time)
-    - U.v[i, j, k] * sw.∂z_vˢ(znode(Face, k, grid), time) )
+    - ℑzᵃᵃᶠ(i, j, k, grid, U.u) * sw.∂z_uˢ(znode(Face, k, grid), time)
+    - ℑzᵃᵃᶠ(i, j, k, grid, U.v) * sw.∂z_vˢ(znode(Face, k, grid), time) )
 end
 
 end # module

--- a/src/TimeSteppers/kernels.jl
+++ b/src/TimeSteppers/kernels.jl
@@ -10,7 +10,7 @@ function calculate_Gu!(Gu, grid, coriolis, surface_waves, closure, U, C, K, F, p
                                   - ∂xᶠᵃᵃ(i, j, k, grid, pHY′)
                                   + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U, K)
                                   + x_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  - ∂t_uˢ(i, j, k, grid, surface_waves, time)
+                                  + ∂t_uˢ(i, j, k, grid, surface_waves, time)
                                   + F.u(i, j, k, grid, time, U, C, parameters)
         )
     end
@@ -25,7 +25,7 @@ function calculate_Gv!(Gv, grid, coriolis, surface_waves, closure, U, C, K, F, p
                                   - ∂yᵃᶠᵃ(i, j, k, grid, pHY′)
                                   + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U, K)
                                   + y_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  - ∂t_vˢ(i, j, k, grid, surface_waves, time)
+                                  + ∂t_vˢ(i, j, k, grid, surface_waves, time)
                                   + F.v(i, j, k, grid, time, U, C, parameters))
     end
     return nothing
@@ -38,7 +38,7 @@ function calculate_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, p
                                   - z_f_cross_U(i, j, k, grid, coriolis, U)
                                   + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U, K)
                                   + z_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  - ∂t_wˢ(i, j, k, grid, surface_waves, time)
+                                  + ∂t_wˢ(i, j, k, grid, surface_waves, time)
                                   + F.w(i, j, k, grid, time, U, C, parameters))
     end
     return nothing


### PR DESCRIPTION
This PR fixes

1. A sign error in the momentum kernels associated with the Stokes drift tendency terms for surface waves and

2. Interpolation (or lack thereof) error in the surface wave pseudovorticity term.