### PR TITLE
Fix method redefinition warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.24.0"
+version = "0.24.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -90,9 +90,6 @@ end
 # This is the default name used in the simulation.output_writers ordered dict.
 defaultname(::Checkpointer, nelems) = :checkpointer
 
-convert_to_arch(::CPU, a) = a
-convert_to_arch(::GPU, a) = CuArray(a)
-
 function restore_if_not_missing(file, address)
     if haskey(file, address)
         return file[address]
@@ -155,7 +152,7 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     Gⁿ_tendency_field_kwargs = NamedTuple{field_names}(Gⁿ_fields)
 
     kwargs[:timestepper_method] = :AdamsBashforth
-    kwargs[:timestepper] = 
+    kwargs[:timestepper] =
         AdamsBashforthTimeStepper(eltype(grid), arch, grid, tracer_names;
                                   G⁻ = TendencyFields(arch, grid, tracer_names; G⁻_tendency_field_kwargs...),
                                   Gⁿ = TendencyFields(arch, grid, tracer_names; Gⁿ_tendency_field_kwargs...))


### PR DESCRIPTION
Fixes #655

`convert_to_arch` was defined in two places.

Will release patch v0.24.1 once merged.