### PR TITLE
Calculate tendencies on boundaries

### DIFF
--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -58,6 +58,7 @@ boundary_condition_function_arguments(model) =
      datatuple(model.tracers), model.parameters)
 
 include("generic_time_stepping.jl")
+include("momentum_and_tracer_tendencies.jl")
 include("time_stepping_kernels.jl")
 include("adams_bashforth.jl")
 

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -58,7 +58,7 @@ boundary_condition_function_arguments(model) =
      datatuple(model.tracers), model.parameters)
 
 include("generic_time_stepping.jl")
-include("momentum_and_tracer_tendencies.jl")
+include("velocity_and_tracer_tendencies.jl")
 include("time_stepping_kernels.jl")
 include("adams_bashforth.jl")
 

--- a/src/TimeSteppers/generic_time_stepping.jl
+++ b/src/TimeSteppers/generic_time_stepping.jl
@@ -68,7 +68,7 @@ function calculate_tendencies!(tendencies, velocities, tracers, pressures, diffu
         model.tracers, boundary_condition_function_arguments(model)...)
 
     # Calculate momentum tendencies on boundaries in `Bounded` directions.
-    #calculate_momentum_tendencies_on_boundaries!(tendency_calculation_args...)
+    calculate_velocity_tendencies_on_boundaries!(tendency_calculation_args...)
 
     return nothing
 end

--- a/src/TimeSteppers/generic_time_stepping.jl
+++ b/src/TimeSteppers/generic_time_stepping.jl
@@ -51,19 +51,24 @@ function calculate_tendencies!(tendencies, velocities, tracers, pressures, diffu
     #
     # "model.timestepper.Gⁿ" is a NamedTuple of Fields, whose data also corresponds to 
     # tendency data.
-    #
-    tendency_args = (tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
-                     model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
-                     diffusivities, model.forcing, model.parameters, model.clock.time)
+    
+    # Arguments needed to calculate tendencies for momentum and tracers
+    tendency_calculation_args = (tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
+                                 model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
+                                 diffusivities, model.forcing, model.parameters, model.clock.time)
 
-    calculate_interior_tendency_contributions!(tendency_args...)
+    # Calculate contributions to momentum and tracer tendencies from fluxes and volume terms in the
+    # interior of the domain
+    calculate_interior_tendency_contributions!(tendency_calculation_args...)
 
+    # Calculate contributions to momentum and tracer tendencies from user-prescribed fluxes across the 
+    # boundaries of the domain
     calculate_boundary_tendency_contributions!(
         model.timestepper.Gⁿ, model.architecture, model.velocities,
         model.tracers, boundary_condition_function_arguments(model)...)
 
-    # Calculate
-    #calculate_tendencies_on_boundaries!(tendency_args...)
+    # Calculate momentum tendencies on boundaries in `Bounded` directions.
+    #calculate_momentum_tendencies_on_boundaries!(tendency_calculation_args...)
 
     return nothing
 end

--- a/src/TimeSteppers/generic_time_stepping.jl
+++ b/src/TimeSteppers/generic_time_stepping.jl
@@ -44,16 +44,26 @@ contribution from non-hydrostatic pressure.
 """
 function calculate_tendencies!(tendencies, velocities, tracers, pressures, diffusivities, model)
 
-    calculate_interior_source_terms!(
-        tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
-        model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
-        diffusivities, model.forcing, model.parameters, model.clock.time
-    )
+    # Note:
+    #
+    # "tendencies" is a NamedTuple of OffsetArrays corresponding to the tendency data for use
+    # in GPU computations.
+    #
+    # "model.timestepper.Gⁿ" is a NamedTuple of Fields, whose data also corresponds to 
+    # tendency data.
+    #
+    tendency_args = (tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
+                     model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
+                     diffusivities, model.forcing, model.parameters, model.clock.time)
 
-    calculate_boundary_source_terms!(
+    calculate_interior_tendency_contributions!(tendency_args...)
+
+    calculate_boundary_tendency_contributions!(
         model.timestepper.Gⁿ, model.architecture, model.velocities,
-        model.tracers, boundary_condition_function_arguments(model)...
-    )
+        model.tracers, boundary_condition_function_arguments(model)...)
+
+    # Calculate
+    #calculate_tendencies_on_boundaries!(tendency_args...)
 
     return nothing
 end

--- a/src/TimeSteppers/time_stepping_kernels.jl
+++ b/src/TimeSteppers/time_stepping_kernels.jl
@@ -45,13 +45,8 @@ end
 """ Calculate the right-hand-side of the u-momentum equation. """
 function calculate_Gu!(Gu, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, time)
     @loop_xyz i j k grid begin
-        @inbounds Gu[i, j, k] = ( - div_ũu(i, j, k, grid, U)
-                                  - x_f_cross_U(i, j, k, grid, coriolis, U)
-                                  - ∂xᶠᵃᵃ(i, j, k, grid, pHY′)
-                                  + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U, K)
-                                  + x_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  + ∂t_uˢ(i, j, k, grid, surface_waves, time)
-                                  + F.u(i, j, k, grid, time, U, C, parameters))
+        @inbounds Gu[i, j, k] = x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                                    closure, U, C, K, F, pHY′, parameters, time)
     end
     return nothing
 end
@@ -59,13 +54,8 @@ end
 """ Calculate the right-hand-side of the v-momentum equation. """
 function calculate_Gv!(Gv, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, time)
     @loop_xyz i j k grid begin
-        @inbounds Gv[i, j, k] = ( - div_ũv(i, j, k, grid, U)
-                                  - y_f_cross_U(i, j, k, grid, coriolis, U)
-                                  - ∂yᵃᶠᵃ(i, j, k, grid, pHY′)
-                                  + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U, K)
-                                  + y_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  + ∂t_vˢ(i, j, k, grid, surface_waves, time)
-                                  + F.v(i, j, k, grid, time, U, C, parameters))
+        @inbounds Gv[i, j, k] = y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                                    closure, U, C, K, F, pHY′, parameters, time)
     end
     return nothing
 end
@@ -73,12 +63,8 @@ end
 """ Calculate the right-hand-side of the w-momentum equation. """
 function calculate_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, parameters, time)
     @loop_xyz i j k grid begin
-        @inbounds Gw[i, j, k] = ( - div_ũw(i, j, k, grid, U)
-                                  - z_f_cross_U(i, j, k, grid, coriolis, U)
-                                  + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U, K)
-                                  + z_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-                                  + ∂t_wˢ(i, j, k, grid, surface_waves, time)
-                                  + F.w(i, j, k, grid, time, U, C, parameters))
+        @inbounds Gw[i, j, k] = z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                                    closure, U, C, K, F, parameters, time)
     end
     return nothing
 end
@@ -86,9 +72,8 @@ end
 """ Calculate the right-hand-side of the tracer advection-diffusion equation. """
 function calculate_Gc!(Gc, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc, parameters, time)
     @loop_xyz i j k grid begin
-        @inbounds Gc[i, j, k] = (- div_uc(i, j, k, grid, U, c)
-                                 + ∇_κ_∇c(i, j, k, grid, closure, c, tracer_index, K, C, buoyancy)
-                                 + Fc(i, j, k, grid, time, U, C, parameters))
+        @inbounds Gc[i, j, k] = tracer_tendency(i, j, k, grid, c, tracer_index,
+                                                closure, buoyancy, U, C, K, Fc, parameters, time)
     end
     return nothing
 end

--- a/src/TimeSteppers/time_stepping_kernels.jl
+++ b/src/TimeSteppers/time_stepping_kernels.jl
@@ -3,7 +3,9 @@
 #####
 
 """ Store previous value of the source term and calculate current source term. """
-function calculate_interior_source_terms!(G, arch, grid, coriolis, buoyancy, surface_waves, closure, U, C, pHY′, K, F, parameters, time)
+function calculate_interior_tendency_contributions!(G, arch, grid, coriolis, buoyancy, surface_waves, closure, 
+                                          U, C, pHY′, K, F, parameters, time)
+
     # Manually choose thread-block layout here as it's ~20% faster.
     # See: https://github.com/climate-machine/Oceananigans.jl/pull/308
     Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
@@ -92,7 +94,7 @@ function calculate_Gc!(Gc, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc
 end
 
 """ Apply boundary conditions by adding flux divergences to the right-hand-side. """
-function calculate_boundary_source_terms!(Gⁿ, arch, U, C, args...)
+function calculate_boundary_tendency_contributions!(Gⁿ, arch, U, C, args...)
 
     # Velocity fields
     for i in 1:3

--- a/src/TimeSteppers/velocity_and_tracer_tendencies.jl
+++ b/src/TimeSteppers/velocity_and_tracer_tendencies.jl
@@ -1,5 +1,5 @@
 """
-    x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+    u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                         closure, U, C, K, F, pHY′, parameters, time)
 
 Return the tendency for the horizontal velocity in the x-direction, or the east-west 
@@ -21,7 +21,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
 and `time` is the physical time of the model.
 """
-@inline function x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+@inline function u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                                      closure, U, C, K, F, pHY′, parameters, time)
 
     return ( - div_ũu(i, j, k, grid, U)
@@ -34,7 +34,7 @@ and `time` is the physical time of the model.
 end
 
 """
-    y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+    v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                         closure, U, C, K, F, pHY′, parameters, time)
 
 Return the tendency for the horizontal velocity in the y-direction, or the north-south 
@@ -56,7 +56,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
 and `time` is the physical time of the model.
 """
-@inline function y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+@inline function v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                                      closure, U, C, K, F, pHY′, parameters, time)
 
     return ( - div_ũv(i, j, k, grid, U)
@@ -69,7 +69,7 @@ and `time` is the physical time of the model.
 end
 
 """
-    z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+    w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                         closure, U, C, K, F, parameters, time)
                         
 Return the tendency for the vertical velocity ``w`` at grid point `i, j, k`.
@@ -89,7 +89,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
 and `time` is the physical time of the model.
 """
-@inline function z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+@inline function w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
                                      closure, U, C, K, F, parameters, time)
 
     return ( - div_ũw(i, j, k, grid, U)

--- a/src/TimeSteppers/velocity_and_tracer_tendencies.jl
+++ b/src/TimeSteppers/velocity_and_tracer_tendencies.jl
@@ -1,0 +1,130 @@
+"""
+    x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′,
+                        parameters, time)
+
+Return the tendency for the horizontal velocity in the x-direction, or the east-west 
+direction, ``u``, at grid point `i, j, k`.
+
+The tendency for ``u`` is called ``G_u`` and defined via
+
+    ``∂_t u = G_u - ∂_x ϕ_n``
+
+where ∂_x ϕ_n is the non-hydrostatic pressure gradient in the x-direction.
+
+`coriolis`, `surface_waves`, and `closure` are types encoding information about Coriolis
+forces, surface waves, and the prescribed turbulence closure.
+
+The arguments `U`, `C`, and `K` are `NamedTuple`s with the three velocity components,
+tracer fields, and precalculated diffusivities where applicable. `F` is a named tuple of 
+forcing functions, `pHY′` is the hydrostatic pressure anomaly.
+
+`parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
+and `time` is the physical time of the model.
+"""
+@inline function x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                     closure, U, C, K, F, pHY′, parameters, time)
+
+    return ( - div_ũu(i, j, k, grid, U)
+             - x_f_cross_U(i, j, k, grid, coriolis, U)
+             - ∂xᶠᵃᵃ(i, j, k, grid, pHY′)
+             + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U, K)
+             + x_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
+             + ∂t_uˢ(i, j, k, grid, surface_waves, time)
+             + F.u(i, j, k, grid, time, U, C, parameters))
+end
+
+"""
+    y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′,
+                        parameters, time)
+
+Return the tendency for the horizontal velocity in the y-direction, or the north-south 
+direction, ``v``, at grid point `i, j, k`.
+
+The tendency for ``v`` is called ``G_v`` and defined via
+
+    ``∂_t v = G_v - ∂_y ϕ_n``
+
+where ∂_y ϕ_n is the non-hydrostatic pressure gradient in the y-direction.
+
+`coriolis`, `surface_waves`, and `closure` are types encoding information about Coriolis
+forces, surface waves, and the prescribed turbulence closure.
+
+The arguments `U`, `C`, and `K` are `NamedTuple`s with the three velocity components,
+tracer fields, and precalculated diffusivities where applicable. `F` is a named tuple of 
+forcing functions, `pHY′` is the hydrostatic pressure anomaly.
+
+`parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
+and `time` is the physical time of the model.
+"""
+@inline function y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                     closure, U, C, K, F, pHY′, parameters, time)
+
+    return ( - div_ũv(i, j, k, grid, U)
+             - y_f_cross_U(i, j, k, grid, coriolis, U)
+             - ∂yᵃᶠᵃ(i, j, k, grid, pHY′)
+             + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U, K)
+             + y_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
+             + ∂t_vˢ(i, j, k, grid, surface_waves, time)
+             + F.v(i, j, k, grid, time, U, C, parameters))
+end
+
+"""
+    z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F,
+                        parameters, time)
+
+Return the tendency for the vertical velocity ``w`` at grid point `i, j, k`.
+The tendency for ``w`` is called ``G_w`` and defined via
+
+    ``∂_t w = G_w - ∂_z ϕ_n``
+
+where ∂_z ϕ_n is the non-hydrostatic pressure gradient in the z-direction.
+
+`coriolis`, `surface_waves`, and `closure` are types encoding information about Coriolis
+forces, surface waves, and the prescribed turbulence closure.
+
+The arguments `U`, `C`, and `K` are `NamedTuple`s with the three velocity components,
+tracer fields, and precalculated diffusivities where applicable. `F` is a named tuple of 
+forcing functions, `pHY′` is the hydrostatic pressure anomaly.
+
+`parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
+and `time` is the physical time of the model.
+"""
+@inline function z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                                     closure, U, C, K, F, parameters, time)
+
+    return ( - div_ũw(i, j, k, grid, U)
+             - z_f_cross_U(i, j, k, grid, coriolis, U)
+             + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U, K)
+             + z_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
+             + ∂t_wˢ(i, j, k, grid, surface_waves, time)
+             + F.w(i, j, k, grid, time, U, C, parameters))
+end
+
+"""
+    tracer_tendency(i, j, k, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc,
+                    parameters, time)
+
+Return the tendency for a tracer field `c` with index `tracer_index` 
+at grid point `i, j, k`.
+
+The tendency for ``c`` is called ``G_c`` and defined via
+
+    ``∂_t c = G_c``
+
+`closure` and `buoyancy` are types encoding information about the prescribed
+turbulence closure and buoyancy model.
+
+The arguments `U`, `C`, and `K` are `NamedTuple`s with the three velocity components, 
+tracer fields, and  precalculated diffusivities where applicable. 
+`Fc` is the user-defined forcing function for tracer `c`.
+
+`parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
+and `time` is the physical time of the model.
+"""
+@inline function tracer_tendency(i, j, k, grid, c, tracer_index, 
+                                 closure, buoyancy, U, C, K, Fc, parameters, time)
+
+    return ( - div_uc(i, j, k, grid, U, c)
+             + ∇_κ_∇c(i, j, k, grid, closure, c, tracer_index, K, C, buoyancy)
+             + Fc(i, j, k, grid, time, U, C, parameters))
+end

--- a/src/TimeSteppers/velocity_and_tracer_tendencies.jl
+++ b/src/TimeSteppers/velocity_and_tracer_tendencies.jl
@@ -1,6 +1,6 @@
 """
-    x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′,
-                        parameters, time)
+    x_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                        closure, U, C, K, F, pHY′, parameters, time)
 
 Return the tendency for the horizontal velocity in the x-direction, or the east-west 
 direction, ``u``, at grid point `i, j, k`.
@@ -34,8 +34,8 @@ and `time` is the physical time of the model.
 end
 
 """
-    y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′,
-                        parameters, time)
+    y_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                        closure, U, C, K, F, pHY′, parameters, time)
 
 Return the tendency for the horizontal velocity in the y-direction, or the north-south 
 direction, ``v``, at grid point `i, j, k`.
@@ -69,9 +69,9 @@ and `time` is the physical time of the model.
 end
 
 """
-    z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, closure, U, C, K, F,
-                        parameters, time)
-
+    z_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
+                        closure, U, C, K, F, parameters, time)
+                        
 Return the tendency for the vertical velocity ``w`` at grid point `i, j, k`.
 The tendency for ``w`` is called ``G_w`` and defined via
 


### PR DESCRIPTION
This PR modifies the time-stepping algorithm so that the tendencies for wall-normal velocity components are calculated on boundaries in `Bounded` directions.

In other words, when `x` is `Bounded`, the algorithm now calculates `Gu` on east boundaries, where `i=Nx+1`. Previously `Gu` was only calculated on west boundaries where `i=1`. The same applies to `y` and `z`.

This change is necessary because, in general, the values of `Gu`, `Gv`, and `Gw` on `x`, `y`, or `z` boundaries are needed to impose predictor velocity and pressure boundary conditions when `x`, `y`, or `z` are `Bounded` --- respectively.

The changes in this PR also motivated a slight refactoring of the way "equations" are specified. There is now a file dedicated to equation / tendency specification, called `velocity_and_tracer_tendencies.jl` in `src/TimeStepping`.

Resolves #259 (since it implements a simple / minimal abstraction for equations).