### PR TITLE
[WIP] Adds a restarter keyword to Model constructor

### DIFF
--- a/src/Models/model.jl
+++ b/src/Models/model.jl
@@ -6,12 +6,11 @@ using Oceananigans.Architectures: AbstractArchitecture
 using Oceananigans.Buoyancy: validate_buoyancy
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers
 
-mutable struct Model{TS, E, A<:AbstractArchitecture, G, RS, T, B, R, SW, U, C, Φ, F,
+mutable struct Model{TS, E, A<:AbstractArchitecture, G, T, B, R, SW, U, C, Φ, F,
                      BCS, S, K, OW, DI, Θ} <: AbstractModel
 
            architecture :: A         # Computer `Architecture` on which `Model` is run
                    grid :: G         # Grid of physical points on which `Model` is solved
-              restarter :: RS        # A path for a checkpoint file
                   clock :: Clock{T}  # Tracks iteration number andsimulation time of `Model`
                buoyancy :: B         # Set of parameters for buoyancy model
                coriolis :: R         # Set of parameters for the background rotation rate of `Model`


### PR DESCRIPTION
The idea here is to minimize the amount of modifications required to the parent script when model is being restarted from a checkpoint.

Currently, the script might look like this when the model is being run for the first time:
```julia
model = Model(
       architecture = GPU(),
         float_type = Float64,
               grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)),
           coriolis = coriolis,
           buoyancy = SeawaterBuoyancy(gravitational_acceleration=g_Europa),
            closure = closure,
boundary_conditions = model_bcs,
            forcing = forcing
)
# model = restore_from_checkpoint(path; kwargs)
```
When restarting from the checkpoint, we'll have to comment the first 9 lines and uncomment the following line. This gets annoying pretty quickly when running a large suite of experiments. So I thought it would be better to integrate the checkpoint specification with model constructor. 

```julia
model = Model(
          restarter = "/path/to/checkpoint/file",
       architecture = GPU(),
         float_type = Float64,
               grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)),
           coriolis = coriolis,
           buoyancy = SeawaterBuoyancy(gravitational_acceleration=g_Europa),
            closure = closure,
boundary_conditions = model_bcs,
            forcing = forcing
)
```
Modifications to parent script are minimized if restarting from checkpointer is integrated into model constructor. 

The way I have implemented it currently, if restarter is specified in model constructor all other kwargs to `Model` are ignored. @ali-ramadhan thinks this doesn't cover all possible model specification cases. 

Any thoughts on how to improve this?