### PR TITLE
Ability to construct field tuples with non-zero data

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ At this time, updating should be done with care, as Oceananigans is under rapid 
 **Note**: Oceananigans requires at least Julia v1.1 to run correctly.
 
 ## Running your first model
-Let's initialize a 3D model with 100×100×50 grid points on a 2×2×1 km domain and simulate it for 10 time steps using steps of 60 seconds each (for a total of 10 minutes of simulation time).
+Let's initialize a 3D model with 100×100×50 grid points on a 2×2×1 km domain and simulate it for 1 time step of 60 seconds.
 ```julia
 using Oceananigans
-model = Model(grid = RegularCartesianGrid(size=(100, 100, 50), length = (2000, 2000, 1000)))
-time_step!(model; Δt=60, Nt=10)
+grid = RegularCartesianGrid(size=(100, 100, 50), length = (2000, 2000, 1000))
+model = IncompressibleModel(grid=grid)
+time_step!(model, 60)
 ```
 You just simulated what might have been a 3D patch of ocean, it's that easy! It was a still lifeless ocean so nothing interesting happened but now you can add interesting dynamics and visualize the output.
 
@@ -97,9 +98,11 @@ using Oceananigans
 
 # We'll set up a 2D model with an xz-slice so there's only 1 grid point in y
 # and use an artificially high viscosity ν and diffusivity κ.
-model = Model(architecture = CPU(),
-                      grid = RegularCartesianGrid(size=(128, 128, 128), length=(2000, 2000, 2000)),
-                   closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2))
+model = IncompressibleModel(
+    architecture = CPU(),
+            grid = RegularCartesianGrid(size=(128, 128, 128), length=(2000, 2000, 2000)),
+         closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
+)
 
 # Set a temperature perturbation with a Gaussian profile located at the center
 # of the vertical slice. This will create a buoyant thermal bubble that will
@@ -109,7 +112,8 @@ x₀, z₀ = Lx/2, Lz/2
 T₀(x, y, z) = 20 + 0.01 * exp(-100 * ((x - x₀)^2 + (z - z₀)^2) / (Lx^2 + Lz^2))
 set!(model; T=T₀)
 
-time_step!(model; Δt=10, Nt=5000)
+simulation = Simulation(model, Δt=10, stop_iteration=5000)
+run!(simulation)
 ```
 By changing `arch=CPU()` to `arch=GPU()`, the example will run on an Nvidia GPU!
 

--- a/src/AbstractOperations/AbstractOperations.jl
+++ b/src/AbstractOperations/AbstractOperations.jl
@@ -32,13 +32,13 @@ import Oceananigans.Diagnostics: run_diagnostic
 #####
 
 """
-    AbstractOperation{X, Y, Z, G} <: AbstractLocatedField{X, Y, Z, Nothing, G} end
+    AbstractOperation{X, Y, Z, G} <: AbstractField{X, Y, Z, Nothing, G}
 
 Represents an operation performed on grid of type `G` at locations `X`, `Y`, and `Z`.
 """
-abstract type AbstractOperation{X, Y, Z, G} <: AbstractLocatedField{X, Y, Z, Nothing, G} end
+abstract type AbstractOperation{X, Y, Z, G} <: AbstractField{X, Y, Z, Nothing, G} end
 
-const ALF = AbstractLocatedField
+const AF = AbstractField
 
 # We (informally) require that all field-like objects define `data` and `parent`:
 data(op::AbstractOperation) = op

--- a/src/AbstractOperations/binary_operations.jl
+++ b/src/AbstractOperations/binary_operations.jl
@@ -36,15 +36,15 @@ end
 
 @inline Base.getindex(β::BinaryOperation, i, j, k) = β.▶op(i, j, k, β.grid, β.op, β.▶a, β.▶b, β.a, β.b)
 
-"""Return an expression that defines an abstract `BinaryOperator` named `op` for `AbstractLocatedField`."""
+"""Return an expression that defines an abstract `BinaryOperator` named `op` for `AbstractField`."""
 function define_binary_operator(op)
     return quote
         import Oceananigans.Grids: AbstractGrid
-        import Oceananigans.Fields: AbstractLocatedField
+        import Oceananigans.Fields: AbstractField
 
         local location = Oceananigans.Fields.location
         local FunctionField = Oceananigans.AbstractOperations.FunctionField
-        local ALF = AbstractLocatedField
+        local AF = AbstractField
 
         @inline $op(i, j, k, grid::AbstractGrid, ▶a, ▶b, a, b) =
             @inbounds $op(▶a(i, j, k, grid, a), ▶b(i, j, k, grid, b))
@@ -65,19 +65,19 @@ function define_binary_operator(op)
         $op(Lc::Tuple, a, b) = $op(Lc, Lc, a, b)
         $op(Lc::Tuple, a::Number, b) = $op(Lc, location(b), a, b)
         $op(Lc::Tuple, a, b::Number) = $op(Lc, location(a), a, b)
-        $op(Lc::Tuple, a::ALF{X, Y, Z}, b::ALF{X, Y, Z}) where {X, Y, Z} = $op(Lc, location(a), a, b)
+        $op(Lc::Tuple, a::AF{X, Y, Z}, b::AF{X, Y, Z}) where {X, Y, Z} = $op(Lc, location(a), a, b)
 
         # Sugar for mixing in functions of (x, y, z)
         $op(Lc::Tuple, a::Function, b::AbstractField) = $op(Lc, FunctionField(Lc, a, b.grid), b)
         $op(Lc::Tuple, a::AbstractField, b::Function) = $op(Lc, a, FunctionField(Lc, b, a.grid))
 
         # Sugary versions with default locations
-        $op(a::ALF, b::ALF) = $op(location(a), a, b)
-        $op(a::ALF, b::Number) = $op(location(a), a, b)
-        $op(a::Number, b::ALF) = $op(location(b), a, b)
+        $op(a::AF, b::AF) = $op(location(a), a, b)
+        $op(a::AF, b::Number) = $op(location(a), a, b)
+        $op(a::Number, b::AF) = $op(location(b), a, b)
 
-        $op(a::ALF, b::Function) = $op(location(a), a, FunctionField(location(a), b, a.grid))
-        $op(a::Function, b::ALF) = $op(location(b), FunctionField(location(b), a, b.grid), b)
+        $op(a::AF, b::Function) = $op(location(a), a, FunctionField(location(a), b, a.grid))
+        $op(a::Function, b::AF) = $op(location(b), FunctionField(location(b), a, b.grid), b)
     end
 end
 

--- a/src/AbstractOperations/derivatives.jl
+++ b/src/AbstractOperations/derivatives.jl
@@ -46,53 +46,53 @@ const derivative_operators = Set([:∂x, :∂y, :∂z])
 push!(operators, derivative_operators...)
 
 """
-    ∂x(L::Tuple, a::Oceananigans.AbstractLocatedField)
+    ∂x(L::Tuple, a::AbstractField)
 
 Return an abstract representation of an x-derivative acting on `a` followed by
 interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Cell`s.
 """
-∂x(L::Tuple, arg::ALF{X, Y, Z}) where {X, Y, Z} =
+∂x(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂x(X), arg, (flip(X), Y, Z), arg.grid)
 
 """
-    ∂y(L::Tuple, a::Oceananigans.AbstractLocatedField)
+    ∂y(L::Tuple, a::AbstractField)
 
 Return an abstract representation of a y-derivative acting on `a` followed by
 interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Cell`s.
 """
-∂y(L::Tuple, arg::ALF{X, Y, Z}) where {X, Y, Z} =
+∂y(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂y(Y), arg, (X, flip(Y), Z), arg.grid)
 
 """
-    ∂z(L::Tuple, a::Oceananigans.AbstractLocatedField)
+    ∂z(L::Tuple, a::AbstractField)
 
 Return an abstract representation of a z-derivative acting on `a` followed by
 interpolation to `L`, where `L` is a 3-tuple of `Face`s and `Cell`s.
 """
-∂z(L::Tuple, arg::ALF{X, Y, Z}) where {X, Y, Z} =
+∂z(L::Tuple, arg::AF{X, Y, Z}) where {X, Y, Z} =
     _derivative(L, ∂z(Z), arg, (X, Y, flip(Z)), arg.grid)
 
 
 # Defaults
 """
-    ∂x(a::Oceananigans.AbstractLocatedField)
+    ∂x(a::AbstractField)
 
 Return an abstract representation of a x-derivative acting on `a`.
 """
-∂x(arg::ALF{X, Y, Z}) where {X, Y, Z} = ∂x((flip(X), Y, Z), arg)
+∂x(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂x((flip(X), Y, Z), arg)
 
 """
-    ∂y(a::Oceananigans.AbstractLocatedField)
+    ∂y(a::AbstractField)
 
 Return an abstract representation of a y-derivative acting on `a`.
 """
-∂y(arg::ALF{X, Y, Z}) where {X, Y, Z} = ∂y((X, flip(Y), Z), arg)
+∂y(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂y((X, flip(Y), Z), arg)
 """
-    ∂z(a::Oceananigans.AbstractLocatedField)
+    ∂z(a::AbstractField)
 
 Return an abstract representation of a z-derivative acting on `a`.
 """
-∂z(arg::ALF{X, Y, Z}) where {X, Y, Z} = ∂z((X, Y, flip(Z)), arg)
+∂z(arg::AF{X, Y, Z}) where {X, Y, Z} = ∂z((X, Y, flip(Z)), arg)
 
 "Adapt `Derivative` to work on the GPU via CUDAnative and CUDAdrv."
 Adapt.adapt_structure(to, deriv::Derivative{X, Y, Z}) where {X, Y, Z} =

--- a/src/AbstractOperations/function_fields.jl
+++ b/src/AbstractOperations/function_fields.jl
@@ -1,10 +1,10 @@
 """
-    FunctionField{X, Y, Z, C, F, G} <: AbstractLocatedField{X, Y, Z, F, G}
+    FunctionField{X, Y, Z, C, F, G} <: AbstractField{X, Y, Z, F, G}
 
-An `AbstractLocatedField` that returns a function evaluated at location `(X, Y, Z)` (and time, if
+An `AbstractField` that returns a function evaluated at location `(X, Y, Z)` (and time, if
 `C` is not `Nothing`) when indexed at `i, j, k`.
 """
-struct FunctionField{X, Y, Z, C, F, G} <: AbstractLocatedField{X, Y, Z, F, G}
+struct FunctionField{X, Y, Z, C, F, G} <: AbstractField{X, Y, Z, F, G}
      func :: F
      grid :: G
     clock :: C
@@ -12,7 +12,7 @@ struct FunctionField{X, Y, Z, C, F, G} <: AbstractLocatedField{X, Y, Z, F, G}
     """
         FunctionField{X, Y, Z}(func, grid; clock=nothing) where {X, Y, Z}
 
-    Returns a `FunctionField` on `grid` and at location `X, Y, Z`. 
+    Returns a `FunctionField` on `grid` and at location `X, Y, Z`.
 
     If `clock` is not specified, then `func` must be a function with signature
     `func(x, y, z)`. If clock is specified, `func` must be a function with signature

--- a/src/AbstractOperations/multiary_operations.jl
+++ b/src/AbstractOperations/multiary_operations.jl
@@ -21,7 +21,7 @@ end
 fieldify(L, a, grid) = a
 fieldify(L, a::Function, grid) = FunctionField(L, a, grid)
 
-"""Return an expression that defines an abstract `MultiaryOperator` named `op` for `AbstractLocatedField`."""
+"""Return an expression that defines an abstract `MultiaryOperator` named `op` for `AbstractField`."""
 function define_multiary_operator(op)
     return quote
         import Oceananigans.Fields: AbstractField

--- a/src/AbstractOperations/unary_operations.jl
+++ b/src/AbstractOperations/unary_operations.jl
@@ -74,7 +74,7 @@ macro unary(ops...)
     for op in ops
         define_unary_operator = quote
             import Oceananigans.Grids: AbstractGrid
-            import Oceananigans.Fields: AbstractLocatedField
+            import Oceananigans.Fields: AbstractField
 
             local location = Oceananigans.Fields.location
 
@@ -82,17 +82,17 @@ macro unary(ops...)
             @inline $op(i, j, k, grid::AbstractGrid, a::Number) = $op(a)
 
             """
-                $($op)(Lop::Tuple, a::AbstractLocatedField)
+                $($op)(Lop::Tuple, a::AbstractField)
 
             Returns an abstract representation of the operator `$($op)` acting on the Oceananigans `Field`
             `a`, and subsequently interpolated to the location indicated by `Lop`.
             """
-            function $op(Lop::Tuple, a::AbstractLocatedField)
+            function $op(Lop::Tuple, a::AbstractField)
                 L = location(a)
                 return Oceananigans.AbstractOperations._unary_operation(Lop, $op, a, L, a.grid)
             end
 
-            $op(a::AbstractLocatedField) = $op(location(a), a)
+            $op(a::AbstractField) = $op(location(a), a)
 
             push!(Oceananigans.AbstractOperations.operators, Symbol($op))
             push!(Oceananigans.AbstractOperations.unary_operators, Symbol($op))

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -5,7 +5,7 @@ using CUDAapi: has_cuda
 
 export
     @hascuda,
-    CPU, GPU,
+    AbstractArchitecture, CPU, GPU,
     device, architecture, array_type
 
 """

--- a/src/Diagnostics/cfl.jl
+++ b/src/Diagnostics/cfl.jl
@@ -34,7 +34,7 @@ for advection across a cell.
 Example
 =======
 ```julia
-julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(8, 8, 8)));
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(8, 8, 8)));
 
 julia> cfl = AdvectiveCFL(1.0);
 
@@ -59,7 +59,7 @@ returned.
 Example
 =======
 ```julia
-julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> dcfl = DiffusiveCFL(0.1);
 

--- a/src/Diagnostics/field_maximum.jl
+++ b/src/Diagnostics/field_maximum.jl
@@ -7,7 +7,7 @@ element-wise to `field`.
 Examples
 =======
 ```julia
-julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> max_abs_u = FieldMaximum(abs, model.velocities.u);
 

--- a/src/Diagnostics/time_series.jl
+++ b/src/Diagnostics/time_series.jl
@@ -19,7 +19,7 @@ A `TimeSeries` `Diagnostic` that records a time series of `diagnostic(model)`.
 Example
 =======
 ```julia
-julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)));
 
 julia> max_u = TimeSeries(FieldMaximum(abs, model.velocities.u), model; frequency=1)
 
@@ -55,7 +55,7 @@ A `TimeSeries` `Diagnostic` that records a `NamedTuple` of time series of
 Example
 =======
 ```julia
-julia> model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))); Δt = 1.0;
+julia> model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))); Δt = 1.0;
 
 julia> cfl = TimeSeries((adv=AdvectiveCFL(Δt), diff=DiffusiveCFL(Δt)), model; frequency=1);
 

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -9,7 +9,6 @@ export
     set!,
     VelocityFields, TracerFields, tracernames, PressureFields, Tendencies
 
-include("field_utils.jl")
 include("field.jl")
 include("set!.jl")
 include("field_tuples.jl")

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -2,7 +2,7 @@ module Fields
 
 export
     Face, Cell,
-    AbstractField, Field, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
+    AbstractField, Field, CellField, XFaceField, YFaceField, ZFaceField,
     interior, interiorparent,
     xnode, ynode, znode, location,
     set!,

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -2,8 +2,7 @@ module Fields
 
 export
     Face, Cell,
-    AbstractField, AbstractLocatedField,
-    Field, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
+    AbstractField, Field, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
     interior, interiorparent,
     xnode, ynode, znode, location,
     set!,

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -14,19 +14,12 @@ using Oceananigans.Utils
 @hascuda using CuArrays
 
 """
-    AbstractField{A, G}
-
-Abstract supertype for fields stored on an architecture `A` and defined on a grid `G`.
-"""
-abstract type AbstractField{A, G} end
-
-"""
-    AbstractLocatedField{X, Y, Z, A, G}
+    AbstractField{X, Y, Z, A, G}
 
 Abstract supertype for fields located at `(X, Y, Z)`, stored on an architecture `A`,
 and defined on a grid `G`.
 """
-abstract type AbstractLocatedField{X, Y, Z, A, G} <: AbstractField{A, G} end
+abstract type AbstractField{X, Y, Z, A, G} end
 
 """
     Cell
@@ -43,11 +36,11 @@ A type describing the location at the face of a grid cell.
 struct Face end
 
 """
-    Field{X, Y, Z, A, G} <: AbstractLocatedField{X, Y, Z, A, G}
+    Field{X, Y, Z, A, G} <: AbstractField{X, Y, Z, A, G}
 
 A field defined at the location (`X`, `Y`, `Z`) which can be either `Cell` or `Face`.
 """
-struct Field{X, Y, Z, A, G} <: AbstractLocatedField{X, Y, Z, A, G}
+struct Field{X, Y, Z, A, G} <: AbstractField{X, Y, Z, A, G}
     data :: A
     grid :: G
     function Field{X, Y, Z}(data, grid) where {X, Y, Z}
@@ -120,7 +113,7 @@ FaceFieldY(arch, grid) = Field((Cell, Face, Cell), arch, grid)
 FaceFieldZ(arch, grid) = Field((Cell, Cell, Face), arch, grid)
 
 location(a) = nothing
-location(::AbstractLocatedField{X, Y, Z}) where {X, Y, Z} = (X, Y, Z)
+location(::AbstractField{X, Y, Z}) where {X, Y, Z} = (X, Y, Z)
 
 architecture(f::Field) = architecture(f.data)
 architecture(o::OffsetArray) = architecture(o.parent)
@@ -179,10 +172,10 @@ nodes(ϕ) = (xnodes(ϕ), ynodes(ϕ), znodes(ϕ))
 
 # Niceties
 const AbstractCPUField =
-    AbstractField{A, G} where {A<:OffsetArray{T, D, <:Array} where {T, D}, G}
+    AbstractField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:Array} where {T, D}, G}
 
 @hascuda const AbstractGPUField =
-    AbstractField{A, G} where {A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
+    AbstractField{X, Y, Z, A, G} where {X, Y, Z, A<:OffsetArray{T, D, <:CuArray} where {T, D}, G}
 
 #####
 ##### Creating fields by dispatching on architecture

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -202,7 +202,12 @@ function Base.zeros(T, ::GPU, grid)
 end
 
 Base.zeros(T, ::CPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz)
-Base.zeros(T, ::GPU, grid, Nx, Ny, Nz) = zeros(T, Nx, Ny, Nz) |> CuArray
+
+function Base.zeros(T, ::GPU, grid, Nx, Ny, Nz)
+    data = CuArray{T}(undef, Nx, Ny, Nz)
+    data .= 0
+    return data
+end
 
 # Default to type of Grid
 Base.zeros(arch, grid::AbstractGrid{T}) where T = zeros(T, arch, grid)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -46,6 +46,14 @@ struct Field{X, Y, Z, A, G} <: AbstractField{X, Y, Z, A, G}
     data :: A
     grid :: G
     function Field{X, Y, Z}(data, grid) where {X, Y, Z}
+        Tx, Ty, Tz = grid.Nx+2grid.Hx, grid.Ny+2grid.Hy, grid.Nz+2grid.Hz
+        
+        if size(data) != (Tx, Ty, Tz)
+            e = "Cannot construct field with size(data)=$(size(data)). " *
+                "Must have the same size as the grid with halos ($Tx, $Ty, $Tz)."
+            throw(ArgumentError(e))
+        end
+
         return new{X, Y, Z, typeof(data), typeof(grid)}(data, grid)
     end
 end

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -1,30 +1,32 @@
 """
-    VelocityFields(arch, grid)
+    VelocityFields(arch, grid; u=zeros(arch, grid), v=zeros(arch, grid), w=zeros(arch, grid))
 
-Return a NamedTuple with fields `u`, `v`, `w` initialized on
-the architecture `arch` and `grid`.
+Return a NamedTuple with fields `u`, `v`, `w` initialized on the architecture `arch`
+and `grid`. Data arrays may be passed via the `u`, `v`, and `w` keyword arguments.
 """
-function VelocityFields(arch, grid)
-    u = FaceFieldX(arch, grid)
-    v = FaceFieldY(arch, grid)
-    w = FaceFieldZ(arch, grid)
+function VelocityFields(arch, grid; u=zeros(arch, grid), v=zeros(arch, grid), w=zeros(arch, grid))
+    u = XFaceField(arch, grid, u)
+    v = YFaceField(arch, grid, v)
+    w = ZFaceField(arch, grid, w)
     return (u=u, v=v, w=w)
 end
 
 """
-    TracerFields(arch, grid)
+    TracerFields(arch, grid, tracer_names; kwargs...)
 
-Return a NamedTuple with tracer fields initialized
-as `CellField`s on the architecture `arch` and `grid`.
+Return a NamedTuple with tracer fields specified by `tracer_names` initialized as
+`CellField`s on the architecture `arch` and `grid`. Optional `kwargs` can be specified
+to assign data arrays to each tracer field.
 """
-function TracerFields(arch, grid, tracernames)
-    tracerfields = Tuple(CellField(arch, grid) for c in tracernames)
-    return NamedTuple{tracernames}(tracerfields)
+function TracerFields(arch, grid, tracer_names; kwargs...)
+    tracer_fields = Tuple(c ∈ keys(kwargs) ? CellField(arch, grid, kwargs[c]) : CellField(arch, grid)
+                          for c in tracer_names)
+    return NamedTuple{tracer_names}(tracer_fields)
 end
 
 TracerFields(arch, grid, ::Union{Tuple{}, Nothing}) = NamedTuple{()}(())
-TracerFields(arch, grid, tracer::Symbol) = TracerFields(arch, grid, tuple(tracer))
-TracerFields(arch, grid, tracers::NamedTuple) = tracers
+TracerFields(arch, grid, tracer::Symbol; kwargs...) = TracerFields(arch, grid, tuple(tracer); kwargs...)
+TracerFields(arch, grid, tracers::NamedTuple; kwargs...) = tracers
 
 tracernames(::Nothing) = ()
 tracernames(name::Symbol) = tuple(name)
@@ -32,31 +34,31 @@ tracernames(names::NTuple{N, Symbol}) where N = :u ∈ names ? names[4:end] : na
 tracernames(::NamedTuple{names}) where names = tracernames(names)
 
 """
-    PressureFields(arch, grid)
+    PressureFields(arch, grid; pHY′=zeros(arch, grid), pNHS=zeros(arch, grid))
 
-Return a NamedTuple with pressure fields `pHY′` and `pNHS`
-initialized as `CellField`s on the architecture `arch` and `grid`.
+Return a NamedTuple with pressure fields `pHY′` and `pNHS` initialized as
+`CellField`s on the architecture `arch` and `grid`. Data arrays may be passed via
+the ``pHY′` and `pNHS` keyword arguments.
 """
-function PressureFields(arch, grid)
-    pHY′ = CellField(arch, grid)
-    pNHS = CellField(arch, grid)
+function PressureFields(arch, grid; pHY′=zeros(arch, grid), pNHS=zeros(arch, grid))
+    pHY′ = CellField(arch, grid, pHY′)
+    pNHS = CellField(arch, grid, pNHS)
     return (pHY′=pHY′, pNHS=pNHS)
 end
 
 """
-    Tendencies(arch, grid, tracernames)
+    Tendencies(arch, grid, tracer_names; kwargs...)
 
-Return a NamedTuple with tendencies for all solution fields
-(velocity fields and tracer fields), initialized on
-the architecture `arch` and `grid`.
+Return a NamedTuple with tendencies for all solution fields (velocity fields and
+tracer fields), initialized on the architecture `arch` and `grid`. Optional `kwargs`
+can be specified to assign data arrays to each tendency field.
 """
-function Tendencies(arch, grid, tracernames)
-
-    velocities = (u = FaceFieldX(arch, grid),
-                  v = FaceFieldY(arch, grid),
-                  w = FaceFieldZ(arch, grid))
-
-    tracers = TracerFields(arch, grid, tracernames)
-
+function Tendencies(arch, grid, tracer_names; kwargs...)
+    velocities = (
+        u = :u ∈ keys(kwargs) ? XFaceField(arch, grid, kwargs[:u]) : XFaceField(arch, grid),
+        v = :v ∈ keys(kwargs) ? YFaceField(arch, grid, kwargs[:v]) : YFaceField(arch, grid),
+        w = :w ∈ keys(kwargs) ? ZFaceField(arch, grid, kwargs[:w]) : ZFaceField(arch, grid)
+    )
+    tracers = TracerFields(arch, grid, tracer_names; kwargs...)
     return merge(velocities, tracers)
 end

--- a/src/Fields/set!.jl
+++ b/src/Fields/set!.jl
@@ -14,7 +14,7 @@ a function with arguments `(x, y, z)`, or any data type for which a
 Example
 =======
 ```julia
-model = Model(grid=RegularCartesianGrid(size=(32, 32, 32), length=(1, 1, 1))
+model = IncompressibleModel(grid=RegularCartesianGrid(size=(32, 32, 32), length=(1, 1, 1))
 
 # Set u to a parabolic function of z, v to random numbers damped
 # at top and bottom, and T to some silly array of half zeros,

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -1,16 +1,16 @@
+import Base: show
+
+using Oceananigans.Grids: show_domain
+
 show_location(X, Y, Z) = "($(typeof(X())), $(typeof(Y())), $(typeof(Z())))"
 
 show_location(field::AbstractField{X, Y, Z}) where {X, Y, Z} = show_location(X, Y, Z)
 
-short_show(a) = string(typeof(a))
-shortname(a::Array) = string(typeof(a).name.wrapper)
+short_show(field::Field) = string("Field at ", show_location(field))
 
-show(io::IO, field::Field) =
-    print(io,
-          short_show(field), '\n',
-          "├── data: ", typeof(field.data), '\n',
-          "└── grid: ", typeof(field.grid), '\n',
-          "    ├── size: ", size(field.grid), '\n',
-          "    └── domain: ", show_domain(field.grid), '\n')
-
-short_show(field::AbstractField) = string("Field at ", show_location(field))
+show(io::IO, field::Field{X, Y, Z}) where {X, Y, Z} =
+    print(io, "$(short_show(field))\n",
+          "├── data: $(typeof(field.data))\n",
+          "└── grid: $(typeof(field.grid))\n",
+          "    ├── size: $(size(field.grid))\n",
+          "    └── domain: $(show_domain(field.grid))\n")

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -1,8 +1,6 @@
-show_location(X, Y, Z) = string("(", string(typeof(X())), ", ",
-                                     string(typeof(Y())), ", ",
-                                     string(typeof(Z())), ")")
+show_location(X, Y, Z) = "($(typeof(X())), $(typeof(Y())), $(typeof(Z())))"
 
-show_location(field::AbstractLocatedField{X, Y, Z}) where {X, Y, Z} = show_location(X, Y, Z)
+show_location(field::AbstractField{X, Y, Z}) where {X, Y, Z} = show_location(X, Y, Z)
 
 short_show(a) = string(typeof(a))
 shortname(a::Array) = string(typeof(a).name.wrapper)
@@ -15,4 +13,4 @@ show(io::IO, field::Field) =
           "    ├── size: ", size(field.grid), '\n',
           "    └── domain: ", show_domain(field.grid), '\n')
 
-short_show(field::AbstractLocatedField) = string("Field at ", show_location(field))
+short_show(field::AbstractField) = string("Field at ", show_location(field))

--- a/src/Fields/show_fields.jl
+++ b/src/Fields/show_fields.jl
@@ -10,7 +10,7 @@ short_show(field::Field) = string("Field at ", show_location(field))
 
 show(io::IO, field::Field{X, Y, Z}) where {X, Y, Z} =
     print(io, "$(short_show(field))\n",
-          "├── data: $(typeof(field.data))\n",
+          "├── data: $(typeof(field.data)), size: $(size(field.data))\n",
           "└── grid: $(typeof(field.grid))\n",
           "    ├── size: $(size(field.grid))\n",
-          "    └── domain: $(show_domain(field.grid))\n")
+          "    └── domain: $(show_domain(field.grid))")

--- a/src/Forcing/model_forcing.jl
+++ b/src/Forcing/model_forcing.jl
@@ -11,7 +11,7 @@ Example
 
 julia> u_forcing = SimpleForcing((x, y, z, t) -> exp(z) * cos(t))
 
-julia> model = Model(forcing=ModelForcing(u=u_forcing))
+julia> model = IncompressibleModel(forcing=ModelForcing(u=u_forcing))
 """
 function ModelForcing(; u=zeroforcing, v=zeroforcing, w=zeroforcing, tracer_forcings...)
     u = at_location((Face, Cell, Cell), u)

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-export Model, ChannelModel, NonDimensionalModel, Clock
+export IncompressibleModel, NonDimensionalModel, Clock
 
 using Oceananigans.Architectures
 using Oceananigans.Fields
@@ -20,7 +20,7 @@ Abstract supertype for models.
 abstract type AbstractModel end
 
 include("clock.jl")
-include("model.jl")
+include("incompressible_model.jl")
 include("non_dimensional_model.jl")
 include("show_models.jl")
 

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -6,8 +6,8 @@ using Oceananigans.Architectures: AbstractArchitecture
 using Oceananigans.Buoyancy: validate_buoyancy
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers
 
-mutable struct Model{TS, E, A<:AbstractArchitecture, G, T, B, R, SW, U, C, Φ, F,
-                     BCS, S, K, Θ} <: AbstractModel
+mutable struct IncompressibleModel{TS, E, A<:AbstractArchitecture, G, T, B, R, SW, U, C, Φ, F,
+                                   BCS, S, K, Θ} <: AbstractModel
 
            architecture :: A         # Computer `Architecture` on which `Model` is run
                    grid :: G         # Grid of physical points on which `Model` is solved
@@ -28,7 +28,7 @@ mutable struct Model{TS, E, A<:AbstractArchitecture, G, T, B, R, SW, U, C, Φ, F
 end
 
 """
-    Model(;
+    IncompressibleModel(;
                    grid,
            architecture = CPU(),
              float_type = Float64,
@@ -48,7 +48,7 @@ end
         pressure_solver = PressureSolver(architecture, grid, PressureBoundaryConditions(boundary_conditions.u))
     )
 
-Construct an `Oceananigans.jl` model on `grid`.
+Construct an incompressible `Oceananigans.jl` model on `grid`.
 
 Keyword arguments
 =================
@@ -63,7 +63,7 @@ Keyword arguments
   or `ModelBoundaryConditions`. See `BoundaryConditions`, `HorizontallyPeriodicSolutionBCs`, and `ChannelSolutionBCs`.
 - `parameters`: User-defined parameters for use in user-defined forcing functions and boundary condition functions.
 """
-function Model(;
+function IncompressibleModel(;
                    grid,
            architecture = CPU(),
              float_type = Float64,
@@ -97,7 +97,7 @@ function Model(;
     closure = with_tracers(tracernames(tracers), closure)
     boundary_conditions = ModelBoundaryConditions(tracernames(tracers), diffusivities, boundary_conditions)
 
-    return Model(architecture, grid, clock, buoyancy, coriolis, surface_waves, velocities, tracers,
-                 pressures, forcing, closure, boundary_conditions, timestepper,
-                 pressure_solver, diffusivities, parameters)
+    return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
+                               velocities, tracers, pressures, forcing, closure, boundary_conditions,
+                               timestepper, pressure_solver, diffusivities, parameters)
 end

--- a/src/Models/non_dimensional_model.jl
+++ b/src/Models/non_dimensional_model.jl
@@ -18,7 +18,7 @@ forcing.
 
 Note that `N`, `L`, and `Re` are required.
 
-Additional `kwargs` are passed to the regular `Model` constructor.
+Additional `kwargs` are passed to the regular `IncompressibleModel` constructor.
 """
 function NonDimensionalModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
     buoyancy = BuoyancyTracer(),
@@ -26,6 +26,6 @@ function NonDimensionalModel(; grid, float_type=Float64, Re, Pr=0.7, Ro=Inf,
      closure = ConstantIsotropicDiffusivity(float_type, ν=1/Re, κ=1/(Pr*Re)),
     kwargs...)
 
-    return Model(; float_type=float_type, grid=grid, closure=closure,
-                   coriolis=coriolis, tracers=(:b,), buoyancy=buoyancy, kwargs...)
+    return IncompressibleModel(; float_type=float_type, grid=grid, closure=closure,
+                               coriolis=coriolis, tracers=(:b,), buoyancy=buoyancy, kwargs...)
 end

--- a/src/Models/show_models.jl
+++ b/src/Models/show_models.jl
@@ -9,4 +9,4 @@ Base.show(io::IO, model::IncompressibleModel) =
         "├── tracers: $(tracernames(model.tracers))\n",
         "├── closure: $(typeof(model.closure))\n",
         "├── buoyancy: $(typeof(model.buoyancy))\n",
-        "└── coriolis: $(typeof(model.coriolis))\n")
+        "└── coriolis: $(typeof(model.coriolis))")

--- a/src/Models/show_models.jl
+++ b/src/Models/show_models.jl
@@ -2,8 +2,8 @@ using Oceananigans.Grids: short_show
 using Oceananigans.Utils: prettytime, ordered_dict_show
 
 """Show the innards of a `Model` in the REPL."""
-Base.show(io::IO, model::Model) =
-    print(io, "Oceananigans.Model on a $(typeof(model.architecture)) architecture ",
+Base.show(io::IO, model::IncompressibleModel) =
+    print(io, "Oceananigans.IncompressibleModel on a $(typeof(model.architecture)) architecture ",
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
         "├── grid: $(short_show(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -46,7 +46,7 @@ export
     TimeStepWizard, update_Δt!,
 
     # Models
-    Model, ChannelModel, NonDimensionalModel,
+    IncompressibleModel, NonDimensionalModel,
 
     # Simulations
     Simulation, run!,

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -16,7 +16,7 @@ export
     RegularCartesianGrid, VerticallyStretchedCartesianGrid,
 
     # Fields and field manipulation
-    Field, CellField, FaceFieldX, FaceFieldY, FaceFieldZ,
+    Field, CellField, XFaceField, YFaceField, ZFaceField,
     interior, set!,
 
     # Forcing functions

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -125,7 +125,7 @@ function restore_from_checkpoint(filepath; kwargs=Dict())
         end
     end
 
-    model = Model(; kwargs...)
+    model = IncompressibleModel(; kwargs...)
 
     # Now restore fields.
     for p in cps

--- a/src/Simulations.jl
+++ b/src/Simulations.jl
@@ -110,8 +110,8 @@ end
 
 function stop_time_exceeded(sim)
     if sim.model.clock.time >= sim.stop_time
-          @info "Simulation is stopping. Model time $(sim.model.clock.time) " *
-                "has hit or exceeded simulation stop time $(sim.stop_time)."
+          @info "Simulation is stopping. Model time $(prettytime(sim.model.clock.time)) " *
+                "has hit or exceeded simulation stop time $(prettytime(sim.stop_time))."
           return true
     end
     return false
@@ -119,8 +119,8 @@ end
 
 function wall_time_limit_exceeded(sim)
     if sim.run_time >= sim.wall_time_limit
-          @info "Simulation is stopping. Simulation run time $(sim.run_time) " *
-                "has hit or exceeded simulation wall time limit $(sim.wall_time_limit)."
+          @info "Simulation is stopping. Simulation run time $(prettytime(sim.run_time)) " *
+                "has hit or exceeded simulation wall time limit $(prettytime(sim.wall_time_limit))."
           return true
     end
     return false
@@ -174,6 +174,6 @@ Base.show(io::IO, s::Simulation) =
             "├── Run time: $(prettytime(s.run_time)), wall time limit: $(s.wall_time_limit)\n",
             "├── Stop time: $(prettytime(s.stop_time)), stop iteration: $(s.stop_iteration)\n",
             "├── Diagnostics: $(ordered_dict_show(s.model.diagnostics, " "))\n",
-            "└── Output writers: $(ordered_dict_show(s.model.output_writers, "│"))\n")
+            "└── Output writers: $(ordered_dict_show(s.model.output_writers, "│"))")
 
 end

--- a/src/TimeSteppers/adams_bashforth.jl
+++ b/src/TimeSteppers/adams_bashforth.jl
@@ -31,12 +31,12 @@ end
 #####
 
 """
-    time_step!(model::Model{<:AdamsBashforthTimeStepper}, Δt; euler=false)
+    time_step!(model::IncompressibleModel{<:AdamsBashforthTimeStepper}, Δt; euler=false)
 
 Step forward `model` one time step `Δt` with a 2nd-order Adams-Bashforth method and
 pressure-correction substep. Setting `euler=true` will take a forward Euler time step.
 """
-function time_step!(model::Model{<:AdamsBashforthTimeStepper}, Δt; euler=false)
+function time_step!(model::IncompressibleModel{<:AdamsBashforthTimeStepper}, Δt; euler=false)
     χ = ifelse(euler, convert(eltype(model.grid), -0.5), model.timestepper.χ)
 
     # Convert NamedTuples of Fields to NamedTuples of OffsetArrays

--- a/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
+++ b/test/regression_tests/ocean_large_eddy_simulation_regression_test.jl
@@ -58,7 +58,7 @@ function run_ocean_large_eddy_simulation_regression_test(arch, closure)
     S_bcs = TracerBoundaryConditions(grid, top = BoundaryCondition(Flux, 5e-8))
 
     # Model instantiation
-    model = Model(
+    model = IncompressibleModel(
              architecture = arch,
                      grid = grid,
                  coriolis = FPlane(f=1e-4),

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -31,7 +31,7 @@ function run_rayleigh_benard_regression_test(arch)
     bbcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Value, 0.0),
                                           bottom = BoundaryCondition(Value, Δb))
 
-    model = Model(
+    model = IncompressibleModel(
                architecture = arch,
                        grid = grid,
                     closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ),

--- a/test/regression_tests/thermal_bubble_regression_test.jl
+++ b/test/regression_tests/thermal_bubble_regression_test.jl
@@ -5,7 +5,7 @@ function run_thermal_bubble_regression_test(arch)
 
     grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
     closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
-    model = Model(architecture=arch, grid=grid, closure=closure, coriolis=FPlane(f=1e-4))
+    model = IncompressibleModel(architecture=arch, grid=grid, closure=closure, coriolis=FPlane(f=1e-4))
     simulation = Simulation(model, Δt=6, stop_iteration=10)
 
     model.tracers.T.data.parent .= 9.85

--- a/test/test_abstract_operations.jl
+++ b/test/test_abstract_operations.jl
@@ -354,7 +354,7 @@ end
             for FT in float_types
                 @info "    Testing computation of abstract operations [$FT, $(typeof(arch))]..."
 
-                model = Model(
+                model = IncompressibleModel(
                     architecture = arch,
                       float_type = FT,
                             grid = RegularCartesianGrid(FT, size=(16, 16, 16), length=(1, 1, 1))

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -13,11 +13,11 @@ function test_z_boundary_condition_simple(arch, FT, fldname, bctype, bc, Nx, Ny)
     fieldbcs = TracerBoundaryConditions(grid, top=bc)
     modelbcs = SolutionBoundaryConditions(grid; Dict(fldname=>fieldbcs)...)
 
-    model = Model(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
 
     time_step!(model, 1e-16, euler=true)
 
-    return typeof(model) <: Model
+    return model isa IncompressibleModel
 end
 
 function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
@@ -29,7 +29,7 @@ function test_z_boundary_condition_top_bottom_alias(arch, FT, fldname)
     fieldbcs = TracerBoundaryConditions(grid, top=top_bc, bottom=bottom_bc)
     modelbcs = SolutionBoundaryConditions(grid; Dict(fldname=>fieldbcs)...)
 
-    model = Model(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions.solution, fldname)
 
@@ -53,7 +53,7 @@ function test_z_boundary_condition_array(arch, FT, fldname)
     fieldbcs = TracerBoundaryConditions(grid, top=value_bc)
     modelbcs = SolutionBoundaryConditions(grid; Dict(fldname=>fieldbcs)...)
 
-    model = Model(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, boundary_conditions=modelbcs)
 
     bcs = getfield(model.boundary_conditions.solution, fldname)
 
@@ -72,8 +72,8 @@ function test_flux_budget(arch, FT, fldname)
     modelbcs = SolutionBoundaryConditions(grid; Dict(fldname=>fieldbcs)...)
 
     closure = ConstantIsotropicDiffusivity(FT, ν=κ, κ=κ)
-    model = Model(grid=grid, closure=closure, architecture=arch,
-                  float_type=FT, buoyancy=nothing, boundary_conditions=modelbcs)
+    model = IncompressibleModel(grid=grid, closure=closure, architecture=arch,
+                                float_type=FT, buoyancy=nothing, boundary_conditions=modelbcs)
 
     if fldname ∈ (:u, :v, :w)
         field = getfield(model.velocities, fldname)
@@ -121,8 +121,9 @@ function fluxes_with_diffusivity_boundary_conditions_are_correct(arch, FT)
     model_bcs = ModelBoundaryConditions(tracer_names, diffusivities, solution_bcs;
                                         diffusivities=diffusivities_bcs)
 
-    model = Model(grid=grid, architecture=arch, float_type=FT, tracers=tracer_names, buoyancy=BuoyancyTracer(),
-                  closure=closure, diffusivities=diffusivities, boundary_conditions=model_bcs)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, tracers=tracer_names,
+                                buoyancy=BuoyancyTracer(), closure=closure, diffusivities=diffusivities,
+                                boundary_conditions=model_bcs)
 
     b₀(x, y, z) = z * bz
     set!(model, b=b₀)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1,6 +1,6 @@
 function horizontal_average_is_correct(arch, FT)
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(100, 100, 100))
-    model = Model(grid=grid, architecture=arch, float_type=FT)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
     T₀(x, y, z) = 20 + 0.01*z
     set!(model; T=T₀)
@@ -14,7 +14,7 @@ end
 
 function nan_checker_aborts_simulation(arch, FT)
     grid=RegularCartesianGrid(size=(16, 16, 2), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, float_type=FT)
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
     # It checks for NaNs in w by default.
     nc = NaNChecker(model; frequency=1, fields=Dict(:w => model.velocities.w.data.parent))
@@ -26,14 +26,16 @@ function nan_checker_aborts_simulation(arch, FT)
 end
 
 TestModel(::GPU, FT, ν=1.0, Δx=0.5) =
-    Model(grid = RegularCartesianGrid(FT, size=(16, 16, 16), length=(16Δx, 16Δx, 16Δx)),
+    IncompressibleModel(
+          grid = RegularCartesianGrid(FT, size=(16, 16, 16), length=(16Δx, 16Δx, 16Δx)),
        closure = ConstantIsotropicDiffusivity(FT, ν=ν, κ=ν),
   architecture = GPU(),
     float_type = FT
 )
 
 TestModel(::CPU, FT, ν=1.0, Δx=0.5) =
-    Model(grid = RegularCartesianGrid(FT, size=(3, 3, 3), length=(3Δx, 3Δx, 3Δx)),
+    IncompressibleModel(
+          grid = RegularCartesianGrid(FT, size=(3, 3, 3), length=(3Δx, 3Δx, 3Δx)),
        closure = ConstantIsotropicDiffusivity(FT, ν=ν, κ=ν),
   architecture = CPU(),
     float_type = FT

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -16,7 +16,7 @@ end
 function test_diffusion_simple(fieldname)
     grid = RegularCartesianGrid(size=(1, 1, 16), length=(1, 1, 1))
     closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
-    model = Model(grid=grid, closure=closure, buoyancy=nothing)
+    model = IncompressibleModel(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     value = π
     interior(field) .= value
@@ -29,7 +29,7 @@ end
 function test_diffusion_budget_default(fieldname)
     grid = RegularCartesianGrid(size=(1, 1, 16), length=(1, 1, 1))
     closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
-    model = Model(grid=grid, closure=closure, buoyancy=nothing)
+    model = IncompressibleModel(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     half_Nz = round(Int, model.grid.Nz/2)
     interior(field)[:, :,   1:half_Nz] .= -1
@@ -41,7 +41,7 @@ end
 function test_diffusion_budget_channel(fieldname)
     grid = RegularCartesianGrid(size=(1, 16, 4), length=(1, 1, 1), topology=(Periodic, Bounded, Bounded))
     closure = ConstantIsotropicDiffusivity(ν=1, κ=1)
-    model = Model(grid=grid, closure=closure, buoyancy=nothing)
+    model = IncompressibleModel(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
     half_Ny = round(Int, model.grid.Ny/2)
     interior(field)[:, 1:half_Ny,   :] .= -1
@@ -60,7 +60,7 @@ function test_diffusion_cosine(fieldname)
     Nz, Lz, κ, m = 128, π/2, 1, 2
     grid = RegularCartesianGrid(size=(1, 1, Nz), length=(1, 1, Lz))
     closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ)
-    model = Model(grid=grid, closure=closure, buoyancy=nothing)
+    model = IncompressibleModel(grid=grid, closure=closure, buoyancy=nothing)
     field = getmodelfield(fieldname, model)
 
     zC = model.grid.zC
@@ -113,7 +113,8 @@ function internal_wave_test(; N=128, Nt=10)
     # Create a model where temperature = buoyancy.
     grid = RegularCartesianGrid(size=(N, 1, N), length=(L, L, L))
     closure = ConstantIsotropicDiffusivity(ν=ν, κ=κ)
-    model = Model(grid=grid, closure=closure, buoyancy=BuoyancyTracer(), tracers=:b, coriolis=FPlane(f=f))
+    model = IncompressibleModel(grid=grid, closure=closure, buoyancy=BuoyancyTracer(),
+                                tracers=:b, coriolis=FPlane(f=f))
 
     set!(model, u=u₀, v=v₀, w=w₀, b=b₀)
 
@@ -138,7 +139,7 @@ function passive_tracer_advection_test(; N=128, κ=1e-12, Nt=100)
 
     grid = RegularCartesianGrid(size=(N, N, 2), length=(L, L, L))
     closure = ConstantIsotropicDiffusivity(ν=κ, κ=κ)
-    model = Model(grid=grid, closure=closure)
+    model = IncompressibleModel(grid=grid, closure=closure)
 
     set!(model, u=u₀, v=v₀, T=T₀)
 
@@ -168,11 +169,12 @@ function taylor_green_vortex_test(arch; FT=Float64, N=64, Nt=10)
     @inline u(x, y, z, t) = -sin(2π*y) * exp(-4π^2 * ν * t)
     @inline v(x, y, z, t) =  sin(2π*x) * exp(-4π^2 * ν * t)
 
-    model = Model(architecture = arch,
-                          grid = RegularCartesianGrid(FT, size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)),
-                       closure = ConstantIsotropicDiffusivity(FT, ν=1, κ=0),  # Turn off diffusivity.
-                       tracers = nothing,
-                      buoyancy = nothing)
+    model = IncompressibleModel(
+        architecture = arch,
+                grid = RegularCartesianGrid(FT, size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)),
+             closure = ConstantIsotropicDiffusivity(FT, ν=1, κ=0),  # Turn off diffusivity.
+             tracers = nothing,
+            buoyancy = nothing)
 
     u₀(x, y, z) = u(x, y, z, 0)
     v₀(x, y, z) = v(x, y, z, 0)

--- a/test/test_dynamics.jl
+++ b/test/test_dynamics.jl
@@ -200,7 +200,7 @@ function taylor_green_vortex_test(arch; FT=Float64, N=64, Nt=10)
     v_rel_err_max = maximum(v_rel_err)
 
     @info "Taylor-Green vortex test [$arch, $FT, Nx=Ny=$N, Nt=$Nt]: " *
-          @sprintf("Δu: (avg=%6.3g, max=%6.3g), Δv: (avg=%6.3g, max=%6.3g)\n",
+          @sprintf("Δu: (avg=%6.3g, max=%6.3g), Δv: (avg=%6.3g, max=%6.3g)",
                    u_rel_err_avg, u_rel_err_max, v_rel_err_avg, v_rel_err_max)
 
     u_rel_err_max < 5e-6 && v_rel_err_max < 5e-6

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -28,7 +28,7 @@ end
     N = (4, 6, 8)
     L = (2π, 3π, 5π)
 
-    fieldtypes = (CellField, FaceFieldX, FaceFieldY, FaceFieldZ)
+    fieldtypes = (CellField, XFaceField, YFaceField, ZFaceField)
 
     @testset "Field initialization" begin
         @info "  Testing field initialization..."

--- a/test/test_forcings.jl
+++ b/test/test_forcings.jl
@@ -15,7 +15,7 @@ function time_step_with_forcing_functions(arch)
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, forcing=forcing)
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, euler=true)
     return true
 end
@@ -28,7 +28,7 @@ function time_step_with_forcing_functions_params(arch)
     forcing = ModelForcing(u=Fu, v=Fv, w=Fw)
 
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, forcing=forcing, parameters=(τ=60,))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing, parameters=(τ=60,))
     time_step!(model, 1, euler=true)
     return true
 end
@@ -40,7 +40,7 @@ function time_step_with_forcing_functions_sin_exp(arch)
     forcing = ModelForcing(u=Fu, T=FT)
 
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, forcing=forcing)
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=forcing)
     time_step!(model, 1, euler=true)
     return true
 end
@@ -48,7 +48,7 @@ end
 function time_step_with_simple_forcing(arch)
     u_forcing = SimpleForcing((x, y, z, t) -> sin(x))
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
 end
@@ -56,7 +56,7 @@ end
 function time_step_with_simple_forcing_parameters(arch)
     u_forcing = SimpleForcing((x, y, z, t, p) -> sin(p.ω * x), parameters=(ω=π,))
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-    model = Model(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
+    model = IncompressibleModel(grid=grid, architecture=arch, forcing=ModelForcing(u=u_forcing))
     time_step!(model, 1, euler=true)
     return true
 end

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -1,5 +1,5 @@
 function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
-    model = Model(architecture=arch, float_type=eltype(grid), grid=grid)
+    model = IncompressibleModel(architecture=arch, float_type=eltype(grid), grid=grid)
     kwarg = Dict(fieldname=>value)
     set!(model; kwarg...)
 
@@ -13,8 +13,8 @@ function set_velocity_tracer_fields(arch, grid, fieldname, value, answer)
 end
 
 function initial_conditions_correctly_set(arch, FT)
-    model = Model(grid=RegularCartesianGrid(FT, size=(16, 16, 8), length=(1, 2, 3)),
-                  architecture=arch, float_type=FT)
+    model = IncompressibleModel(grid=RegularCartesianGrid(FT, size=(16, 16, 8), length=(1, 2, 3)),
+                                architecture=arch, float_type=FT)
 
     # Set initial condition to some basic function we can easily check for.
     # We offset the functions by an integer so that we don't end up comparing
@@ -54,10 +54,10 @@ end
         for arch in archs, FT in float_types
             topology = (Periodic, Periodic, Bounded)
             grid = RegularCartesianGrid(FT, size=(16, 16, 2), length=(1, 2, 3), topology=topology)
-            model = Model(grid=grid, architecture=arch, float_type=FT)
+            model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
-            # Just testing that a Model was constructed with no errors/crashes.
-            @test true
+            # Just testing that a horizontally periodic model was constructed with no errors/crashes.
+            @test model isa IncompressibleModel
         end
     end
 
@@ -66,10 +66,10 @@ end
         for arch in archs, FT in float_types
             topology = (Periodic, Bounded, Bounded)
             grid = RegularCartesianGrid(FT, size=(16, 16, 2), length=(1, 2, 3), topology=topology)
-            model = Model(grid=grid, architecture=arch, float_type=FT)
+            model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
-            # Just testing that a ChannelModel was constructed with no errors/crashes.
-            @test true
+            # Just testing that a channel model was constructed with no errors/crashes.
+            @test model isa IncompressibleModel
         end
     end
 
@@ -80,7 +80,7 @@ end
             model = NonDimensionalModel(architecture=arch, float_type=FT, grid=grid, Re=1, Pr=1, Ro=Inf)
 
             # Just testing that a NonDimensionalModel was constructed with no errors/crashes.
-            @test true
+            @test model isa IncompressibleModel
         end
     end
 

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -9,7 +9,7 @@ function run_thermal_bubble_netcdf_tests(arch)
 
     grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
     closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
-    model = Model(architecture=arch, grid=grid, closure=closure)
+    model = IncompressibleModel(architecture=arch, grid=grid, closure=closure)
     simulation = Simulation(model, Δt=6, stop_iteration=10)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
@@ -75,7 +75,7 @@ function run_thermal_bubble_netcdf_tests(arch)
 end
 
 function run_jld2_file_splitting_tests(arch)
-    model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+    model = IncompressibleModel(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
     simulation = Simulation(model, Δt=1, stop_iteration=10)
 
     u(model) = Array(model.velocities.u.data.parent)
@@ -126,7 +126,7 @@ function run_thermal_bubble_checkpointer_tests(arch)
 
     grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
     closure = ConstantIsotropicDiffusivity(ν=4e-2, κ=4e-2)
-    true_model = Model(architecture=arch, grid=grid, closure=closure)
+    true_model = IncompressibleModel(architecture=arch, grid=grid, closure=closure)
 
     # Add a cube-shaped warm temperature anomaly that takes up the middle 50%
     # of the domain volume.

--- a/test/test_regression.jl
+++ b/test/test_regression.jl
@@ -21,15 +21,15 @@ include("regression_tests/ocean_large_eddy_simulation_regression_test.jl")
     @info "Running regression tests..."
 
     for arch in archs
-        # @testset "Thermal bubble [$(typeof(arch))]" begin
-        #     @info "  Testing thermal bubble regression [$(typeof(arch))]"
-        #     run_thermal_bubble_regression_test(arch)
-        # end
-        #
-        # @testset "Rayleigh–Bénard tracer [$(typeof(arch))]" begin
-        #     @info "  Testing Rayleigh–Bénard tracer regression [$(typeof(arch))]"
-        #     run_rayleigh_benard_regression_test(arch)
-        # end
+        @testset "Thermal bubble [$(typeof(arch))]" begin
+            @info "  Testing thermal bubble regression [$(typeof(arch))]"
+            run_thermal_bubble_regression_test(arch)
+        end
+
+        @testset "Rayleigh–Bénard tracer [$(typeof(arch))]" begin
+            @info "  Testing Rayleigh–Bénard tracer regression [$(typeof(arch))]"
+            run_rayleigh_benard_regression_test(arch)
+        end
 
         @testset "Ocean large eddy simulation [$(typeof(arch))]" begin
             for closure in (AnisotropicMinimumDissipation(), ConstantSmagorinsky())

--- a/test/test_simulations.jl
+++ b/test/test_simulations.jl
@@ -6,7 +6,7 @@ using Oceananigans.Simulations:
 
     for arch in archs, Δt in (3, TimeStepWizard(Δt=5.0))
         grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1))
-        model = Model(architecture=arch, grid=grid)
+        model = IncompressibleModel(architecture=arch, grid=grid)
         simulation = Simulation(model, Δt=Δt, stop_iteration=1)
 
         # Just make sure we can construct a simulation without any errors.

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -47,9 +47,9 @@ function compute_w_from_continuity(arch, FT)
     grid = RegularCartesianGrid(FT; size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
     bcs = SolutionBoundaryConditions(grid)
 
-    u = FaceFieldX(FT, arch, grid)
-    v = FaceFieldY(FT, arch, grid)
-    w = FaceFieldZ(FT, arch, grid)
+    u = XFaceField(FT, arch, grid)
+    v = YFaceField(FT, arch, grid)
+    w = ZFaceField(FT, arch, grid)
     div_u = CellField(FT, arch, grid)
 
     interior(u) .= rand(FT, Nx, Ny, Nz)

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -2,7 +2,7 @@ function time_stepping_works_with_closure(arch, FT, Closure)
     # Use halos of size 2 to accomadate time stepping with AnisotropicBiharmonicDiffusivity.
     grid = RegularCartesianGrid(FT; size=(16, 16, 16), halo=(2, 2, 2), length=(1, 2, 3))
 
-    model = Model(grid=grid, architecture=arch, float_type=FT, closure=Closure(FT))
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT, closure=Closure(FT))
     time_step!(model, 1, euler=true)
 
     return true  # Test that no errors/crashes happen when time stepping.
@@ -14,7 +14,7 @@ function time_stepping_works_with_nonlinear_eos(arch, FT, eos_type)
     eos = RoquetIdealizedNonlinearEquationOfState(eos_type)
     b = SeawaterBuoyancy(equation_of_state=eos)
 
-    model = Model(architecture=arch, float_type=FT, grid=grid, buoyancy=b)
+    model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid, buoyancy=b)
     time_step!(model, 1, euler=true)
 
     return true  # Test that no errors/crashes happen when time stepping.
@@ -22,8 +22,8 @@ end
 
 function run_first_AB2_time_step_tests(arch, FT)
     add_ones(args...) = 1.0
-    model = Model(grid=RegularCartesianGrid(FT; size=(16, 16, 16), length=(1, 2, 3)),
-                  architecture=arch, float_type=FT, forcing=ModelForcing(T=add_ones))
+    model = IncompressibleModel(grid=RegularCartesianGrid(FT; size=(16, 16, 16), length=(1, 2, 3)),
+                                architecture=arch, float_type=FT, forcing=ModelForcing(T=add_ones))
     time_step!(model, 1, euler=true)
 
     # Test that GT = 1 after first time step and that AB2 actually reduced to forward Euler.
@@ -87,7 +87,8 @@ function incompressible_in_time(arch, FT, Nt)
     Nx, Ny, Nz = 32, 32, 32
     Lx, Ly, Lz = 10, 10, 10
 
-    model = Model(grid=RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)), architecture=arch, float_type=FT)
+    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    model = IncompressibleModel(grid=grid, architecture=arch, float_type=FT)
 
     grid = model.grid
     u, v, w = model.velocities.u, model.velocities.v, model.velocities.w
@@ -133,8 +134,8 @@ function tracer_conserved_in_channel(arch, FT, Nt)
 
     topology = (Periodic, Bounded, Bounded)
     grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
-    model = Model(architecture = arch, float_type = FT, grid = grid,
-                  closure = ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
+    model = IncompressibleModel(architecture = arch, float_type = FT, grid = grid,
+                                closure = ConstantAnisotropicDiffusivity(νh=νh, νv=νv, κh=κh, κv=κv))
 
     Ty = 1e-4  # Meridional temperature gradient [K/m].
     Tz = 5e-3  # Vertical temperature gradient [K/m].

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -101,8 +101,8 @@ end
 function time_step_with_tupled_closure(FT, arch)
     closure_tuple = (AnisotropicMinimumDissipation(FT), ConstantAnisotropicDiffusivity(FT))
 
-    model = Model(architecture=arch, float_type=FT, closure=closure_tuple,
-                  grid=RegularCartesianGrid(FT, size=(16, 16, 16), length=(1, 2, 3)))
+    model = IncompressibleModel(architecture=arch, float_type=FT, closure=closure_tuple,
+                                grid=RegularCartesianGrid(FT, size=(16, 16, 16), length=(1, 2, 3)))
 
     time_step!(model, 1, euler=true)
     return true
@@ -111,7 +111,7 @@ end
 function compute_closure_specific_diffusive_cfl(closurename)
     grid = RegularCartesianGrid(size=(16, 16, 16), length=(1, 2, 3))
     closure = getproperty(TurbulenceClosures, closurename)()
-    model = Model(grid=grid, closure=closure)
+    model = IncompressibleModel(grid=grid, closure=closure)
     dcfl = DiffusiveCFL(0.1)
     dcfl(model)
     return true  # Just make sure dcfl(model) does not error.

--- a/verification/stratified_couette_flow/stratified_couette_flow.jl
+++ b/verification/stratified_couette_flow/stratified_couette_flow.jl
@@ -113,7 +113,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     ##### Non-dimensional model setup
     #####
 
-    model = Model(
+    model = IncompressibleModel(
                architecture = arch,
                        grid = grid,
                    buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=1.0, β=0.0)),


### PR DESCRIPTION
This PR is part 1/3 of making boundary conditions a field property.

I was refactoring the fields module, and in doing so I added optional kwargs to allow for data arrays to be passed.

This allows the checkpointer to be simplified as it no longer has to keep track of array references, and makes restoring/checkpointing large models possible. I will address this in part 2.

Changes:

1. `AbstractLocatedField` has been removed. Now there is only `AbstractField`.

2. Fields can now be initialized with a data array. This will make restoring/checkpointing large models possible.

    Right now `field.data` can store anything. We could check to make sure that `field.data` has the same size as the grid, but this is extra code and could limit flexibility in the future so I did not add a check for this.

3. Field tuple initializers (`VelocityFields`, `TracerFields`, etc.) can now accept data arrays through keyword arguments.

4. `FaceFieldX` has been renamed to `XFaceField`, and same for y and z.

Note: This PR branches off #626.