### PR TITLE
Model constructor cleanup

### DIFF
--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -46,7 +46,8 @@ noisy_field = CellField(arch, grid, TracerBoundaryConditions(grid), randn(16, 16
 tracer_fields = TracerFields(arch, grid, tracers, random=noisy_field)
 ```
 """
-function TracerFields(arch, grid, tracer_names; kwargs...)
+function TracerFields(arch, grid, names; kwargs...)
+    tracer_names = tracernames(names) # filter `names` if it contains velocity fields
     tracer_fields =
         Tuple(c ∈ keys(kwargs) ?
               kwargs[c] :
@@ -56,13 +57,14 @@ function TracerFields(arch, grid, tracer_names; kwargs...)
 end
 
 """
-    TracerFields(arch, grid, tracer_names, bcs::NamedTuple)
+    TracerFields(arch, grid, tracer_names, bcs)
 
 Return a NamedTuple with tracer fields specified by `tracer_names` initialized as
 `CellField`s on the architecture `arch` and `grid`. Boundary conditions `bcs` may
 be specified via a named tuple of `FieldBoundaryCondition`s.
 """
-function TracerFields(arch, grid, tracer_names, bcs::NamedTuple)
+function TracerFields(arch, grid, names, bcs)
+    tracer_names = tracernames(names) # filter `names` if it contains velocity fields
     tracer_fields =
         Tuple(c ∈ keys(bcs) ?
               CellField(arch, grid, bcs[c]) :
@@ -71,13 +73,36 @@ function TracerFields(arch, grid, tracer_names, bcs::NamedTuple)
     return NamedTuple{tracer_names}(tracer_fields)
 end
 
-TracerFields(arch, grid, ::Union{Tuple{}, Nothing}; kwargs...) = NamedTuple()
+TracerFields(arch, grid, ::Union{Tuple{}, Nothing}, args...; kwargs...) = NamedTuple()
 TracerFields(arch, grid, tracer::Symbol; kwargs...) = TracerFields(arch, grid, tuple(tracer); kwargs...)
-TracerFields(arch, grid, tracers::NamedTuple; kwargs...) = tracers
+
+"""
+    TracerFields(arch, grid, tracer_fields::NamedTuple; kwargs...)
+
+Convenience method for restoring checkpointed models that returns the already-instantiated
+`tracer_fields` with non-default boundary conditions.
+"""
+function TracerFields(arch, grid, proposed_tracer_fields::NamedTuple, bcs; kwargs...)
+    grid = proposed_tracer_fields[1].grid
+
+    tracer_fields = 
+        Tuple(c ∈ keys(bcs) ?
+              Field{Cell, Cell, Cell}(proposed_tracer_fields[c].data, grid, bcs[c]) :
+              Field{Cell, Cell, Cell}(proposed_tracer_fields[c].data, grid, TracerBoundaryConditions(grid))
+              for c in tracernames(proposed_tracer_fields))
+
+    return NamedTuple{tracernames(proposed_tracer_fields)}(tracer_fields)
+end
+
+"Shortcut constructor for empty tracer fields."
+TracerFields(arch, grid, empty_tracer_fields::NamedTuple{(),Tuple{}}, args...; kwargs...) = NamedTuple()
+
+"Returns true if the first three elements of `names` are `(:u, :v, :w)`."
+has_velocities(names) = :u == names[1] #&& :v == names[2] && :w == names[3]
 
 tracernames(::Nothing) = ()
 tracernames(name::Symbol) = tuple(name)
-tracernames(names::NTuple{N, Symbol}) where N = :u ∈ names ? names[4:end] : names
+tracernames(names::NTuple{N, Symbol}) where N = has_velocities(names) ? names[4:end] : names
 tracernames(::NamedTuple{names}) where names = tracernames(names)
 
 """

--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -98,7 +98,7 @@ end
 TracerFields(arch, grid, empty_tracer_fields::NamedTuple{(),Tuple{}}, args...; kwargs...) = NamedTuple()
 
 "Returns true if the first three elements of `names` are `(:u, :v, :w)`."
-has_velocities(names) = :u == names[1] #&& :v == names[2] && :w == names[3]
+has_velocities(names) = :u == names[1] && :v == names[2] && :w == names[3]
 
 tracernames(::Nothing) = ()
 tracernames(name::Symbol) = tuple(name)

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -42,7 +42,6 @@ end
                            w=WVelocityBoundaryConditions(grid)),
              parameters = nothing,
              velocities = VelocityFields(architecture, grid, boundary_conditions),
-          tracer_fields = TracerFields(architecture, grid, tracernames(tracers), boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
      timestepper_method = :AdamsBashforth,
@@ -80,7 +79,6 @@ function IncompressibleModel(;
                            w=WVelocityBoundaryConditions(grid)),
              parameters = nothing,
              velocities = VelocityFields(architecture, grid, boundary_conditions),
-          tracer_fields = TracerFields(architecture, grid, tracernames(tracers), boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
      timestepper_method = :AdamsBashforth,
@@ -97,6 +95,9 @@ function IncompressibleModel(;
     # Regularize forcing and closure for given tracer fields.
     forcing = ModelForcing(tracernames(tracers), forcing)
     closure = with_tracers(tracernames(tracers), closure)
+
+    # Instantiate tracer fields if not already instantiated
+    tracer_fields = TracerFields(architecture, grid, tracers, boundary_conditions)
 
     return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
                                velocities, tracer_fields, pressures, forcing, closure,

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -44,8 +44,7 @@ end
              velocities = VelocityFields(architecture, grid, boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
-     timestepper_method = :AdamsBashforth,
-            timestepper = TimeStepper(timestepper_method, float_type, architecture, grid, tracernames(tracers)),
+            timestepper = :AdamsBashforth,
         pressure_solver = PressureSolver(architecture, grid, PressureBoundaryConditions(grid))
     )
 
@@ -81,8 +80,7 @@ function IncompressibleModel(;
              velocities = VelocityFields(architecture, grid, boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
-     timestepper_method = :AdamsBashforth,
-            timestepper = TimeStepper(timestepper_method, float_type, architecture, grid, tracernames(tracers)),
+            timestepper = :AdamsBashforth,
         pressure_solver = PressureSolver(architecture, grid, PressureBoundaryConditions(grid))
     )
 
@@ -98,6 +96,9 @@ function IncompressibleModel(;
 
     # Instantiate tracer fields if not already instantiated
     tracer_fields = TracerFields(architecture, grid, tracers, boundary_conditions)
+
+    # Instantiate timestepper if not already instantiated
+    timestepper = TimeStepper(timestepper, float_type, architecture, grid, tracernames(tracers))
 
     return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
                                velocities, tracer_fields, pressures, forcing, closure,

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -154,7 +154,6 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     Gⁿ_tendency_field_kwargs = NamedTuple{field_names}(Gⁿ_fields)
 
     # Restore time stepper
-    kwargs[:timestepper_method] = :AdamsBashforth
     kwargs[:timestepper] =
         AdamsBashforthTimeStepper(eltype(grid), arch, grid, tracer_names;
                                   G⁻ = TendencyFields(arch, grid, tracer_names; G⁻_tendency_field_kwargs...),

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -140,7 +140,6 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     kwargs[:tracers] = TracerFields(arch, grid, tracer_names; tracer_fields_kwargs...)
 
     filter!(p -> p ≠ :tracers, cps) # pop :tracers from checkpointed properties
-    @show cps
 
     # Restore time stepper tendency fields
     field_names = (:u, :v, :w, tracer_names...) # field names

--- a/src/OutputWriters/checkpointer.jl
+++ b/src/OutputWriters/checkpointer.jl
@@ -139,7 +139,6 @@ function restore_from_checkpoint(filepath; kwargs=Dict{Symbol,Any}())
     tracer_fields_kwargs = NamedTuple{tracer_names}(tracer_fields)
     kwargs[:tracers] = TracerFields(arch, grid, tracer_names; tracer_fields_kwargs...)
 
-    @show cps
     filter!(p -> p ≠ :tracers, cps) # pop :tracers from checkpointed properties
     @show cps
 

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -50,7 +50,7 @@ function TimeStepper(name::Symbol, args...)
 end
 
 # Fallback
-TimeStepper(stepper, args...) = stepper
+TimeStepper(stepper::AbstractTimeStepper, args...) = stepper
 
 """Returns the arguments passed to boundary conditions functions."""
 boundary_condition_function_arguments(model) =


### PR DESCRIPTION
This PR consolidates the `tracers` and `tracer_fields` kwargs to `IncompressibleModel`, and the `timestepper` and `timestepper_method` kwargs to `IncompressibleModel`.

Resolves #647.