### PR TITLE
Purge famous people

### DIFF
--- a/docs/src/model_setup/boundary_conditions.md
+++ b/docs/src/model_setup/boundary_conditions.md
@@ -15,8 +15,8 @@ See [Numerical implementation of boundary conditions](@ref numerical_bcs) for mo
 ## Types of boundary conditions
 1. [`Periodic`](@ref Periodic)
 2. [`Flux`](@ref Flux)
-3. [`Value`](@ref Value) ([`Dirchlet`](@ref))
-4. [`Gradient`](@ref Gradient) ([`Neumann`](@ref))
+3. [`Value`](@ref Value)
+4. [`Gradient`](@ref Gradient)
 5. [`No-penetration`](@ref NoPenetration)
 
 Notice that open boundary conditions and radiation boundary conditions can be imposed via flux or value boundary

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -1,12 +1,12 @@
 module BoundaryConditions
 
 export
-    BCType, Periodic, Flux, Gradient, Value, NoPenetration, Dirchlet, Neumann,
+    BCType, Periodic, Flux, Gradient, Value, NoPenetration,
     BoundaryCondition, bctype, getbc, setbc!,
     CoordinateBoundaryConditions,
     FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
     SolutionBoundaryConditions, HorizontallyPeriodicSolutionBCs, ChannelSolutionBCs,
-    TendenciesBoundaryConditions, PressureBoundaryConditions, 
+    TendenciesBoundaryConditions, PressureBoundaryConditions,
     DiffusivityBoundaryConditions, DiffusivitiesBoundaryConditions,
     ModelBoundaryConditions, BoundaryFunction,
     apply_z_bcs!, apply_y_bcs!,

--- a/src/BoundaryConditions/boundary_condition_types.jl
+++ b/src/BoundaryConditions/boundary_condition_types.jl
@@ -55,19 +55,3 @@ to normal velocity components at a wall, where the velocity at the cell face col
 at the wall is known and set to zero.
 """
 struct NoPenetration <: BCType end
-
-# Famous people
-
-"""
-    Dirchlet
-
-An alias for the `Value` boundary condition type.
-"""
-const Dirchlet = Value
-
-"""
-    Neumann
-
-An alias for the `Gradient` boundary condition type.
-"""
-const Neumann = Gradient

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -33,7 +33,7 @@ export
 
     # Boundary conditions
     BoundaryCondition,
-    Periodic, Flux, Gradient, Value, Dirchlet, Neumann,
+    Periodic, Flux, Gradient, Value,
     CoordinateBoundaryConditions, FieldBoundaryConditions, HorizontallyPeriodicBCs, ChannelBCs,
     BoundaryConditions, SolutionBoundaryConditions, HorizontallyPeriodicSolutionBCs, ChannelSolutionBCs,
     BoundaryFunction, getbc, setbc!,


### PR DESCRIPTION
This PR removes the `Dirchlet` and `Neumann` aliases for boundary condition types.