### PR TITLE
Differentiated and variable AMD model constants

### DIFF
--- a/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
@@ -58,15 +58,33 @@ Example
 =======
 
 julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
+VerstappenAnisotropicMinimumDissipation{Float64} turbulence closure with:
+           Poincaré constant for momentum eddy viscosity Cν: 0.5
+    Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: 0.5
+                        Buoyancy modification multiplier Cb: 0.0
+                Background diffusivit(ies) for tracer(s), κ: 1.46e-7
+             Background kinematic viscosity for momentum, ν: 1.05e-6
 
 julia> const Δz = 0.5; # grid resolution at surface
 
 julia> surface_enhanced_tracer_C(x, y, z) = 1/12 * (1 + exp((z + Δz/2) / 8Δz))
+surface_enhanced_tracer_C (generic function with 1 method)
 
 julia> fancy_closure = AnisotropicMinimumDissipation(Cκ=surface_enhanced_tracer_C)
+VerstappenAnisotropicMinimumDissipation{Float64} turbulence closure with:
+           Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
+    Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: surface_enhanced_tracer_C
+                        Buoyancy modification multiplier Cb: 0.0
+                Background diffusivit(ies) for tracer(s), κ: 1.46e-7
+             Background kinematic viscosity for momentum, ν: 1.05e-6
 
 julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c₂=1/6))
-
+VerstappenAnisotropicMinimumDissipation{Float64} turbulence closure with:
+           Poincaré constant for momentum eddy viscosity Cν: 0.08333333333333333
+    Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: (c₁ = 0.08333333333333333, c₂ = 0.16666666666666666)
+                        Buoyancy modification multiplier Cb: 0.0
+                Background diffusivit(ies) for tracer(s), κ: 1.46e-7
+             Background kinematic viscosity for momentum, ν: 1.05e-6
 
 References
 ==========

--- a/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
@@ -18,8 +18,8 @@ end
 
 const VAMD = VerstappenAnisotropicMinimumDissipation
 
-function Base.show(io::IO, closure::VAMD{FT}) where FT =
-    print(io, "VerstappenAnisotropicMinimumDissipation{$FT} turbulence closure with:\n"
+Base.show(io::IO, closure::VAMD{FT}) where FT =
+    print(io, "VerstappenAnisotropicMinimumDissipation{$FT} turbulence closure with:\n",
               "           Poincaré constant for momentum eddy viscosity Cν: ", closure.Cν, '\n',
               "    Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: ", closure.Cκ, '\n',
               "                        Buoyancy modification multiplier Cb: ", closure.Cb, '\n',

--- a/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
@@ -18,6 +18,14 @@ end
 
 const VAMD = VerstappenAnisotropicMinimumDissipation
 
+function Base.show(io::IO, closure::VAMD{FT}) where FT =
+    print(io, "VerstappenAnisotropicMinimumDissipation{$FT} turbulence closure with:\n"
+              "           Poincaré constant for momentum eddy viscosity Cν: ", closure.Cν, '\n',
+              "    Poincaré constant for tracer(s) eddy diffusivit(ies) Cκ: ", closure.Cκ, '\n',
+              "                        Buoyancy modification multiplier Cb: ", closure.Cb, '\n',
+              "                Background diffusivit(ies) for tracer(s), κ: ", closure.κ, '\n',
+              "             Background kinematic viscosity for momentum, ν: ", closure.ν, '\n')
+
 """
     VerstappenAnisotropicMinimumDissipation(FT=Float64; C=1/12, Cν=nothing, Cκ=nothing,
                                             Cb=0.0, ν=ν₀, κ=κ₀)
@@ -43,6 +51,22 @@ By default: `C = Cν = Cκ` = 1/12, which is appropriate for a finite-volume met
 second-order advection scheme, `Cb` = 0, which terms off the buoyancy modification term,
 the molecular viscosity of seawater at 20 deg C and 35 psu is used for `ν`, and 
 the molecular diffusivity of heat in seawater at 20 deg C and 35 psu is used for `κ`.
+
+`Cν` or `Cκ` may be constant numbers, or functions of `x, y, z`.
+
+Example
+=======
+
+julia> pretty_diffusive_closure = AnisotropicMinimumDissipation(C=1/2)
+
+julia> const Δz = 0.5; # grid resolution at surface
+
+julia> surface_enhanced_tracer_C(x, y, z) = 1/12 * (1 + exp((z + Δz/2) / 8Δz))
+
+julia> fancy_closure = AnisotropicMinimumDissipation(Cκ=surface_enhanced_tracer_C)
+
+julia> tracer_specific_closure = AnisotropicMinimumDissipation(Cκ=(c₁=1/12, c₂=1/6))
+
 
 References
 ==========

--- a/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
+++ b/src/TurbulenceClosures/turbulence_closure_implementations/verstappen_anisotropic_minimum_dissipation.jl
@@ -12,7 +12,7 @@ struct VerstappenAnisotropicMinimumDissipation{FT, PK, PN, K} <: AbstractAnisotr
      κ :: K
 
     function VerstappenAnisotropicMinimumDissipation{FT}(Cν, Cκ, Cb, ν, κ) where FT
-        return new{FT, typeof(Cν), typeof(Cκ), typeof(κ)}(Cν, Cκ, Cb, ν, convert_diffusivity(FT, κ))
+        return new{FT, typeof(Cκ), typeof(Cν), typeof(κ)}(Cν, Cκ, Cb, ν, convert_diffusivity(FT, κ))
     end
 end
 

--- a/src/TurbulenceClosures/turbulence_closure_utils.jl
+++ b/src/TurbulenceClosures/turbulence_closure_utils.jl
@@ -6,7 +6,7 @@ function Base.convert(::TurbulenceClosure{T2}, closure::TurbulenceClosure{T1}) w
     return Closure(T2; paramdict...)
 end
 
-tracer_diffusivities(tracers, κ::Number) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
+tracer_diffusivities(tracers, κ::Union{Number, Function}) = with_tracers(tracers, NamedTuple(), (tracers, init) -> κ)
 
 function tracer_diffusivities(tracers, κ::NamedTuple)
 


### PR DESCRIPTION
This PR differentiates the AMD model constants for eddy viscosity and eddy diffusivity, and permits them to be functions of `x, y, z`. 

For simplicity we will permit just one model constant specification for all tracers. It is possible to permit different constants for different tracers, but 

Also, with this PR the "Verstappen" implementation of AMD is now diverging from the "Rozema" implementation. It may be time to nuke the "Rozema" implementation.