### PR TITLE
Simulation parameters and prettier show methods

### DIFF
--- a/src/Models/show_models.jl
+++ b/src/Models/show_models.jl
@@ -2,8 +2,8 @@ using Oceananigans.Grids: short_show
 using Oceananigans.Utils: prettytime, ordered_dict_show
 
 """Show the innards of a `Model` in the REPL."""
-Base.show(io::IO, model::IncompressibleModel) =
-    print(io, "Oceananigans.IncompressibleModel on a $(typeof(model.architecture)) architecture ",
+Base.show(io::IO, model::IncompressibleModel{TS, C, A}) where {TS, C, A} =
+    print(io, "IncompressibleModel{$A, $(eltype(model.grid))} ",
         "(time = $(prettytime(model.clock.time)), iteration = $(model.clock.iteration)) \n",
         "├── grid: $(short_show(model.grid))\n",
         "├── tracers: $(tracernames(model.tracers))\n",

--- a/src/Simulations.jl
+++ b/src/Simulations.jl
@@ -13,7 +13,7 @@ using Oceananigans.OutputWriters
 using Oceananigans.TimeSteppers
 using Oceananigans.Utils
 
-mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F}
+mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F, Π}
                  model :: M
                     Δt :: Δ
          stop_criteria :: C
@@ -25,6 +25,7 @@ mutable struct Simulation{M, Δ, C, I, T, W, R, D, O, P, F}
         output_writers :: O
               progress :: P
     progress_frequency :: F
+            parameters :: Π
 end
 
 """
@@ -36,7 +37,8 @@ end
            diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
         output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
               progress = nothing,
-    progress_frequency = 1)
+    progress_frequency = 1,
+            parameters = nothing)
 
 Construct an Oceananigans.jl `Simulation` for a `model` with time step `Δt`.
 
@@ -55,6 +57,7 @@ Keyword arguments
   `progress_frequency` iterations. Useful for logging simulation health.
 - `progress_frequency`: How often to update the time step, check stop criteria, and call
   `progress` function (in number of iterations).
+- `parameters`: Parameters that can be accessed in the `progress` function.
 """
 function Simulation(model; Δt,
         stop_criteria = Any[iteration_limit_exceeded, stop_time_exceeded, wall_time_limit_exceeded],
@@ -64,7 +67,8 @@ function Simulation(model; Δt,
           diagnostics = OrderedDict{Symbol, AbstractDiagnostic}(),
        output_writers = OrderedDict{Symbol, AbstractOutputWriter}(),
              progress = nothing,
-   progress_frequency = 1)
+   progress_frequency = 1,
+           parameters = nothing)
 
    if stop_iteration == Inf && stop_time == Inf && wall_time_limit == Inf
        @warn "This simulation will run forever as stop iteration = stop time " *
@@ -79,7 +83,8 @@ function Simulation(model; Δt,
    run_time = 0.0
 
    return Simulation(model, Δt, stop_criteria, stop_iteration, stop_time, wall_time_limit,
-                     run_time, diagnostics, output_writers, progress, progress_frequency)
+                     run_time, diagnostics, output_writers, progress, progress_frequency,
+                     parameters)
 end
 
 function stop(sim)

--- a/src/Simulations.jl
+++ b/src/Simulations.jl
@@ -173,7 +173,7 @@ Base.show(io::IO, s::Simulation) =
             "├── Stop criteria: $(s.stop_criteria)\n",
             "├── Run time: $(prettytime(s.run_time)), wall time limit: $(s.wall_time_limit)\n",
             "├── Stop time: $(prettytime(s.stop_time)), stop iteration: $(s.stop_iteration)\n",
-            "├── Diagnostics: $(ordered_dict_show(s.model.diagnostics, " "))\n",
-            "└── Output writers: $(ordered_dict_show(s.model.output_writers, "│"))")
+            "├── Diagnostics: $(ordered_dict_show(s.diagnostics, " "))\n",
+            "└── Output writers: $(ordered_dict_show(s.output_writers, "│"))")
 
 end

--- a/src/Simulations.jl
+++ b/src/Simulations.jl
@@ -171,14 +171,14 @@ function run!(sim)
 end
 
 Base.show(io::IO, s::Simulation) =
-    print(io, "Oceananigans.Simulation with a model on a $(typeof(s.model.architecture)) architecture \n",
+    print(io, "Simulation{$(typeof(s.model).name){$(typeof(s.model.architecture)), $(eltype(s.model.grid))}}\n",
             "├── Model clock: time = $(prettytime(s.model.clock.time)), iteration = $(s.model.clock.iteration) \n",
             "├── Next time step ($(typeof(s.Δt))): $(prettytime(get_Δt(s.Δt))) \n",
             "├── Progress frequency: $(s.progress_frequency)\n",
             "├── Stop criteria: $(s.stop_criteria)\n",
             "├── Run time: $(prettytime(s.run_time)), wall time limit: $(s.wall_time_limit)\n",
             "├── Stop time: $(prettytime(s.stop_time)), stop iteration: $(s.stop_iteration)\n",
-            "├── Diagnostics: $(ordered_dict_show(s.diagnostics, " "))\n",
+            "├── Diagnostics: $(ordered_dict_show(s.diagnostics, "│"))\n",
             "└── Output writers: $(ordered_dict_show(s.output_writers, "│"))")
 
 end

--- a/src/Utils/ordered_dict_show.jl
+++ b/src/Utils/ordered_dict_show.jl
@@ -2,17 +2,13 @@ using OrderedCollections: OrderedDict
 
 function ordered_dict_show(dict, padchar)
     if length(dict) == 0
-        return string(typeof(dict), " with no entries")
+        return "$(typeof(dict).name) with no entries"
     elseif length(dict) == 1
-        return string(typeof(dict), " with 1 entry:", '\n',
-                      padchar, "   └── ", dict.keys[1], " => ", typeof(dict.vals[1]))
+        return "$(typeof(dict).name) with 1 entry:\n" *
+               "$padchar   └── $(dict.keys[1]) => $(typeof(dict.vals[1]).name)"
     else
-        return string(typeof(dict), " with $(length(dict)) entries:", '\n',
-                      Tuple(string(padchar,
-                                   "   ├── ", name, " => ", typeof(dict[name]), '\n')
-                            for name in dict.keys[1:end-1]
-                           )...,
-                           padchar, "   └── ", dict.keys[end], " => ", typeof(dict.vals[end])
-                      )
+        return string(typeof(dict).name, " with $(length(dict)) entries:\n",
+                      Tuple("$padchar   ├── $name => $(typeof(dict[name]).name)\n" for name in dict.keys[1:end-1])...,
+                            "$padchar   └── $(dict.keys[end]) => $(typeof(dict.vals[end]).name)")
     end
 end


### PR DESCRIPTION
This PR allows simulations to hold parameters, useful if you need to access stuff from the `progress` function (e.g. see https://github.com/thabbott/JULES.jl/pull/63) going with the idea that we'll probably get rid of `model.parameters` in favor of more local parameters.

It also cleans up show functions for models and simulations.