### PR TITLE
Fix memory allocations on CPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.mem
 deps/deps.jl
 
 # Swap files.

--- a/src/BoundaryConditions/apply_flux_bcs.jl
+++ b/src/BoundaryConditions/apply_flux_bcs.jl
@@ -33,6 +33,13 @@ function apply_y_bcs!(Gc, c, arch, args...)
     return nothing
 end
 
+# Avoid some computation / memory accesses for Value, Gradient, Periodic, NoPenetration,
+# and no-flux boundary conditions --- every boundary condition that does *not* prescribe
+# a non-trivial flux.
+const NotFluxBC = Union{VBC, GBC, PBC, NPBC, NFBC}
+@inline _apply_z_bcs!(Gc, grid, ::NotFluxBC, ::NotFluxBC, args...) = nothing
+@inline _apply_y_bcs!(Gc, grid, ::NotFluxBC, ::NotFluxBC, args...) = nothing
+
 """
     _apply_z_bcs!(Gc, grid, bottom_bc, top_bc, args...)
 


### PR DESCRIPTION
My fault, must have messed up and forgot to skip `_apply_*_bcs!` for `NotFluxBC` in PR #631. 

Fixes #675 and should fix failing tests on PR #671.

Before:
```
 ──────────────────────────────────────────────────────────────────────────────────────
        Static ocean benchmarks                Time                   Allocations      
                                       ──────────────────────   ───────────────────────
           Tot / % measured:                24.3s / 2.17%           1.83GiB / 18.1%    

 Section                       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────
  32× 32× 32  [CPU, Float32]       10    256ms  48.6%  25.6ms    170MiB  50.0%  17.0MiB
  32× 32× 32  [CPU, Float64]       10    270ms  51.4%  27.0ms    170MiB  50.0%  17.0MiB
 ──────────────────────────────────────────────────────────────────────────────────────
 ```

 After:
 ```
  ──────────────────────────────────────────────────────────────────────────────────────
        Static ocean benchmarks                Time                   Allocations      
                                       ──────────────────────   ───────────────────────
           Tot / % measured:                 126s / 62.8%           1.46GiB / 0.13%    

 Section                       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────────────────
  32× 32× 32  [CPU, Float32]       10    39.4s  49.9%   3.94s   1.00MiB  50.0%   102KiB
  32× 32× 32  [CPU, Float64]       10    39.5s  50.1%   3.95s   1.00MiB  50.0%   102KiB
 ──────────────────────────────────────────────────────────────────────────────────────
 ```

Unfortunately still a bit higher than v0.22.0 (~50 KiB allocations) but much better and more acceptable than 17 MiB!

Remaining memory allocations seem to be occuring in `fill_halo_regions.jl` but tried inlining some functions and didn't help so I'll revisit the problem in the future.

```
julia> analyze_malloc(".")
323-element Array{CoverageTools.MallocInfo,1}:        
 ⋮                                                                                                    
 CoverageTools.MallocInfo(5008, "./benchmark/benchmark_static_ocean.jl.32885.mem", 36)                
 CoverageTools.MallocInfo(5952, "./benchmark/benchmark_utils.jl.32885.mem", 35)                       
 CoverageTools.MallocInfo(6080, "./src/TimeSteppers/time_stepping_kernels.jl.32885.mem", 139)         
 CoverageTools.MallocInfo(7136, "./src/Architectures.jl.32885.mem", 39)                               
 CoverageTools.MallocInfo(12160, "./src/Utils/tuple_utils.jl.32885.mem", 14)                          
 CoverageTools.MallocInfo(12480, "./src/BoundaryConditions/apply_no_penetration_bcs.jl.32885.mem", 20)
 CoverageTools.MallocInfo(12480, "./src/BoundaryConditions/apply_no_penetration_bcs.jl.32885.mem", 38)
 CoverageTools.MallocInfo(12800, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 45)       
 CoverageTools.MallocInfo(12800, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 49)       
 CoverageTools.MallocInfo(16640, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 52)       
 CoverageTools.MallocInfo(16640, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 53)       
 CoverageTools.MallocInfo(16640, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 56)       
 CoverageTools.MallocInfo(16640, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 57)       
 CoverageTools.MallocInfo(44000, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 26)       
 CoverageTools.MallocInfo(44000, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 27)       
 CoverageTools.MallocInfo(44000, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 28)       
 CoverageTools.MallocInfo(44000, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 29)       
 CoverageTools.MallocInfo(44000, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 30)       
 CoverageTools.MallocInfo(46400, "./src/BoundaryConditions/apply_flux_bcs.jl.32885.mem", 17)          
 CoverageTools.MallocInfo(46400, "./src/BoundaryConditions/apply_flux_bcs.jl.32885.mem", 30)          
 CoverageTools.MallocInfo(56320, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 20)       
 CoverageTools.MallocInfo(95040, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 25)       
 CoverageTools.MallocInfo(235751, "./benchmark/benchmark_static_ocean.jl.32885.mem", 55)              
 CoverageTools.MallocInfo(249600, "./src/BoundaryConditions/fill_halo_regions.jl.32885.mem", 70)      
 CoverageTools.MallocInfo(739712, "./benchmark/benchmark_utils.jl.32885.mem", 20)                     
 CoverageTools.MallocInfo(1686022, "./benchmark/benchmark_static_ocean.jl.32885.mem", 50) 
 ```