### PR TITLE
Fixes off-by-one indexing error in hydrostatic pressure integrat…

### DIFF
--- a/src/TimeSteppers/kernels.jl
+++ b/src/TimeSteppers/kernels.jl
@@ -168,10 +168,10 @@ the `buoyancy_perturbation` downwards:
 """
 function update_hydrostatic_pressure!(pHY′, grid, buoyancy, C)
     @loop_xy i j grid begin
-        @inbounds pHY′[i, j, grid.Nz] = - ℑzᵃᵃᶠ(i, j, grid.Nz, grid, buoyancy_perturbation, buoyancy, C) * ΔzF(i, j, grid.Nz, grid)
+        @inbounds pHY′[i, j, grid.Nz] = - ℑzᵃᵃᶠ(i, j, grid.Nz+1, grid, buoyancy_perturbation, buoyancy, C) * ΔzF(i, j, grid.Nz+1, grid)
         @unroll for k in grid.Nz-1 : -1 : 1
             @inbounds pHY′[i, j, k] =
-                pHY′[i, j, k+1] - ℑzᵃᵃᶠ(i, j, k+1, grid, buoyancy_perturbation, buoyancy, C) * ΔzF(i, j, k, grid)
+                pHY′[i, j, k+1] - ℑzᵃᵃᶠ(i, j, k+1, grid, buoyancy_perturbation, buoyancy, C) * ΔzF(i, j, k+1, grid)
         end
     end
     return nothing


### PR DESCRIPTION
This error may not be consequential for any work we've done so far because it amounts to changing an irrelevant 'gauge condition' on the pressure in many cases.

It does impact set-ups with vertically stretched grids, and it may impact set-ups that specify a horizontal buoyancy gradient at the surface. None of the regression tests deal with such scenarios.