### PR TITLE
Simplify checkpointer and make it work for large models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.21.0"
+version = "0.22.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -91,6 +91,7 @@ makedocs(
                                      "model_setup/turbulent_diffusivity_closures_and_les_models.md",
                     "Diagnostics" => "model_setup/diagnostics.md",
                  "Output writers" => "model_setup/output_writers.md",
+                  "Checkpointing" => "model_setup/checkpointing.md",
                   "Time stepping" => "model_setup/time_stepping.md",
             "Setting initial conditions" =>
                                      "model_setup/setting_initial_conditions.md"

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -152,6 +152,13 @@ Pages   = [
 ]
 ```
 
+## Simulations
+```@autodocs
+Modules = [Oceananigans.Simulations]
+Private = false
+Pages   = ["Simulations.jl"]
+```
+
 ## Tubrulence closures
 ```@autodocs
 Modules = [Oceananigans.TurbulenceClosures]

--- a/docs/src/model_setup/checkpointing.md
+++ b/docs/src/model_setup/checkpointing.md
@@ -1,0 +1,31 @@
+# Checkpointing
+A checkpointer can be used to serialize the entire model state to a file from which the model can be restored at any
+time. This is useful if you'd like to periodically checkpoint when running long simulations in case of crashes or
+cluster time limits, but also if you'd like to restore from a checkpoint and try out multiple scenarios.
+
+For example, to periodically checkpoint the model state to disk every 1,000,000 seconds of simulation time to files of
+the form `model_checkpoint_iteration12500.jld2` where `12500` is the iteration number (automatically filled in)
+```@example
+model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+model.output_writers[:checkpointer] = Checkpointer(model; interval=1e6, prefix="model_checkpoint")
+```
+
+The default options should provide checkpoint files that are easy to restore from in most cases. For more advanced
+options and features, see [`Checkpointer`](@ref).
+
+## Restoring from a checkpoint file
+To restore the model from a checkpoint file, for example `model_checkpoint_12345.jld2`, simply call
+```
+model = restore_from_checkpoint("model_checkpoint_12345.jld2")
+```
+which will create a new model object that is identical to the one that was serialized to disk. You can continue time
+stepping after restoring from a checkpoint.
+
+You can pass additional parameters to the `Model` constructor. See [`restore_from_checkpoint`](@ref) for more
+information.
+
+## Restoring with functions
+JLD2 cannot serialize functions to disk. so if you used forcing functions, boundary conditions containing functions, or
+the model included references to functions then they will not be serialized to the checkpoint file. When restoring from
+a checkpoint file, any model property that contained functions must be manually restored via keyword arguments to
+[`restore_from_checkpoint`](@ref).

--- a/docs/src/model_setup/diagnostics.md
+++ b/docs/src/model_setup/diagnostics.md
@@ -4,12 +4,12 @@ interest you may want to save to disk, such as the horizontal average of the tem
 produce a time series of salinity. They also include utilities for diagnosing model health, such as the CFL number or
 to check for NaNs.
 
-Diagnostics are stored as a list of diagnostics in `model.diagnostics`. Diagnostics can be specified at model creation
-time or be specified at any later time and appended (or assigned with a key value pair) to `model.diagnostics`.
+Diagnostics are stored as a list of diagnostics in `simulation.diagnostics`. Diagnostics can be specified at model creation
+time or be specified at any later time and appended (or assigned with a key value pair) to `simulation.diagnostics`.
 
 Most diagnostics can be run at specified frequencies (e.g. every 25 time steps) or specified intervals (e.g. every
 15 minutes of simulation time). If you'd like to run a diagnostic on demand then do not specify a frequency or interval
-(and do not add it to `model.diagnostics`).
+(and do not add it to `simulation.diagnostics`).
 
 We describe the `HorizontalAverage` diagnostic in detail below but see the API documentation for other diagnostics such
 as [`TimeSeries`](@ref), [`FieldMaximum`](@ref), [`CFL`](@ref), and [`NaNChecker`](@ref).
@@ -18,26 +18,29 @@ as [`TimeSeries`](@ref), [`FieldMaximum`](@ref), [`CFL`](@ref), and [`NaNChecker
 You can create a `HorizontalAverage` diagnostic by passing a field to the constructor, e.g.
 ```@example
 model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+simulation = Simulation(model, Δt=6, stop_iteration=10)
 T_avg = HorizontalAverage(model.tracers.T)
-push!(model.diagnostics, T_avg)
+push!(simulation.diagnostics, T_avg)
 ```
 which can then be called on-demand via `T_avg(model)` to return the horizontally averaged temperature. When running on
 the GPU you may want it to return an `Array` instead of a `CuArray` in case you want to save the horizontal average to
 disk in which case you'd want to construct it like
 ```@example
 model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
-T_avg = HorizontalAverage(model.tracers.T; return_type=Array)
-push!(model.diagnostics, T_avg)
+simulation = Simulation(model, Δt=6, stop_iteration=10)
+T_avg = HorizontalAverage(model.tracers.T, return_type=Array)
+push!(simulation.diagnostics, T_avg)
 ```
 
 You can also use pass an abstract operator to take the horizontal average of any diagnosed quantity. For example, to
 compute the horizontal average of the vertical component of vorticity:
 ```@example
 model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+simulation = Simulation(model, Δt=6, stop_iteration=10)
 u, v, w = model.velocities
 ζ = ∂x(v) - ∂y(u)
 ζ_avg = HorizontalAverage(ζ)
-model.diagnostics[:vorticity_profile] = ζ_avg
+simulation.diagnostics[:vorticity_profile] = ζ_avg
 ```
 
 See [`HorizontalAverage`](@ref) for more details and options.

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -3,9 +3,9 @@ Saving model data to disk can be done in a flexible manner using output writers.
 implemented are a NetCDF output writer (relying on [NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl))
 and a JLD2 output writer (relying on [JLD2.jl](https://github.com/JuliaIO/JLD2.jl)).
 
-Output writers are stored as a list of output writers in `model.output_writers`. Output writers can be specified at
-model creation time or be specified at any later time and appended (or assigned with a key value pair) to
-`model.output_writers`.
+Output writers are stored as a list of output writers in `simulation.output_writers`. Output writers can be specified
+at model creation time or be specified at any later time and appended (or assigned with a key value pair) to
+`simulation.output_writers`.
 
 ## NetCDF output writer
 Model data can be saved to NetCDF files along with associated metadata. The NetCDF output writer is generally used by
@@ -16,6 +16,7 @@ slices) along with output attributes
 ```@example
 Nx = Ny = Nz = 16
 model = Model(grid=RegularCartesianGrid(size=(Nx, Ny, Nz), length=(1, 1, 1)))
+simulation = Simulation(model, Δt=12, stop_time=3600)
 
 fields = Dict(
     "u" => model.velocities.u,
@@ -27,12 +28,14 @@ output_attributes = Dict(
     "T" => Dict("longname" => "Temperature", "units" => "C")
 )
 
-model.output_writers[:field_writer] = NetCDFOutputWriter(model, fields; filename="output_fields.nc",
-                                                         interval=6hour, output_attributes=output_attributes)
+simulation.output_writers[:field_writer] =
+    NetCDFOutputWriter(model, fields; filename="output_fields.nc",
+                       interval=6hour, output_attributes=output_attributes)
 
-model.output_writers[:surface_slice_writer] = NetCDFOutputWriter(model, fields; filename="output_surface_xy_slice.nc",
-                                                                 interval=5minute, output_attributes=output_attributes,
-                                                                 zC=Nz, zF=Nz)
+simulation.output_writers[:surface_slice_writer] =
+    NetCDFOutputWriter(model, fields; filename="output_surface_xy_slice.nc",
+                       interval=5minute, output_attributes=output_attributes,
+                       zC=Nz, zF=Nz)
 ```
 
 See [`NetCDFOutputWriter`](@ref) for more details and options.
@@ -47,6 +50,7 @@ of the function will be saved to the JLD2 file. For example, to write out 3D fie
 of T every 1 hour of simulation time to a file called `some_data.jld2`
 ```@example
 model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
+simulation = Simulation(model, Δt=12, stop_time=3600)
 
 function init_save_some_metadata(file, model)
     file["author"] = "Chim Riggles"
@@ -62,9 +66,9 @@ outputs = Dict(
     :T_avg => model -> T_avg(model)
 )
 
-jld2_writer = JLD2OutputWriter(model, outputs; init=init_save_some_metadata, interval=1hour, prefix="some_data")
+jld2_writer = JLD2OutputWriter(model, outputs, init=init_save_some_metadata, interval=1hour, prefix="some_data")
 
-push!(model.output_writers, jld2_writer)
+push!(simulation.output_writers, jld2_writer)
 ```
 
 See [`JLD2OutputWriter`](@ref) for more details and options.

--- a/docs/src/model_setup/output_writers.md
+++ b/docs/src/model_setup/output_writers.md
@@ -68,35 +68,3 @@ push!(model.output_writers, jld2_writer)
 ```
 
 See [`JLD2OutputWriter`](@ref) for more details and options.
-
-## Checkpointer
-A checkpointer can be used to serialize the entire model state to a file from which the model can be restored at any
-time. This is useful if you'd like to periodically checkpoint when running long simulations in case of crashes or
-cluster time limits, but also if you'd like to restore from a checkpoint and try out multiple scenarios.
-
-For example, to periodically checkpoint the model state to disk every 1,000,000 seconds of simulation time to files of
-the form `model_checkpoint_xxx.jld2` where `xxx` is the iteration number (automatically filled in)
-```@example
-model = Model(grid=RegularCartesianGrid(size=(16, 16, 16), length=(1, 1, 1)))
-model.output_writers[:checkpointer] = Checkpointer(model; interval=1e6, prefix="model_checkpoint")
-```
-
-The default options should provide checkpoint files that are easy to restore from in most cases. For more advanced
-options and features, see [`Checkpointer`](@ref).
-
-### Restoring from a checkpoint file
-To restore the model from a checkpoint file, for example `model_checkpoint_12345.jld2`, simply call
-```
-model = restore_from_checkpoint("model_checkpoint_12345.jld2")
-```
-which will create a new model object that is identical to the one that was serialized to disk. You can continue time
-stepping after restoring from a checkpoint.
-
-You can pass additional parameters to the `Model` constructor. See [`restore_from_checkpoint`](@ref) for more
-information.
-
-### Restoring with functions
-JLD2 cannot serialize functions to disk. so if you used forcing functions, boundary conditions containing functions, or
-the model included references to functions then they will not be serialized to the checkpoint file. When restoring from
-a checkpoint file, any model property that contained functions must be manually restored via keyword arguments to
-[`restore_from_checkpoint`](@ref).

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -6,7 +6,7 @@ export
     interior, interiorparent,
     xnode, ynode, znode, location,
     set!,
-    VelocityFields, TracerFields, tracernames, PressureFields, Tendencies
+    VelocityFields, TracerFields, tracernames, PressureFields, TendencyFields
 
 include("field.jl")
 include("set!.jl")

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -47,13 +47,13 @@ function PressureFields(arch, grid; pHY′=zeros(arch, grid), pNHS=zeros(arch, g
 end
 
 """
-    Tendencies(arch, grid, tracer_names; kwargs...)
+    TendencyFields(arch, grid, tracer_names; kwargs...)
 
 Return a NamedTuple with tendencies for all solution fields (velocity fields and
 tracer fields), initialized on the architecture `arch` and `grid`. Optional `kwargs`
 can be specified to assign data arrays to each tendency field.
 """
-function Tendencies(arch, grid, tracer_names; kwargs...)
+function TendencyFields(arch, grid, tracer_names; kwargs...)
     velocities = (
         u = :u ∈ keys(kwargs) ? XFaceField(arch, grid, kwargs[:u]) : XFaceField(arch, grid),
         v = :v ∈ keys(kwargs) ? YFaceField(arch, grid, kwargs[:v]) : YFaceField(arch, grid),

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -81,7 +81,7 @@ function IncompressibleModel(;
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, tracernames(tracers), closure),
      timestepper_method = :AdamsBashforth,
-            timestepper = TimeStepper(timestepper_method, float_type, architecture, grid, tracers),
+            timestepper = TimeStepper(timestepper_method, float_type, architecture, grid, tracernames(tracers)),
         pressure_solver = PressureSolver(architecture, grid, PressureBoundaryConditions(boundary_conditions))
     )
 
@@ -89,12 +89,12 @@ function IncompressibleModel(;
          throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
     end
 
-    validate_buoyancy(buoyancy, tracers)
+    validate_buoyancy(buoyancy, tracernames(tracers))
 
     # Regularize forcing, boundary conditions, and closure for given tracer fields
-    forcing = ModelForcing(tracers, forcing)
-    closure = with_tracers(tracers, closure)
-    boundary_conditions = ModelBoundaryConditions(tracers, diffusivities, boundary_conditions)
+    forcing = ModelForcing(tracernames(tracers), forcing)
+    closure = with_tracers(tracernames(tracers), closure)
+    boundary_conditions = ModelBoundaryConditions(tracernames(tracers), diffusivities, boundary_conditions)
 
     return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
                                velocities, tracer_fields, pressures, forcing, closure, boundary_conditions,

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -80,15 +80,14 @@ function IncompressibleModel(;
           tracer_fields = TracerFields(architecture, grid, tracers),
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, tracernames(tracers), closure),
-            timestepper = :AdamsBashforth,
+     timestepper_method = :AdamsBashforth,
+            timestepper = TimeStepper(timestepper_method, float_type, architecture, grid, tracers),
         pressure_solver = PressureSolver(architecture, grid, PressureBoundaryConditions(boundary_conditions))
     )
 
-    if architecture == GPU()
-        !has_cuda() && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
+    if architecture == GPU() && !has_cuda()
+         throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
     end
-
-    timestepper = TimeStepper(timestepper, float_type, architecture, grid, tracers)
 
     validate_buoyancy(buoyancy, tracers)
 

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -77,6 +77,7 @@ function IncompressibleModel(;
     boundary_conditions = SolutionBoundaryConditions(grid),
              parameters = nothing,
              velocities = VelocityFields(architecture, grid),
+          tracer_fields = TracerFields(architecture, grid, tracers),
               pressures = PressureFields(architecture, grid),
           diffusivities = TurbulentDiffusivities(architecture, grid, tracernames(tracers), closure),
             timestepper = :AdamsBashforth,
@@ -87,17 +88,16 @@ function IncompressibleModel(;
         !has_cuda() && throw(ArgumentError("Cannot create a GPU model. No CUDA-enabled GPU was detected!"))
     end
 
-    timestepper = TimeStepper(timestepper, float_type, architecture, grid, tracernames(tracers))
+    timestepper = TimeStepper(timestepper, float_type, architecture, grid, tracers)
 
-    tracers = TracerFields(architecture, grid, tracers)
-    validate_buoyancy(buoyancy, tracernames(tracers))
+    validate_buoyancy(buoyancy, tracers)
 
     # Regularize forcing, boundary conditions, and closure for given tracer fields
-    forcing = ModelForcing(tracernames(tracers), forcing)
-    closure = with_tracers(tracernames(tracers), closure)
-    boundary_conditions = ModelBoundaryConditions(tracernames(tracers), diffusivities, boundary_conditions)
+    forcing = ModelForcing(tracers, forcing)
+    closure = with_tracers(tracers, closure)
+    boundary_conditions = ModelBoundaryConditions(tracers, diffusivities, boundary_conditions)
 
     return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
-                               velocities, tracers, pressures, forcing, closure, boundary_conditions,
+                               velocities, tracer_fields, pressures, forcing, closure, boundary_conditions,
                                timestepper, pressure_solver, diffusivities, parameters)
 end

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -101,17 +101,24 @@ abstract type AbstractPoissonSolver end
 """
     AbstractDiagnostic
 
-Abstract supertype for types that compute diagnostic information from the current model
-state.
+Abstract supertype for diagnostics that compute information from the current
+model state.
 """
 abstract type AbstractDiagnostic end
 
 """
     AbstractOutputWriter
 
-Abstract supertype for types that perform input and output.
+Abstract supertype for output writers that write data to disk.
 """
 abstract type AbstractOutputWriter end
+
+"""
+    AbstractTimeStepper
+
+Abstract supertype for time steppers.
+"""
+abstract type AbstractTimeStepper end
 
 #####
 ##### Place-holder functions

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -113,13 +113,6 @@ Abstract supertype for output writers that write data to disk.
 """
 abstract type AbstractOutputWriter end
 
-"""
-    AbstractTimeStepper
-
-Abstract supertype for time steppers.
-"""
-abstract type AbstractTimeStepper end
-
 #####
 ##### Place-holder functions
 #####
@@ -160,9 +153,9 @@ include("BoundaryConditions/BoundaryConditions.jl")
 include("Solvers/Solvers.jl")
 include("Forcing/Forcing.jl")
 include("Models/Models.jl")
+include("TimeSteppers/TimeSteppers.jl")
 include("Diagnostics/Diagnostics.jl")
 include("OutputWriters/OutputWriters.jl")
-include("TimeSteppers/TimeSteppers.jl")
 include("Simulations.jl")
 include("AbstractOperations/AbstractOperations.jl")
 

--- a/src/OutputWriters/OutputWriters.jl
+++ b/src/OutputWriters/OutputWriters.jl
@@ -8,6 +8,7 @@ export
 
 using Oceananigans
 using Oceananigans.Grids
+using Oceananigans.Fields
 using Oceananigans.Architectures
 
 using Oceananigans: AbstractOutputWriter, @hascuda

--- a/src/OutputWriters/OutputWriters.jl
+++ b/src/OutputWriters/OutputWriters.jl
@@ -12,6 +12,7 @@ using Oceananigans.Fields
 using Oceananigans.Architectures
 
 using Oceananigans: AbstractOutputWriter, @hascuda
+using Oceananigans.Fields: OffsetArray
 
 @hascuda using CUDAnative, CuArrays
 

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -108,15 +108,15 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     grid = file["grid"]
 
     # Restore velocity fields
-    u_data = _arr(arch, file["velocities/u"])
-    v_data = _arr(arch, file["velocities/v"])
-    w_data = _arr(arch, file["velocities/w"])
+    u_data = OffsetArray(_arr(arch, file["velocities/u"]), grid)
+    v_data = OffsetArray(_arr(arch, file["velocities/v"]), grid)
+    w_data = OffsetArray(_arr(arch, file["velocities/w"]), grid)
     kwargs[:velocities] = VelocityFields(arch, grid, u=u_data, v=v_data, w=w_data)
     filter!(p -> p ≠ :velocities, cps)
 
     # Restore tracer fields
     tracer_names = Tuple(Symbol.(keys(file["tracers"])))
-    tracer_data  = Tuple(_arr(arch, file["tracers/$c"]) for c in tracer_names)
+    tracer_data  = Tuple(OffsetArray(_arr(arch, file["tracers/$c"]), grid) for c in tracer_names)
     tracer_field_kwargs = NamedTuple{tracer_names}(tracer_data)
     kwargs[:tracers] = tracer_names
     kwargs[:tracer_fields] = TracerFields(arch, grid, tracer_names; tracer_field_kwargs...)
@@ -124,8 +124,8 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
 
     # Restore time stepper tendency fields
     field_names = (:u, :v, :w, tracer_names...)
-    G⁻_data = Tuple(_arr(arch, file["timestepper/G⁻/$c"]) for c in field_names)
-    Gⁿ_data = Tuple(_arr(arch, file["timestepper/Gⁿ/$c"]) for c in field_names)
+    G⁻_data = Tuple(OffsetArray(_arr(arch, file["timestepper/G⁻/$c"]), grid) for c in field_names)
+    Gⁿ_data = Tuple(OffsetArray(_arr(arch, file["timestepper/Gⁿ/$c"]), grid) for c in field_names)
     G⁻_tendency_field_kwargs = NamedTuple{field_names}(G⁻_data)
     Gⁿ_tendency_field_kwargs = NamedTuple{field_names}(Gⁿ_data)
     kwargs[:timestepper_method] = :AdamsBashforth

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -132,8 +132,8 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     kwargs[:timestepper] =
         AdamsBashforthTimeStepper(
             eltype(grid), arch, grid, tracer_names;
-            Gⁿ = TendencyFields(arch, grid, tracer_names; G⁻_tendency_field_kwargs...),
-            G⁻ = TendencyFields(arch, grid, tracer_names; Gⁿ_tendency_field_kwargs...))
+            Gⁿ = TendencyFields(arch, grid, tracer_names; Gⁿ_tendency_field_kwargs...),
+            G⁻ = TendencyFields(arch, grid, tracer_names; G⁻_tendency_field_kwargs...))
     filter!(p -> p ≠ :timestepper, cps)
 
     for p in cps

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -90,8 +90,8 @@ end
 # This is the default name used in the simulation.output_writers ordered dict.
 defaultname(::Checkpointer, nelems) = :checkpointer
 
-_arr(::CPU, a) = a
-_arr(::GPU, a) = CuArray(a)
+convert_to_arch(::CPU, a) = a
+convert_to_arch(::GPU, a) = CuArray(a)
 
 """
     restore_from_checkpoint(filepath; kwargs=Dict())
@@ -108,15 +108,15 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     grid = file["grid"]
 
     # Restore velocity fields
-    u_data = OffsetArray(_arr(arch, file["velocities/u"]), grid)
-    v_data = OffsetArray(_arr(arch, file["velocities/v"]), grid)
-    w_data = OffsetArray(_arr(arch, file["velocities/w"]), grid)
+    u_data = OffsetArray(convert_to_arch(arch, file["velocities/u"]), grid)
+    v_data = OffsetArray(convert_to_arch(arch, file["velocities/v"]), grid)
+    w_data = OffsetArray(convert_to_arch(arch, file["velocities/w"]), grid)
     kwargs[:velocities] = VelocityFields(arch, grid, u=u_data, v=v_data, w=w_data)
     filter!(p -> p ≠ :velocities, cps)
 
     # Restore tracer fields
     tracer_names = Tuple(Symbol.(keys(file["tracers"])))
-    tracer_data  = Tuple(OffsetArray(_arr(arch, file["tracers/$c"]), grid) for c in tracer_names)
+    tracer_data  = Tuple(OffsetArray(convert_to_arch(arch, file["tracers/$c"]), grid) for c in tracer_names)
     tracer_field_kwargs = NamedTuple{tracer_names}(tracer_data)
     kwargs[:tracers] = tracer_names
     kwargs[:tracer_fields] = TracerFields(arch, grid, tracer_names; tracer_field_kwargs...)
@@ -124,8 +124,8 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
 
     # Restore time stepper tendency fields
     field_names = (:u, :v, :w, tracer_names...)
-    G⁻_data = Tuple(OffsetArray(_arr(arch, file["timestepper/G⁻/$c"]), grid) for c in field_names)
-    Gⁿ_data = Tuple(OffsetArray(_arr(arch, file["timestepper/Gⁿ/$c"]), grid) for c in field_names)
+    G⁻_data = Tuple(OffsetArray(convert_to_arch(arch, file["timestepper/G⁻/$c"]), grid) for c in field_names)
+    Gⁿ_data = Tuple(OffsetArray(convert_to_arch(arch, file["timestepper/Gⁿ/$c"]), grid) for c in field_names)
     G⁻_tendency_field_kwargs = NamedTuple{field_names}(G⁻_data)
     Gⁿ_tendency_field_kwargs = NamedTuple{field_names}(Gⁿ_data)
     kwargs[:timestepper_method] = :AdamsBashforth

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -1,6 +1,6 @@
-using Oceananigans: AbstractTimeStepper
 using Oceananigans.Fields: AbstractField
-using Oceananigans.BoundaryConditions: bctype, CoordinateBoundaryConditions
+using Oceananigans.BoundaryConditions: bctype, CoordinateBoundaryConditions, ModelBoundaryConditions
+using Oceananigans.TimeSteppers: AdamsBashforthTimeStepper
 
 #####
 ##### Output writer utilities
@@ -36,13 +36,23 @@ function saveproperty!(file, location, cbcs::CoordinateBoundaryConditions)
     end
 end
 
+# Special savepropety! for AB2 time stepper struct used by the checkpointer so
+# it only saves the fields and not the tendency BCs or χ value (as they can be
+# constructed by the `Model` constructor).
+function saveproperty!(file, location, ts::AdamsBashforthTimeStepper)
+    saveproperty!(file, location * "/Gⁿ", ts.Gⁿ)
+    saveproperty!(file, location * "/G⁻", ts.G⁻)
+end
+
 saveproperties!(file, structure, ps) = [saveproperty!(file, "$p", getproperty(structure, p)) for p in ps]
 
 # When checkpointing, `serializeproperty!` is used, which serializes objects
 # unless they need to be converted (basically CuArrays only).
-serializeproperty!(file, location, p) = file[location] = p
+
+serializeproperty!(file, location, p) = (file[location] = p)
+serializeproperty!(file, location, p::ModelBoundaryConditions) = (file[location] = p)
 serializeproperty!(file, location, p::Union{AbstractArray, AbstractField}) = saveproperty!(file, location, p)
-serializeproperty!(file, location, p::Union{NamedTuple, AbstractTimeStepper}) = saveproperty!(file, location, p)
+serializeproperty!(file, location, p::Union{NamedTuple, AdamsBashforthTimeStepper}) = saveproperty!(file, location, p)
 serializeproperty!(file, location, p::Function) = @warn "Cannot serialize Function property into $location"
 
 serializeproperties!(file, structure, ps) = [serializeproperty!(file, "$p", getproperty(structure, p)) for p in ps]

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -1,6 +1,6 @@
 using Oceananigans: AbstractTimeStepper
 using Oceananigans.Fields: AbstractField
-using Oceananigans.BoundaryConditions: CoordinateBoundaryConditions
+using Oceananigans.BoundaryConditions: bctype, CoordinateBoundaryConditions
 
 #####
 ##### Output writer utilities
@@ -25,13 +25,13 @@ saveproperty!(file, location, p) = [saveproperty!(file, location * "/$subp", get
 function saveproperty!(file, location, cbcs::CoordinateBoundaryConditions)
     for endpoint in propertynames(cbcs)
         endpoint_bc = getproperty(cbcs, endpoint)
-        if isa(endpoint_bc.condition, Function)
+        if endpoint_bc.condition isa Function
             @warn "$field.$coord.$endpoint boundary is of type Function and cannot be saved to disk!"
-            file["boundary_conditions/$field/$coord/$endpoint/type"] = string(bctype(endpoint_bc))
-            file["boundary_conditions/$field/$coord/$endpoint/condition"] = missing
+            file[location * "/$endpoint/type"] = string(bctype(endpoint_bc))
+            file[location * "/$endpoint/condition"] = missing
         else
-            file["boundary_conditions/$field/$coord/$endpoint/type"] = string(bctype(endpoint_bc))
-            file["boundary_conditions/$field/$coord/$endpoint/condition"] = endpoint_bc.condition
+            file[location * "/$endpoint/type"] = string(bctype(endpoint_bc))
+            file[location * "/$endpoint/condition"] = endpoint_bc.condition
         end
     end
 end

--- a/src/OutputWriters/output_writer_utils.jl
+++ b/src/OutputWriters/output_writer_utils.jl
@@ -1,3 +1,4 @@
+using Oceananigans: AbstractTimeStepper
 using Oceananigans.Fields: AbstractField
 using Oceananigans.BoundaryConditions: CoordinateBoundaryConditions
 
@@ -18,7 +19,7 @@ saveproperty!(file, location, p::Function) = @warn "Cannot save Function propert
 saveproperty!(file, location, p::Tuple) = [saveproperty!(file, location * "/$i", p[i]) for i in 1:length(p)]
 
 saveproperty!(file, location, p) = [saveproperty!(file, location * "/$subp", getproperty(p, subp))
-                                        for subp in propertynames(p)]
+                                    for subp in propertynames(p)]
 
 # Special saveproperty! so boundary conditions are easily readable outside julia.
 function saveproperty!(file, location, cbcs::CoordinateBoundaryConditions)
@@ -41,6 +42,7 @@ saveproperties!(file, structure, ps) = [saveproperty!(file, "$p", getproperty(st
 # unless they need to be converted (basically CuArrays only).
 serializeproperty!(file, location, p) = file[location] = p
 serializeproperty!(file, location, p::Union{AbstractArray, AbstractField}) = saveproperty!(file, location, p)
+serializeproperty!(file, location, p::Union{NamedTuple, AbstractTimeStepper}) = saveproperty!(file, location, p)
 serializeproperty!(file, location, p::Function) = @warn "Cannot serialize Function property into $location"
 
 serializeproperties!(file, structure, ps) = [serializeproperty!(file, "$p", getproperty(structure, p)) for p in ps]

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -22,13 +22,17 @@ using Oceananigans.SurfaceWaves
 using Oceananigans.BoundaryConditions
 using Oceananigans.Solvers
 using Oceananigans.Models
-using Oceananigans.Diagnostics
-using Oceananigans.OutputWriters
 using Oceananigans.Utils
 
-using Oceananigans: AbstractTimeStepper
 using Oceananigans.TurbulenceClosures:
     calculate_diffusivities!, ∂ⱼ_2ν_Σ₁ⱼ, ∂ⱼ_2ν_Σ₂ⱼ, ∂ⱼ_2ν_Σ₃ⱼ, ∇_κ_∇c
+
+"""
+    AbstractTimeStepper
+
+Abstract supertype for time steppers.
+"""
+abstract type AbstractTimeStepper end
 
 """
     TimeStepper(name, args...)

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -26,7 +26,9 @@ using Oceananigans.Diagnostics
 using Oceananigans.OutputWriters
 using Oceananigans.Utils
 
-using ..TurbulenceClosures: calculate_diffusivities!, ∂ⱼ_2ν_Σ₁ⱼ, ∂ⱼ_2ν_Σ₂ⱼ, ∂ⱼ_2ν_Σ₃ⱼ, ∇_κ_∇c
+using Oceananigans: AbstractTimeStepper
+using Oceananigans.TurbulenceClosures:
+    calculate_diffusivities!, ∂ⱼ_2ν_Σ₁ⱼ, ∂ⱼ_2ν_Σ₂ⱼ, ∂ⱼ_2ν_Σ₃ⱼ, ∇_κ_∇c
 
 """
     TimeStepper(name, args...)

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -14,6 +14,7 @@ using Oceananigans.Architectures: @hascuda
 
 using Oceananigans.Architectures
 using Oceananigans.Grids
+using Oceananigans.Fields
 using Oceananigans.Operators
 using Oceananigans.Coriolis
 using Oceananigans.Buoyancy
@@ -24,8 +25,6 @@ using Oceananigans.Models
 using Oceananigans.Diagnostics
 using Oceananigans.OutputWriters
 using Oceananigans.Utils
-
-using Oceananigans.Fields: Tendencies, tracernames
 
 using ..TurbulenceClosures: calculate_diffusivities!, ∂ⱼ_2ν_Σ₁ⱼ, ∂ⱼ_2ν_Σ₂ⱼ, ∂ⱼ_2ν_Σ₃ⱼ, ∇_κ_∇c
 

--- a/src/TimeSteppers/adams_bashforth.jl
+++ b/src/TimeSteppers/adams_bashforth.jl
@@ -1,10 +1,13 @@
 import Oceananigans.OutputWriters: saveproperty!
 
 """
-    AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ)
+    AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125;
+                              Gⁿ = TendencyFields(arch, grid, tracers),
+                              G⁻ = TendencyFields(arch, grid, tracers))
 
-Return an AdamsBashforthTimeStepper object with tendency
-fields on `arch` and `grid` and AB2 parameter `χ`.
+Return an AdamsBashforthTimeStepper object with tendency fields on `arch` and
+`grid` with AB2 parameter `χ`. The tendency fields can be specified via optional
+kwargs.
 """
 struct AdamsBashforthTimeStepper{T, TG}
       Gⁿ :: TG
@@ -12,9 +15,9 @@ struct AdamsBashforthTimeStepper{T, TG}
        χ :: T
 end
 
-function AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125)
-   Gⁿ = Tendencies(arch, grid, tracers)
-   G⁻ = Tendencies(arch, grid, tracers)
+function AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125;
+                                   Gⁿ = TendencyFields(arch, grid, tracers),
+                                   G⁻ = TendencyFields(arch, grid, tracers))
    return AdamsBashforthTimeStepper{float_type, typeof(Gⁿ)}(Gⁿ, G⁻, χ)
 end
 

--- a/src/TimeSteppers/adams_bashforth.jl
+++ b/src/TimeSteppers/adams_bashforth.jl
@@ -9,16 +9,16 @@ Return an AdamsBashforthTimeStepper object with tendency fields on `arch` and
 `grid` with AB2 parameter `χ`. The tendency fields can be specified via optional
 kwargs.
 """
-struct AdamsBashforthTimeStepper{T, TG}
-      Gⁿ :: TG
-      G⁻ :: TG
-       χ :: T
+struct AdamsBashforthTimeStepper{T, TG} <: AbstractTimeStepper
+     χ :: T
+    Gⁿ :: TG
+    G⁻ :: TG
 end
 
 function AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125;
                                    Gⁿ = TendencyFields(arch, grid, tracers),
                                    G⁻ = TendencyFields(arch, grid, tracers))
-   return AdamsBashforthTimeStepper{float_type, typeof(Gⁿ)}(Gⁿ, G⁻, χ)
+   return AdamsBashforthTimeStepper{float_type, typeof(Gⁿ)}(χ, Gⁿ, G⁻)
 end
 
 # Special savepropety! for AB2 time stepper struct used by the checkpointer so

--- a/src/TimeSteppers/adams_bashforth.jl
+++ b/src/TimeSteppers/adams_bashforth.jl
@@ -1,5 +1,3 @@
-import Oceananigans.OutputWriters: saveproperty!
-
 """
     AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125;
                               Gⁿ = TendencyFields(arch, grid, tracers),
@@ -19,14 +17,6 @@ function AdamsBashforthTimeStepper(float_type, arch, grid, tracers, χ=0.125;
                                    Gⁿ = TendencyFields(arch, grid, tracers),
                                    G⁻ = TendencyFields(arch, grid, tracers))
    return AdamsBashforthTimeStepper{float_type, typeof(Gⁿ)}(χ, Gⁿ, G⁻)
-end
-
-# Special savepropety! for AB2 time stepper struct used by the checkpointer so
-# it only saves the fields and not the tendency BCs or χ value (as they can be
-# constructed by the `Model` constructor).
-function saveproperty!(file, location, ts::AdamsBashforthTimeStepper)
-    saveproperty!(file, location * "/Gⁿ", ts.Gⁿ)
-    saveproperty!(file, location * "/G⁻", ts.G⁻)
 end
 
 #####

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -157,8 +157,8 @@ function run_thermal_bubble_checkpointer_tests(arch)
         time_step!(restored_model, Δt, euler=false)
     end
 
-    rm("checkpoint0.jld2", force=true)
-    rm("checkpoint5.jld2", force=true)
+    rm("checkpoint_iteration0.jld2", force=true)
+    rm("checkpoint_iteration5.jld2", force=true)
 
     # Now the true_model and restored_model should be identical.
     @test all(restored_model.velocities.u.data     .≈ true_model.velocities.u.data)

--- a/test/test_output_writers.jl
+++ b/test/test_output_writers.jl
@@ -151,7 +151,7 @@ function run_thermal_bubble_checkpointer_tests(arch)
     checkpointed_model = nothing
 
     model_kwargs = Dict{Symbol, Any}(:boundary_conditions => SolutionBoundaryConditions(grid))
-    restored_model = restore_from_checkpoint("checkpoint5.jld2", kwargs=model_kwargs)
+    restored_model = restore_from_checkpoint("checkpoint_iteration5.jld2", kwargs=model_kwargs)
 
     for n in 1:4
         time_step!(restored_model, Δt, euler=false)


### PR DESCRIPTION
This PR finally upgrades the checkpointer so it can restore large models that take up more than 50% of system memory. It used to create a model then restore the fields which allocates twice as much memory as needed. Now the data needed to restore the fields is passed to the model constructor so no double allocation. Some refactoring had to happen to make this possible.

This PR is also part 2/3 of making boundary conditions a field property.

Should help a lot with #602 and #603.

Resolves #416
Resolves #417

Note: This PR branches off #627.