### PR TITLE
Reorganize boundary function functionality

### DIFF
--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -15,7 +15,7 @@ export
 
 using CUDAnative
 
-using Oceananigans: Cell, Face
+using Oceananigans: Cell, Face, xnode, ynode, znode
 using Oceananigans.Architectures
 using Oceananigans.Grids
 

--- a/src/BoundaryConditions/boundary_function.jl
+++ b/src/BoundaryConditions/boundary_function.jl
@@ -1,12 +1,4 @@
 """
-    BoundaryFunction{B, X1, X2, F}
-
-A wrapper for user-defined boundary condition functions.
-"""
-struct BoundaryFunction{B, X1, X2, F} <: Function
-    func :: F
-
-    """
         BoundaryFunction{B, X1, X2}(func)
 
     A wrapper for user-defined boundary condition functions on the
@@ -20,10 +12,22 @@ struct BoundaryFunction{B, X1, X2, F} <: Function
     (::BoundaryFunction{:z,Cell,Cell,getfield(Main, Symbol("##7#8"))}) (generic function with 1 method)
 
     julia> top_tracer_bc = BoundaryCondition(Flux, top_tracer_flux);
-    """
+"""
+struct BoundaryFunction{B, X1, X2, F} <: Function
+    func :: F
+
     function BoundaryFunction{B, X1, X2}(func) where {B, X1, X2}
         B ∈ (:x, :y, :z) || throw(ArgumentError("The boundary B at which the BoundaryFunction is
                                                 to be applied must be either :x, :y, or :z."))
-        new{B, X1, X2, typeof(func)}(func)
+        return new{B, X1, X2, typeof(func)}(func)
     end
 end
+
+@inline (bc::BoundaryFunction{:x, Y, Z})(j, k, grid, time, args...) where {Y, Z} =
+    bc.func(ynode(Y, j, grid), znode(Z, k, grid), time)
+
+@inline (bc::BoundaryFunction{:y, X, Z})(i, k, grid, time, args...) where {X, Z} =
+    bc.func(xnode(X, i, grid), znode(Z, k, grid), time)
+
+@inline (bc::BoundaryFunction{:z, X, Y})(i, j, grid, time, args...) where {X, Y} =
+    bc.func(xnode(X, i, grid), ynode(Y, j, grid), time)

--- a/src/Fields/Fields.jl
+++ b/src/Fields/Fields.jl
@@ -16,6 +16,5 @@ include("field.jl")
 include("set!.jl")
 include("field_tuples.jl")
 include("show_fields.jl")
-include("boundary_function.jl")
 
 end

--- a/src/Fields/boundary_function.jl
+++ b/src/Fields/boundary_function.jl
@@ -1,8 +1,0 @@
-@inline (bc::BoundaryFunction{:x, Y, Z})(j, k, grid, time, args...) where {Y, Z} =
-    bc.func(ynode(Y, j, grid), znode(Z, k, grid), time)
-
-@inline (bc::BoundaryFunction{:y, X, Z})(i, k, grid, time, args...) where {X, Z} =
-    bc.func(xnode(X, i, grid), znode(Z, k, grid), time)
-
-@inline (bc::BoundaryFunction{:z, X, Y})(i, j, grid, time, args...) where {X, Y} =
-    bc.func(xnode(X, i, grid), ynode(Y, j, grid), time)

--- a/src/Fields/field.jl
+++ b/src/Fields/field.jl
@@ -4,6 +4,7 @@ using Base: @propagate_inbounds
 import Adapt
 using OffsetArrays
 
+import Oceananigans: xnode, ynode, znode
 import Oceananigans.Architectures: architecture
 import Oceananigans.Utils: datatuple
 import Oceananigans.Grids: total_size, topology

--- a/src/Oceananigans.jl
+++ b/src/Oceananigans.jl
@@ -105,6 +105,11 @@ A type describing the location at the face of a grid cell.
 """
 struct Face end
 
+# placeholders
+function xnode end
+function ynode end
+function znode end
+
 """
     AbstractDiagnostic
 

--- a/test/test_boundary_conditions.jl
+++ b/test/test_boundary_conditions.jl
@@ -1,6 +1,6 @@
 using Oceananigans.BoundaryConditions: PBC, NFBC, NPBC
 
-function test_boundary_function(B, X1, X2, func)
+function instantiate_boundary_function(B, X1, X2, func)
     boundary_function = BoundaryFunction{B, X1, X2}(func)
     return true
 end
@@ -14,7 +14,7 @@ end
         simple_bc(ξ, η, t) = exp(ξ) * cos(η) * sin(t)
         for B in (:x, :y, :z)
             for X1 in (:Face, :Cell)
-                @test test_boundary_function(B, X1, Cell, simple_bc)
+                @test instantiate_boundary_function(B, X1, Cell, simple_bc)
             end
         end
     end


### PR DESCRIPTION
This PR reorganizes the functionality for `BoundaryFunction` so that it is entirely contained within `src/BoundaryConditions/boundary_function.jl`. This requires defining placeholders for `xnode`, `ynode`, and `znode` in `Oceananigans.jl`.