### PR TITLE
Simpler boundary condition functions and forcing functions

### DIFF
--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -120,7 +120,7 @@ end
 # is applied at location `(c, c, c)`.
 
 function Fb_eady_func(i, j, k, grid, clock, state, p) 
-    return @inbounds (- p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, C.b)
+    return @inbounds (- p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.tracers.b)
                       + p.f * p.α * ℑyᵃᶜᵃ(i, j, k, grid, state.velocities.v))
 end
 

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -8,8 +8,10 @@
 #   * How to implement a background flow (a background geostrophic shear)
 
 using Random, Printf
+
 using Oceananigans, Oceananigans.Diagnostics, Oceananigans.OutputWriters,
-      Oceananigans.AbstractOperations, Oceananigans.Utils, Oceananigans.BoundaryConditions
+      Oceananigans.AbstractOperations, Oceananigans.Utils, Oceananigans.BoundaryConditions,
+      Oceananigans.Forcing
 
 # These imports from Oceananigans's `TurbuleneClosures` module are needed for imposing
 # a background flow as a user-defined forcing.

--- a/examples/eady_turbulence.jl
+++ b/examples/eady_turbulence.jl
@@ -9,7 +9,7 @@
 
 using Random, Printf
 using Oceananigans, Oceananigans.Diagnostics, Oceananigans.OutputWriters,
-      Oceananigans.AbstractOperations, Oceananigans.Utils
+      Oceananigans.AbstractOperations, Oceananigans.Utils, Oceananigans.BoundaryConditions
 
 # These imports from Oceananigans's `TurbuleneClosures` module are needed for imposing
 # a background flow as a user-defined forcing.
@@ -55,11 +55,11 @@ grid = RegularCartesianGrid(size=(Nh, Nh, Nz), halo=(2, 2, 2),
 
 bc_parameters = (μ=μ, H=Lz)
 
-@inline τ₁₃_linear_drag(i, j, grid, time, iter, U, C, p) = @inbounds p.μ * p.H * U.u[i, j, 1]
-@inline τ₂₃_linear_drag(i, j, grid, time, iter, U, C, p) = @inbounds p.μ * p.H * U.v[i, j, 1]
+@inline τ₁₃_linear_drag(i, j, grid, clock, state, p) = @inbounds p.μ * p.H * state.velocities.u[i, j, 1]
+@inline τ₂₃_linear_drag(i, j, grid, clock, state, p) = @inbounds p.μ * p.H * state.velocities.v[i, j, 1]
 
-ubcs = UVelocityBoundaryConditions(grid, bottom = BoundaryCondition(Flux, τ₁₃_linear_drag))
-vbcs = VVelocityBoundaryConditions(grid, bottom = BoundaryCondition(Flux, τ₂₃_linear_drag))
+ubcs = UVelocityBoundaryConditions(grid, bottom = ParameterizedBoundaryCondition(Flux, τ₁₃_linear_drag, bc_parameters))
+vbcs = VVelocityBoundaryConditions(grid, bottom = ParameterizedBoundaryCondition(Flux, τ₂₃_linear_drag, bc_parameters))
 bbcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Value, 0),
                                       bottom = BoundaryCondition(Value, -N² * Lz))
 
@@ -86,8 +86,10 @@ forcing_parameters = (α=α, f=f, H=Lz)
 #
 # is applied at location `(f, c, c)`.
 
-Fu_eady(i, j, k, grid, time, U, C, p) = @inbounds (- p.α * ℑxzᶠᵃᶜ(i, j, k, grid, U.w)
-                                                   - p.α * (grid.zC[k] + p.H) * ∂xᶠᵃᵃ(i, j, k, grid, ℑxᶜᵃᵃ, U.u))
+function Fu_eady_func(i, j, k, grid, clock, state, p) 
+    return @inbounds (- p.α * ℑxzᶠᵃᶜ(i, j, k, grid, state.velocities.w)
+                      - p.α * (grid.zC[k] + p.H) * ∂xᶠᵃᵃ(i, j, k, grid, ℑxᶜᵃᵃ, state.velocities.u))
+end
 
 # The $y$-momentum forcing
 #
@@ -95,7 +97,9 @@ Fu_eady(i, j, k, grid, time, U, C, p) = @inbounds (- p.α * ℑxzᶠᵃᶜ(i, j,
 #
 # is applied at location `(c, f, c)`.
 
-Fv_eady(i, j, k, grid, time, U, C, p) = @inbounds -p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, U.v)
+function Fv_eady_func(i, j, k, grid, clock, state, p) 
+    return @inbounds -p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.velocities.v)
+end
 
 # The $z$-momentum forcing
 #
@@ -103,7 +107,9 @@ Fv_eady(i, j, k, grid, time, U, C, p) = @inbounds -p.α * (grid.zC[k] + p.H) * �
 #
 # is applied at location `(c, c, f)`.
 
-Fw_eady(i, j, k, grid, time, U, C, p) = @inbounds -p.α * (grid.zF[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, U.w)
+function Fw_eady_func(i, j, k, grid, clock, state, p) 
+    return @inbounds -p.α * (grid.zF[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, state.velocities.w)
+end
 
 # The buoyancy forcing
 #
@@ -111,8 +117,15 @@ Fw_eady(i, j, k, grid, time, U, C, p) = @inbounds -p.α * (grid.zF[k] + p.H) * �
 #
 # is applied at location `(c, c, c)`.
 
-Fb_eady(i, j, k, grid, time, U, C, p) = @inbounds (- p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, C.b)
-                                                   + p.f * p.α * ℑyᵃᶜᵃ(i, j, k, grid, U.v))
+function Fb_eady_func(i, j, k, grid, clock, state, p) 
+    return @inbounds (- p.α * (grid.zC[k] + p.H) * ∂xᶜᵃᵃ(i, j, k, grid, ℑxᶠᵃᵃ, C.b)
+                      + p.f * p.α * ℑyᵃᶜᵃ(i, j, k, grid, state.velocities.v))
+end
+
+Fu_eady = ParameterizedForcing(Fu_eady_func, forcing_parameters)
+Fv_eady = ParameterizedForcing(Fv_eady_func, forcing_parameters)
+Fw_eady = ParameterizedForcing(Fw_eady_func, forcing_parameters)
+Fb_eady = ParameterizedForcing(Fb_eady_func, forcing_parameters)
 
 # # Turbulence closures
 #
@@ -135,15 +148,13 @@ output_filename_prefix = string("eady_turb_Nh", Nh, "_Nz", Nz)
 # Our use of biharmonic diffusivity means we must instantiate the model grid
 # with halos of size `(2, 2, 2)` in `(x, y, z)`.
 
-model = IncompressibleModel( grid = grid,
-       architecture = CPU(),
-           coriolis = FPlane(f=f),
-           buoyancy = BuoyancyTracer(), tracers = :b,
-            forcing = ModelForcing(u=Fu_eady, v=Fv_eady, w=Fw_eady, b=Fb_eady),
-            closure = closure,
-boundary_conditions = (u=ubcs, v=vbcs, b=bbcs),
-# "parameters" is a NamedTuple of user-defined parameters that can be used in boundary condition and forcing functions.
-         parameters = merge(bc_parameters, forcing_parameters))
+model = IncompressibleModel(               grid = grid,
+                                   architecture = CPU(),
+                                       coriolis = FPlane(f=f),
+                                       buoyancy = BuoyancyTracer(), tracers = :b,
+                                        forcing = ModelForcing(u=Fu_eady, v=Fv_eady, w=Fw_eady, b=Fb_eady),
+                                        closure = closure,
+                            boundary_conditions = (u=ubcs, v=vbcs, b=bbcs))
 
 # # Initial conditions
 #

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -14,6 +14,7 @@
 # some nice features for writing output data to disk.
 
 using Random, Printf, Plots
+
 using Oceananigans, Oceananigans.OutputWriters, Oceananigans.Diagnostics, Oceananigans.Utils,
       Oceananigans.BoundaryConditions
 
@@ -70,7 +71,7 @@ T_bcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Flux, Qᵀ),
                                        bottom = BoundaryCondition(Gradient, ∂T∂z))
 
 ## Salinity flux: Qˢ = - E * S
-@inline Qˢ(i, j, grid, time, iter, U, C, p) = @inbounds -p.evaporation * C.S[i, j, 1]
+@inline Qˢ(i, j, grid, clock, state, p) = @inbounds -p.evaporation * state.tracers.S[i, j, 1]
 
 S_bcs = TracerBoundaryConditions(grid, top = ParameterizedBoundaryCondition(Flux, Qˢ, (evaporation=evaporation,)))
 nothing # hide

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -14,7 +14,8 @@
 # some nice features for writing output data to disk.
 
 using Random, Printf, Plots
-using Oceananigans, Oceananigans.OutputWriters, Oceananigans.Diagnostics, Oceananigans.Utils
+using Oceananigans, Oceananigans.OutputWriters, Oceananigans.Diagnostics, Oceananigans.Utils,
+      Oceananigans.BoundaryConditions
 
 # ## Model parameters
 #
@@ -71,7 +72,7 @@ T_bcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Flux, Qᵀ),
 ## Salinity flux: Qˢ = - E * S
 @inline Qˢ(i, j, grid, time, iter, U, C, p) = @inbounds -p.evaporation * C.S[i, j, 1]
 
-S_bcs = TracerBoundaryConditions(grid, top = BoundaryCondition(Flux, Qˢ))
+S_bcs = TracerBoundaryConditions(grid, top = ParameterizedBoundaryCondition(Flux, Qˢ, (evaporation=evaporation,)))
 nothing # hide
 
 # ## Model instantiation
@@ -84,15 +85,12 @@ nothing # hide
 # model.parameters for use in the boundary condition function that calculates the salinity
 # flux.
 
-model = IncompressibleModel(
-         architecture = CPU(),
-                 grid = grid,
-             coriolis = FPlane(f=f),
-             buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=α, β=β)),
-              closure = AnisotropicMinimumDissipation(),
-  boundary_conditions = (u=u_bcs, T=T_bcs, S=S_bcs),
-           parameters = (evaporation = evaporation,)
-)
+model = IncompressibleModel(       architecture = CPU(),
+                                           grid = grid,
+                                       coriolis = FPlane(f=f),
+                                       buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(α=α, β=β)),
+                                        closure = AnisotropicMinimumDissipation(),
+                            boundary_conditions = (u=u_bcs, T=T_bcs, S=S_bcs))
 nothing # hide
 
 # Notes:

--- a/examples/ocean_wind_mixing_and_convection.jl
+++ b/examples/ocean_wind_mixing_and_convection.jl
@@ -6,7 +6,6 @@
 #   * how to use the `SeawaterBuoyancy` model for buoyancy with a linear equation of state;
 #   * how to use a turbulence closure for large eddy simulation;
 #   * how to use a function to impose a boundary condition;
-#   * how to use user-defined `model.parameters` in a boundary condition function.
 #
 # In addition to `Oceananigans.jl` we need `Plots` for plotting, `Random` for
 # generating random initial conditions, and `Printf` for printing progress messages.
@@ -82,9 +81,7 @@ nothing # hide
 # using a `FPlane` model for rotation (constant rotation rate), a linear equation
 # of state for temperature and salinity, the Anisotropic Minimum Dissipation closure
 # to model the effects of unresolved turbulence, and the previously defined boundary
-# conditions for `u`, `T`, and `S`. We also pass the evaporation rate to the container
-# model.parameters for use in the boundary condition function that calculates the salinity
-# flux.
+# conditions for `u`, `T`, and `S`.
 
 model = IncompressibleModel(       architecture = CPU(),
                                            grid = grid,

--- a/src/BoundaryConditions/BoundaryConditions.jl
+++ b/src/BoundaryConditions/BoundaryConditions.jl
@@ -10,6 +10,7 @@ export
     WVelocityBoundaryConditions, TracerBoundaryConditions, PressureBoundaryConditions,
     DiffusivityBoundaryConditions,
     BoundaryFunction,
+    ParameterizedBoundaryCondition, ParameterizedBoundaryConditionFunction,
     apply_z_bcs!, apply_y_bcs!,
     fill_halo_regions!, zero_halo_regions!
 
@@ -24,6 +25,7 @@ include("boundary_condition.jl")
 include("coordinate_boundary_conditions.jl")
 include("field_boundary_conditions.jl")
 include("boundary_function.jl")
+include("parameterized_boundary_condition.jl")
 include("show_boundary_conditions.jl")
 
 include("fill_halo_regions.jl")

--- a/src/BoundaryConditions/apply_no_penetration_bcs.jl
+++ b/src/BoundaryConditions/apply_no_penetration_bcs.jl
@@ -4,39 +4,45 @@ using Oceananigans.Operators: Δx, Δy, ΔzC, div_xyᶜᶜᵃ, div_xzᶜᵃᶜ, 
 ##### Outer functions for setting velocity on boundary and filling halo beyond boundary.
 #####
 
-function fill_west_halo!(u, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. u.parent[1+grid.Hx, :, :] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :yz) _fill_west_halo!(u, bc, grid, U.v, U.w)
+function fill_west_halo!(u, bc::NPBC, arch, grid, clock, state)
+    @views @. u.parent[1 + grid.Hx, :, :] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :yz), 
+            _fill_west_halo!(u, bc, grid, state.velocities.v, state.velocities.w))
     return nothing
 end
 
-function fill_south_halo!(v, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. v.parent[:, 1+grid.Hy, :] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :xz) _fill_south_halo!(v, bc, grid, U.u, U.w)
+function fill_south_halo!(v, bc::NPBC, arch, grid, clock, state)
+    @views @. v.parent[:, 1 + grid.Hy, :] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :xz),
+            _fill_south_halo!(v, bc, grid, state.velocities.u, state.velocities.w))
     return nothing
 end
 
-function fill_bottom_halo!(w, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. w.parent[:, :, 1+grid.Hz] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :xy) _fill_bottom_halo!(w, bc, grid, U.u, U.v)
+function fill_bottom_halo!(w, bc::NPBC, arch, grid, clock, state)
+    @views @. w.parent[:, :, 1 + grid.Hz] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :xy),
+            _fill_bottom_halo!(w, bc, grid, state.velocities.u, state.velocities.v))
     return nothing
 end
 
-function fill_east_halo!(u, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. u.parent[grid.Nx+1+grid.Hx, :, :] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :yz) _fill_east_halo!(u, bc, grid, U.v, U.w)
+function fill_east_halo!(u, bc::NPBC, arch, grid, clock, state)
+    @views @. u.parent[grid.Nx + 1 + grid.Hx, :, :] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :yz),
+            _fill_east_halo!(u, bc, grid, state.velocities.v, state.velocities.w))
     return nothing
 end
 
-function fill_north_halo!(v, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. v.parent[:, grid.Ny+1+grid.Hy, :] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :xz) _fill_north_halo!(v, bc, grid, U.u, U.v)
+function fill_north_halo!(v, bc::NPBC, arch, grid, clock, state)
+    @views @. v.parent[:, grid.Ny + 1 + grid.Hy, :] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :xz),
+            _fill_north_halo!(v, bc, grid, state.velocities.u, state.velocities.v))
     return nothing
 end
 
-function fill_top_halo!(w, bc::NPBC, arch, grid, time, iter, U, args...)
-    @views @. w.parent[:, :, grid.Nz+1+grid.Hz] = 0 # fix velocity on boundary
-    @launch device(arch) config=launch_config(grid, :xy) _fill_bottom_halo!(w, bc, grid, U.u, U.v)
+function fill_top_halo!(w, bc::NPBC, arch, grid, clock, state)
+    @views @. w.parent[:, :, grid.Nz + 1 + grid.Hz] = 0 # fix velocity on boundary
+    @launch(device(arch), config=launch_config(grid, :xy),
+            _fill_bottom_halo!(w, bc, grid, state.velocities.u, state.velocities.v))
     return nothing
 end
 

--- a/src/BoundaryConditions/boundary_function.jl
+++ b/src/BoundaryConditions/boundary_function.jl
@@ -23,11 +23,11 @@ struct BoundaryFunction{B, X1, X2, F} <: Function
     end
 end
 
-@inline (bc::BoundaryFunction{:x, Y, Z})(j, k, grid, time, args...) where {Y, Z} =
-    bc.func(ynode(Y, j, grid), znode(Z, k, grid), time)
+@inline (bc::BoundaryFunction{:x, Y, Z})(j, k, grid, clock, state) where {Y, Z} =
+    bc.func(ynode(Y, j, grid), znode(Z, k, grid), clock.time)
 
-@inline (bc::BoundaryFunction{:y, X, Z})(i, k, grid, time, args...) where {X, Z} =
-    bc.func(xnode(X, i, grid), znode(Z, k, grid), time)
+@inline (bc::BoundaryFunction{:y, X, Z})(i, k, grid, clock, state) where {X, Z} =
+    bc.func(xnode(X, i, grid), znode(Z, k, grid), clock.time)
 
-@inline (bc::BoundaryFunction{:z, X, Y})(i, j, grid, time, args...) where {X, Y} =
-    bc.func(xnode(X, i, grid), ynode(Y, j, grid), time)
+@inline (bc::BoundaryFunction{:z, X, Y})(i, j, grid, clock, state) where {X, Y} =
+    bc.func(xnode(X, i, grid), ynode(Y, j, grid), clock.time)

--- a/src/BoundaryConditions/fill_halo_regions.jl
+++ b/src/BoundaryConditions/fill_halo_regions.jl
@@ -21,13 +21,13 @@ fill_halo_regions!(field, arch, args...) =
     fill_halo_regions!(field.data, field.boundary_conditions, arch, field.grid, args...)
 
 "Fill halo regions in x, y, and z for a given field."
-function fill_halo_regions!(c::AbstractArray, fieldbcs, arch, grid, args...)
-      fill_west_halo!(c, fieldbcs.x.left,   arch, grid, args...)
-      fill_east_halo!(c, fieldbcs.x.right,  arch, grid, args...)
-     fill_south_halo!(c, fieldbcs.y.left,   arch, grid, args...)
-     fill_north_halo!(c, fieldbcs.y.right,  arch, grid, args...)
-    fill_bottom_halo!(c, fieldbcs.z.bottom, arch, grid, args...)
-       fill_top_halo!(c, fieldbcs.z.top,    arch, grid, args...)
+function fill_halo_regions!(c::AbstractArray, fieldbcs, arch, args...)
+      fill_west_halo!(c, fieldbcs.x.left,   arch, args...)
+      fill_east_halo!(c, fieldbcs.x.right,  arch, args...)
+     fill_south_halo!(c, fieldbcs.y.left,   arch, args...)
+     fill_north_halo!(c, fieldbcs.y.right,  arch, args...)
+    fill_bottom_halo!(c, fieldbcs.z.bottom, arch, args...)
+       fill_top_halo!(c, fieldbcs.z.top,    arch, args...)
     return nothing
 end
 

--- a/src/BoundaryConditions/parameterized_boundary_condition.jl
+++ b/src/BoundaryConditions/parameterized_boundary_condition.jl
@@ -1,0 +1,37 @@
+"""
+    ParameterizedBoundaryConditionFunction(func, parameters)
+
+A wrapper for boundary condition functions implemented as functions with parameters.
+The boundary condition `func` is called with the signature
+
+    `func(i, j, grid, clock, state, parameters)`
+
+where `i, j` are the indices along the boundary, `grid` and `clock` are `model.grid` and
+`model.clock`, and `state` is a `NamedTuple` with fields `velocities`, `tracers`,
+and `diffusivities`, which are each `NamedTuple`s of `OffsetArray`s that reference
+the data associated with their corresponding fields.
+
+Example
+=======
+
+@inline linear_drag(i, j, grid, clock, state, parameters) = 
+    @inbounds - parameters.μ * state.velocities.u[i, j, 1]
+
+u_boundary_condition = ParameterizedBoundaryCondition(linear_drag, (μ=π,))
+"""
+struct ParameterizedBoundaryConditionFunction{F, P} <: Function
+    func :: F
+    parameters :: P
+end
+
+@inline (bc::ParameterizedBoundaryConditionFunction)(args...) = bc.func(args..., bc.parameters)
+
+"""
+    ParameterizedBoundaryCondition(bctype, func, parameters)
+
+Returns a `BoundaryCondition` of `bctype` with a `ParameterizedBoundaryConditionFunction`
+with function `func` and `parameters`.
+"""
+ParameterizedBoundaryCondition(bctype, func, parameters) =
+    BoundaryCondition(bctype, ParameterizedBoundaryConditionFunction(func, parameters))    
+

--- a/src/Forcing/Forcing.jl
+++ b/src/Forcing/Forcing.jl
@@ -1,6 +1,6 @@
 module Forcing
 
-export ModelForcing, SimpleForcing
+export ModelForcing, SimpleForcing, ParameterizedForcing
 
 using Oceananigans.Fields
 

--- a/src/Forcing/Forcing.jl
+++ b/src/Forcing/Forcing.jl
@@ -8,5 +8,6 @@ zeroforcing(args...) = 0
 
 include("simple_forcing.jl")
 include("model_forcing.jl")
+include("parameterized_forcing.jl")
 
 end

--- a/src/Forcing/model_forcing.jl
+++ b/src/Forcing/model_forcing.jl
@@ -21,7 +21,7 @@ function ModelForcing(; u=zeroforcing, v=zeroforcing, w=zeroforcing, tracer_forc
     return merge((u=u, v=v, w=w), tracer_forcings)
 end
 
-at_location(location, u::Function) = u
+at_location(location, u) = u # Fallback
 at_location(location, u::SimpleForcing) =
     SimpleForcing{location[1], location[2], location[3]}(u.func, u.parameters)
 

--- a/src/Forcing/parameterized_forcing.jl
+++ b/src/Forcing/parameterized_forcing.jl
@@ -1,0 +1,24 @@
+"""
+    ParameterizedForcing(func, parameters)
+
+Construct a forcing function with parameters. The forcing function, which is
+applied at grid point `i, j, k`, is called with the signature
+
+    `func(i, j, k, grid, clock, state, parameters)`
+    
+Example
+=======
+
+function cool_forcing_function(i, j, k, grid, clock, state, parameters) = 
+    return @inbounds - parameters.μ * exp(grid.zC[k] / parameters.λ) * state.velocities.u[i, j, k]
+end
+
+cool_forcing = ParameterizedForcing(cool_forcing_function, parameters=(μ=42, λ=π))
+"""
+struct ParameterizedForcing{F, P}
+    func :: F
+    parameters :: P
+end
+
+@inline (F::ParameterizedForcing)(i, j, k, grid, clock, state) = 
+    F.func(i, j, k, grid, clock, state, F.parameters)

--- a/src/Forcing/simple_forcing.jl
+++ b/src/Forcing/simple_forcing.jl
@@ -45,8 +45,8 @@ SimpleForcing(func::Function; kwargs...) = SimpleForcing((Cell, Cell, Cell), fun
 
 SimpleForcing(location::Tuple, forcing::SimpleForcing) = SimpleForcing(location, forcing.func)
 
-@inline (f::SimpleForcing{X, Y, Z})(i, j, k, grid, time, U, C, params) where {X, Y, Z} =
-    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), time, f.parameters)
+@inline (f::SimpleForcing{X, Y, Z})(i, j, k, grid, clock, state) where {X, Y, Z} =
+    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), clock.time, f.parameters)
 
-@inline (f::SimpleForcing{X, Y, Z, F, <:Nothing})(i, j, k, grid, time, U, C, params) where {X, Y, Z, F} =
-    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), time)
+@inline (f::SimpleForcing{X, Y, Z, F, <:Nothing})(i, j, k, grid, clock, state) where {X, Y, Z, F} =
+    @inbounds f.func(xnode(X, i, grid), ynode(Y, j, grid), znode(Z, k, grid), clock.time)

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -2,6 +2,8 @@ module Models
 
 export IncompressibleModel, NonDimensionalModel, Clock, tick!, state
 
+using Adapt
+
 using Oceananigans.Architectures
 using Oceananigans.Fields
 using Oceananigans.Coriolis

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-export IncompressibleModel, NonDimensionalModel, Clock, tick!
+export IncompressibleModel, NonDimensionalModel, Clock, tick!, state
 
 using Oceananigans.Architectures
 using Oceananigans.Fields
@@ -18,6 +18,16 @@ using Oceananigans.Utils
 Abstract supertype for models.
 """
 abstract type AbstractModel end
+
+"""
+    state(model)
+
+Returns a `NamedTuple` with fields `velocities, tracers, diffusivities, tendencies` 
+corresponding to `NamedTuple`s of `OffsetArray`s that reference each of the field's data.
+"""
+@inline state(model) = (   velocities = datatuple(model.velocities),
+                              tracers = datatuple(model.tracers),
+                        diffusivities = datatuple(model.diffusivities))
 
 include("clock.jl")
 include("incompressible_model.jl")

--- a/src/Models/clock.jl
+++ b/src/Models/clock.jl
@@ -10,8 +10,8 @@ using Dates: AbstractTime, Nanosecond
 Keeps track of the current `time` and `iteration` number. The `time::T` can be either a number of a `DateTime` object.
 """
 mutable struct Clock{T}
-       time :: T
-  iteration :: Int
+         time :: T
+    iteration :: Int
 end
 
 Clock(; time, iteration=0) = Clock(time, iteration)
@@ -30,3 +30,6 @@ function tick!(clock::Clock{<:AbstractTime}, Δt)
     clock.iteration += 1
     return nothing
 end
+
+"Adapt `Clock` to work on the GPU via CUDAnative and CUDAdrv."
+Adapt.adapt_structure(to, clock::Clock) = (time=clock.time, iteration=clock.iteration)

--- a/src/Models/incompressible_model.jl
+++ b/src/Models/incompressible_model.jl
@@ -7,7 +7,7 @@ using Oceananigans.Buoyancy: validate_buoyancy
 using Oceananigans.TurbulenceClosures: ν₀, κ₀, with_tracers
 
 mutable struct IncompressibleModel{TS, E, A<:AbstractArchitecture, G, T, B, R, SW, U, C, Φ, F,
-                                   S, K, Θ} <: AbstractModel
+                                   S, K} <: AbstractModel
        architecture :: A         # Computer `Architecture` on which `Model` is run
                grid :: G         # Grid of physical points on which `Model` is solved
               clock :: Clock{T}  # Tracks iteration number and simulation time of `Model`
@@ -22,7 +22,6 @@ mutable struct IncompressibleModel{TS, E, A<:AbstractArchitecture, G, T, B, R, S
         timestepper :: TS        # Object containing timestepper fields and parameters
     pressure_solver :: S         # Pressure/Poisson solver
       diffusivities :: K         # Container for turbulent diffusivities
-         parameters :: Θ         # Container for arbitrary user-defined parameters
 end
 
 """
@@ -40,7 +39,6 @@ end
     boundary_conditions = (u=UVelocityBoundaryConditions(grid),
                            v=VVelocityBoundaryConditions(grid),
                            w=WVelocityBoundaryConditions(grid)),
-             parameters = nothing,
              velocities = VelocityFields(architecture, grid, boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
@@ -60,7 +58,6 @@ Keyword arguments
 - `coriolis`: Parameters for the background rotation rate of the model.
 - `forcing`: User-defined forcing functions that contribute to solution tendencies.
 - `boundary_conditions`: Named tuple containing field boundary conditions.
-- `parameters`: User-defined parameters for use in user-defined forcing functions and boundary condition functions.
 """
 function IncompressibleModel(;
                    grid,
@@ -76,7 +73,6 @@ function IncompressibleModel(;
     boundary_conditions = (u=UVelocityBoundaryConditions(grid),
                            v=VVelocityBoundaryConditions(grid),
                            w=WVelocityBoundaryConditions(grid)),
-             parameters = nothing,
              velocities = VelocityFields(architecture, grid, boundary_conditions),
               pressures = PressureFields(architecture, grid, boundary_conditions),
           diffusivities = DiffusivityFields(architecture, grid, tracernames(tracers), boundary_conditions, closure),
@@ -102,5 +98,5 @@ function IncompressibleModel(;
 
     return IncompressibleModel(architecture, grid, clock, buoyancy, coriolis, surface_waves,
                                velocities, tracer_fields, pressures, forcing, closure,
-                               timestepper, pressure_solver, diffusivities, parameters)
+                               timestepper, pressure_solver, diffusivities)
 end

--- a/src/TimeSteppers/TimeSteppers.jl
+++ b/src/TimeSteppers/TimeSteppers.jl
@@ -3,7 +3,8 @@ module TimeSteppers
 export
     AdamsBashforthTimeStepper,
     time_step!,
-    compute_w_from_continuity!
+    compute_w_from_continuity!,
+    tendencies
 
 using GPUifyLoops: @launch, @loop, @unroll
 
@@ -49,13 +50,11 @@ function TimeStepper(name::Symbol, args...)
     return eval(Expr(:call, fullname, args...))
 end
 
-# Fallback
+# Fallbacks
 TimeStepper(stepper::AbstractTimeStepper, args...) = stepper
 
 """Returns the arguments passed to boundary conditions functions."""
-boundary_condition_function_arguments(model) =
-    (model.clock.time, model.clock.iteration, datatuple(model.velocities),
-     datatuple(model.tracers), model.parameters)
+@inline boundary_condition_function_arguments(model) = (model.clock, state(model))
 
 include("generic_time_stepping.jl")
 include("velocity_and_tracer_tendencies.jl")

--- a/src/TimeSteppers/generic_time_stepping.jl
+++ b/src/TimeSteppers/generic_time_stepping.jl
@@ -55,7 +55,7 @@ function calculate_tendencies!(tendencies, velocities, tracers, pressures, diffu
     # Arguments needed to calculate tendencies for momentum and tracers
     tendency_calculation_args = (tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
                                  model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
-                                 diffusivities, model.forcing, model.parameters, model.clock)
+                                 diffusivities, model.forcing, model.clock)
 
     # Calculate contributions to momentum and tracer tendencies from fluxes and volume terms in the
     # interior of the domain

--- a/src/TimeSteppers/generic_time_stepping.jl
+++ b/src/TimeSteppers/generic_time_stepping.jl
@@ -55,7 +55,7 @@ function calculate_tendencies!(tendencies, velocities, tracers, pressures, diffu
     # Arguments needed to calculate tendencies for momentum and tracers
     tendency_calculation_args = (tendencies, model.architecture, model.grid, model.coriolis, model.buoyancy,
                                  model.surface_waves, model.closure, velocities, tracers, pressures.pHY′,
-                                 diffusivities, model.forcing, model.parameters, model.clock.time)
+                                 diffusivities, model.forcing, model.parameters, model.clock)
 
     # Calculate contributions to momentum and tracer tendencies from fluxes and volume terms in the
     # interior of the domain

--- a/src/TimeSteppers/time_stepping_kernels.jl
+++ b/src/TimeSteppers/time_stepping_kernels.jl
@@ -4,7 +4,7 @@
 
 """ Store previous value of the source term and calculate current source term. """
 function calculate_interior_tendency_contributions!(G, arch, grid, coriolis, buoyancy, surface_waves, closure, 
-                                                    U, C, pHY′, K, F, parameters, clock)
+                                                    U, C, pHY′, K, F, clock)
 
     # Manually choose thread-block layout here as it's ~20% faster.
     # See: https://github.com/climate-machine/Oceananigans.jl/pull/308
@@ -22,13 +22,13 @@ function calculate_interior_tendency_contributions!(G, arch, grid, coriolis, buo
     end
 
     @launch(device(arch), threads=(Tx, Ty), blocks=(Bx, By, Bz),
-            calculate_Gu!(G.u, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, clock))
+            calculate_Gu!(G.u, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, clock))
 
     @launch(device(arch), threads=(Tx, Ty), blocks=(Bx, By, Bz),
-            calculate_Gv!(G.v, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, clock))
+            calculate_Gv!(G.v, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, clock))
 
     @launch(device(arch), threads=(Tx, Ty), blocks=(Bx, By, Bz),
-            calculate_Gw!(G.w, grid, coriolis, surface_waves, closure, U, C, K, F, parameters, clock))
+            calculate_Gw!(G.w, grid, coriolis, surface_waves, closure, U, C, K, F, clock))
 
     for tracer_index in 1:length(C)
         @inbounds Gc = G[tracer_index+3]
@@ -36,7 +36,7 @@ function calculate_interior_tendency_contributions!(G, arch, grid, coriolis, buo
         @inbounds  c = C[tracer_index]
 
         @launch(device(arch), threads=(Tx, Ty), blocks=(Bx, By, Bz),
-                calculate_Gc!(Gc, grid, c, Val(tracer_index), closure, buoyancy, U, C, K, Fc, parameters, clock))
+                calculate_Gc!(Gc, grid, c, Val(tracer_index), closure, buoyancy, U, C, K, Fc, clock))
     end
 
     return nothing
@@ -65,17 +65,17 @@ end
 """
     calculate_east_boundary_Gu!(G, arch, grid::AbstractGrid{FT, <:Bounded},
                                 coriolis, buoyancy, surface_waves, closure,
-                                U, C, pHY′, K, F, parameters, clock) where FT
+                                U, C, pHY′, K, F, clock) where FT
 
 Calculate `Gu` on east boundaries when the x-direction has `Bounded` topology.
 """
 function calculate_east_boundary_Gu!(G, arch, grid::AbstractGrid{FT, <:Bounded},
                                      coriolis, buoyancy, surface_waves, closure,
-                                     U, C, pHY′, K, F, parameters, clock) where FT
+                                     U, C, pHY′, K, F, clock) where FT
 
     @launch(device(arch), config=launch_config(grid, :yz), 
             _calculate_east_boundary_Gu!(G.u, grid, coriolis, surface_waves, 
-                                         closure, U, C, K, F, pHY′, parameters, clock))
+                                         closure, U, C, K, F, pHY′, clock))
 
     return nothing
 end
@@ -83,17 +83,17 @@ end
 """
     calculate_north_boundary_Gu!(G, arch, grid::AbstractGrid{FT, <:Bounded},
                                  coriolis, buoyancy, surface_waves, closure,
-                                 U, C, pHY′, K, F, parameters, clock) where FT
+                                 U, C, pHY′, K, F, clock) where FT
 
 Calculate `Gv` on north boundaries when the y-direction has `Bounded` topology.
 """
 function calculate_north_boundary_Gv!(G, arch, grid::AbstractGrid{FT, TX, <:Bounded},
                                       coriolis, buoyancy, surface_waves, closure,
-                                      U, C, pHY′, K, F, parameters, clock) where {FT, TX}
+                                      U, C, pHY′, K, F, clock) where {FT, TX}
 
     @launch(device(arch), config=launch_config(grid, :xz), 
             _calculate_north_boundary_Gv!(G.v, grid, coriolis, surface_waves, 
-                                          closure, U, C, K, F, pHY′, parameters, clock))
+                                          closure, U, C, K, F, pHY′, clock))
 
     return nothing
 end
@@ -101,17 +101,17 @@ end
 """
     calculate_top_boundary_Gw!(G, arch, grid::AbstractGrid{FT, <:Bounded},
                                coriolis, buoyancy, surface_waves, closure,
-                               U, C, pHY′, K, F, parameters, clock) where FT
+                               U, C, pHY′, K, F, clock) where FT
 
 Calculate `Gw` on top boundaries when the z-direction has `Bounded` topology.
 """
 function calculate_top_boundary_Gw!(G, arch, grid::AbstractGrid{FT, TX, TY, <:Bounded},
                                     coriolis, buoyancy, surface_waves, closure,
-                                    U, C, pHY′, K, F, parameters, clock) where {FT, TX, TY}
+                                    U, C, pHY′, K, F, clock) where {FT, TX, TY}
 
     @launch(device(arch), config=launch_config(grid, :xy), 
             _calculate_top_boundary_Gw!(G.w, grid, coriolis, surface_waves, 
-                                        closure, U, C, K, F, parameters, clock))
+                                        closure, U, C, K, F, clock))
 
     return nothing
 end
@@ -121,21 +121,21 @@ end
 #####
 
 """ Calculate the right-hand-side of the u-velocity equation. """
-function calculate_Gu!(Gu, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, clock)
+function calculate_Gu!(Gu, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, clock)
     @loop_xyz i j k grid begin
         @inbounds Gu[i, j, k] = u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, pHY′, parameters, clock)
+                                                    closure, U, C, K, F, pHY′, clock)
     end
     return nothing
 end
 
 """ Calculate the right-hand-side of the u-velocity equation on the east boundary. """
 function _calculate_east_boundary_Gu!(Gu, grid, coriolis, surface_waves,
-                                      closure, U, C, K, F, pHY′, parameters, clock)
+                                      closure, U, C, K, F, pHY′, clock)
     i = grid.Nx + 1
     @loop_yz j k grid begin
         @inbounds Gu[i, j, k] = u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, pHY′, parameters, clock)
+                                                    closure, U, C, K, F, pHY′, clock)
     end
     return nothing
 end
@@ -145,21 +145,21 @@ end
 #####
 
 """ Calculate the right-hand-side of the v-velocity equation. """
-function calculate_Gv!(Gv, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, parameters, clock)
+function calculate_Gv!(Gv, grid, coriolis, surface_waves, closure, U, C, K, F, pHY′, clock)
     @loop_xyz i j k grid begin
         @inbounds Gv[i, j, k] = v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, pHY′, parameters, clock)
+                                                    closure, U, C, K, F, pHY′, clock)
     end
     return nothing
 end
 
 """ Calculate the right-hand-side of the v-velocity equation on the north boundary. """
 function _calculate_north_boundary_Gv!(Gv, grid, coriolis, surface_waves,
-                                       closure, U, C, K, F, pHY′, parameters, clock)
+                                       closure, U, C, K, F, pHY′, clock)
     j = grid.Ny + 1
     @loop_xz i k grid begin
         @inbounds Gv[i, j, k] = v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, pHY′, parameters, clock)
+                                                    closure, U, C, K, F, pHY′, clock)
     end
     return nothing
 end
@@ -169,20 +169,20 @@ end
 #####
 
 """ Calculate the right-hand-side of the w-velocity equation. """
-function calculate_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, parameters, clock)
+function calculate_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, clock)
     @loop_xyz i j k grid begin
         @inbounds Gw[i, j, k] = w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, parameters, clock)
+                                                    closure, U, C, K, F, clock)
     end
     return nothing
 end
 
 """ Calculate the right-hand-side of the w-velocity equation. """
-function _calculate_top_boundary_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, parameters, clock)
+function _calculate_top_boundary_Gw!(Gw, grid, coriolis, surface_waves, closure, U, C, K, F, clock)
     k = grid.Nz + 1
     @loop_xy i j grid begin
         @inbounds Gw[i, j, k] = w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                                    closure, U, C, K, F, parameters, clock)
+                                                    closure, U, C, K, F, clock)
     end
     return nothing
 end
@@ -192,10 +192,10 @@ end
 #####
 
 """ Calculate the right-hand-side of the tracer advection-diffusion equation. """
-function calculate_Gc!(Gc, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc, parameters, clock)
+function calculate_Gc!(Gc, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc, clock)
     @loop_xyz i j k grid begin
         @inbounds Gc[i, j, k] = tracer_tendency(i, j, k, grid, c, tracer_index,
-                                                closure, buoyancy, U, C, K, Fc, parameters, clock)
+                                                closure, buoyancy, U, C, K, Fc, clock)
     end
     return nothing
 end

--- a/src/TimeSteppers/velocity_and_tracer_tendencies.jl
+++ b/src/TimeSteppers/velocity_and_tracer_tendencies.jl
@@ -1,6 +1,6 @@
 """
     u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, pHY′, parameters, clock)
+                        closure, U, C, K, F, pHY′, clock)
 
 Return the tendency for the horizontal velocity in the x-direction, or the east-west 
 direction, ``u``, at grid point `i, j, k`.
@@ -22,7 +22,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 and `clock` is the physical clock of the model.
 """
 @inline function u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, pHY′, parameters, clock)
+                                     closure, U, C, K, F, pHY′, clock)
 
     return ( - div_ũu(i, j, k, grid, U)
              - x_f_cross_U(i, j, k, grid, coriolis, U)
@@ -35,7 +35,7 @@ end
 
 """
     v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, pHY′, parameters, clock)
+                        closure, U, C, K, F, pHY′, clock)
 
 Return the tendency for the horizontal velocity in the y-direction, or the north-south 
 direction, ``v``, at grid point `i, j, k`.
@@ -57,7 +57,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 and `clock` is the physical clock of the model.
 """
 @inline function v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, pHY′, parameters, clock)
+                                     closure, U, C, K, F, pHY′, clock)
 
     return ( - div_ũv(i, j, k, grid, U)
              - y_f_cross_U(i, j, k, grid, coriolis, U)
@@ -70,7 +70,7 @@ end
 
 """
     w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, parameters, clock)
+                        closure, U, C, K, F, clock)
                         
 Return the tendency for the vertical velocity ``w`` at grid point `i, j, k`.
 The tendency for ``w`` is called ``G_w`` and defined via
@@ -90,7 +90,7 @@ forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 and `clock` is the physical clock of the model.
 """
 @inline function w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, parameters, clock)
+                                     closure, U, C, K, F, clock)
 
     return ( - div_ũw(i, j, k, grid, U)
              - z_f_cross_U(i, j, k, grid, coriolis, U)
@@ -101,8 +101,8 @@ and `clock` is the physical clock of the model.
 end
 
 """
-    tracer_tendency(i, j, k, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc,
-                    parameters, clock)
+    tracer_tendency(i, j, k, grid, c, tracer_index, 
+                    closure, buoyancy, U, C, K, Fc, clock)
 
 Return the tendency for a tracer field `c` with index `tracer_index` 
 at grid point `i, j, k`.
@@ -118,11 +118,10 @@ The arguments `U`, `C`, and `K` are `NamedTuple`s with the three velocity compon
 tracer fields, and  precalculated diffusivities where applicable. 
 `Fc` is the user-defined forcing function for tracer `c`.
 
-`parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
-and `clock` is the physical clock of the model.
+`clock` keeps track of `clock.time` and `clock.iteration`.
 """
 @inline function tracer_tendency(i, j, k, grid, c, tracer_index, 
-                                 closure, buoyancy, U, C, K, Fc, parameters, clock)
+                                 closure, buoyancy, U, C, K, Fc, clock)
 
     return ( - div_uc(i, j, k, grid, U, c)
              + ∇_κ_∇c(i, j, k, grid, closure, c, tracer_index, K, C, buoyancy)

--- a/src/TimeSteppers/velocity_and_tracer_tendencies.jl
+++ b/src/TimeSteppers/velocity_and_tracer_tendencies.jl
@@ -1,6 +1,6 @@
 """
     u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, pHY′, parameters, time)
+                        closure, U, C, K, F, pHY′, parameters, clock)
 
 Return the tendency for the horizontal velocity in the x-direction, or the east-west 
 direction, ``u``, at grid point `i, j, k`.
@@ -19,23 +19,23 @@ tracer fields, and precalculated diffusivities where applicable. `F` is a named 
 forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
-and `time` is the physical time of the model.
+and `clock` is the physical clock of the model.
 """
 @inline function u_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, pHY′, parameters, time)
+                                     closure, U, C, K, F, pHY′, parameters, clock)
 
     return ( - div_ũu(i, j, k, grid, U)
              - x_f_cross_U(i, j, k, grid, coriolis, U)
              - ∂xᶠᵃᵃ(i, j, k, grid, pHY′)
              + ∂ⱼ_2ν_Σ₁ⱼ(i, j, k, grid, closure, U, K)
-             + x_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-             + ∂t_uˢ(i, j, k, grid, surface_waves, time)
-             + F.u(i, j, k, grid, time, U, C, parameters))
+             + x_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, clock.time)
+             + ∂t_uˢ(i, j, k, grid, surface_waves, clock.time)
+             + F.u(i, j, k, grid, clock, (velocities=U, tracers=C, diffusivities=K)))
 end
 
 """
     v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, pHY′, parameters, time)
+                        closure, U, C, K, F, pHY′, parameters, clock)
 
 Return the tendency for the horizontal velocity in the y-direction, or the north-south 
 direction, ``v``, at grid point `i, j, k`.
@@ -54,23 +54,23 @@ tracer fields, and precalculated diffusivities where applicable. `F` is a named 
 forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
-and `time` is the physical time of the model.
+and `clock` is the physical clock of the model.
 """
 @inline function v_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, pHY′, parameters, time)
+                                     closure, U, C, K, F, pHY′, parameters, clock)
 
     return ( - div_ũv(i, j, k, grid, U)
              - y_f_cross_U(i, j, k, grid, coriolis, U)
              - ∂yᵃᶠᵃ(i, j, k, grid, pHY′)
              + ∂ⱼ_2ν_Σ₂ⱼ(i, j, k, grid, closure, U, K)
-             + y_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-             + ∂t_vˢ(i, j, k, grid, surface_waves, time)
-             + F.v(i, j, k, grid, time, U, C, parameters))
+             + y_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, clock.time)
+             + ∂t_vˢ(i, j, k, grid, surface_waves, clock.time)
+             + F.v(i, j, k, grid, clock, (velocities=U, tracers=C, diffusivities=K)))
 end
 
 """
     w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                        closure, U, C, K, F, parameters, time)
+                        closure, U, C, K, F, parameters, clock)
                         
 Return the tendency for the vertical velocity ``w`` at grid point `i, j, k`.
 The tendency for ``w`` is called ``G_w`` and defined via
@@ -87,22 +87,22 @@ tracer fields, and precalculated diffusivities where applicable. `F` is a named 
 forcing functions, `pHY′` is the hydrostatic pressure anomaly.
 
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
-and `time` is the physical time of the model.
+and `clock` is the physical clock of the model.
 """
 @inline function w_velocity_tendency(i, j, k, grid, coriolis, surface_waves, 
-                                     closure, U, C, K, F, parameters, time)
+                                     closure, U, C, K, F, parameters, clock)
 
     return ( - div_ũw(i, j, k, grid, U)
              - z_f_cross_U(i, j, k, grid, coriolis, U)
              + ∂ⱼ_2ν_Σ₃ⱼ(i, j, k, grid, closure, U, K)
-             + z_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, time)
-             + ∂t_wˢ(i, j, k, grid, surface_waves, time)
-             + F.w(i, j, k, grid, time, U, C, parameters))
+             + z_curl_Uˢ_cross_U(i, j, k, grid, surface_waves, U, clock.time)
+             + ∂t_wˢ(i, j, k, grid, surface_waves, clock.time)
+             + F.w(i, j, k, grid, clock, (velocities=U, tracers=C, diffusivities=K)))
 end
 
 """
     tracer_tendency(i, j, k, grid, c, tracer_index, closure, buoyancy, U, C, K, Fc,
-                    parameters, time)
+                    parameters, clock)
 
 Return the tendency for a tracer field `c` with index `tracer_index` 
 at grid point `i, j, k`.
@@ -119,12 +119,12 @@ tracer fields, and  precalculated diffusivities where applicable.
 `Fc` is the user-defined forcing function for tracer `c`.
 
 `parameters` is a `NamedTuple` of scalar parameters for user-defined forcing functions 
-and `time` is the physical time of the model.
+and `clock` is the physical clock of the model.
 """
 @inline function tracer_tendency(i, j, k, grid, c, tracer_index, 
-                                 closure, buoyancy, U, C, K, Fc, parameters, time)
+                                 closure, buoyancy, U, C, K, Fc, parameters, clock)
 
     return ( - div_uc(i, j, k, grid, U, c)
              + ∇_κ_∇c(i, j, k, grid, closure, c, tracer_index, K, C, buoyancy)
-             + Fc(i, j, k, grid, time, U, C, parameters))
+             + Fc(i, j, k, grid, clock, (velocities=U, tracers=C, diffusivities=K)))
 end

--- a/test/regression_tests/rayleigh_benard_regression_test.jl
+++ b/test/regression_tests/rayleigh_benard_regression_test.jl
@@ -27,7 +27,7 @@ function run_rayleigh_benard_regression_test(arch)
 
     # Force salinity as a passive tracer (βS=0)
     c★(x, z) = exp(4z) * sin(2π/Lx * x)
-    Fc(i, j, k, grid, time, U, C, params) = 1/10 * (c★(grid.xC[i], grid.zC[k]) - C.c[i, j, k])
+    Fc(i, j, k, grid, clock, state) = 1/10 * (c★(grid.xC[i], grid.zC[k]) - state.tracers.c[i, j, k])
 
     bbcs = TracerBoundaryConditions(grid,    top = BoundaryCondition(Value, 0.0),
                                           bottom = BoundaryCondition(Value, Δb))

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -214,11 +214,12 @@ function vertically_stretched_poisson_solver_correct_answer(arch, Nx, Ny, zF)
     interior(Rw) .= zeros(Nx, Ny, Nz)
 
     U = (u=Ru, v=Rv, w=Rw)
-    fill_halo_regions!(U, arch, 0, 0, datatuple(U))
+    state = (velocities=datatuple(U), tracers=(), diffusivities=nothing)
+    fill_halo_regions!(U, arch, nothing, state)
 
     _compute_w_from_continuity!(U, fake_grid)
 
-    fill_halo_regions!(Rw, arch, 0, 0, datatuple(U))
+    fill_halo_regions!(Rw, arch, nothing, state)
 
     R = zeros(Nx, Ny, Nz)
     for i in 1:Nx, j in 1:Ny, k in 1:Nz
@@ -249,7 +250,7 @@ function vertically_stretched_poisson_solver_correct_answer(arch, Nx, Ny, zF)
     ##### Compute Laplacian of solution ϕ to test that it's correct
     #####
 
-    fill_halo_regions!(ϕ, arch)
+    fill_halo_regions!(ϕ, arch, nothing, state)
 
     ∇²ϕ = CellField(Float64, arch, fake_grid, PressureBoundaryConditions(fake_grid))
     for i in 1:Nx, j in 1:Ny, k in 1:Nz

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -51,12 +51,13 @@ function compute_w_from_continuity(arch, FT)
     interior(U.u) .= rand(FT, Nx, Ny, Nz)
     interior(U.v) .= rand(FT, Nx, Ny, Nz)
 
-    fill_halo_regions!(U, arch, 0, 0, datatuple(U))
+    state = (velocities=datatuple(U), tracers=(), diffusivities=nothing)
+    fill_halo_regions!(U, arch, nothing, state)
 
     @launch(device(arch), config=launch_config(grid, :xy),
             _compute_w_from_continuity!((u=U.u.data, v=U.v.data, w=U.w.data), grid))
 
-    fill_halo_regions!(U, arch, 0, 0, datatuple(U))
+    fill_halo_regions!(U, arch, nothing, state)
     velocity_div!(grid, U.u.data, U.v.data, U.w.data, div_U.data)
 
     # Set div_U to zero at the top because the initial velocity field is not

--- a/test/test_turbulence_closures.jl
+++ b/test/test_turbulence_closures.jl
@@ -35,7 +35,8 @@ function test_constant_isotropic_diffusivity_fluxdiv(FT=Float64; ν=FT(0.3), κ=
         interior(T)[:, 1, k] .= [0, -1, 0]
     end
 
-    fill_halo_regions!(merge(velocities, tracers), arch, 0, 1, datatuple(velocities))
+    state = (velocities=datatuple(velocities), tracers=datatuple(tracers), diffusivities=nothing)
+    fill_halo_regions!(merge(velocities, tracers), arch, nothing, state)
 
     U, C = datatuples(velocities, tracers)
 
@@ -72,7 +73,8 @@ function test_anisotropic_diffusivity_fluxdiv(FT=Float64; νh=FT(0.3), κh=FT(0.
     interior(T)[:, 1, 3] .= [0, -4, 0]
     interior(T)[:, 1, 4] .= [0,  1, 0]
 
-    fill_halo_regions!(merge(velocities, tracers), arch, 0, 0, datatuple(velocities))
+    state = (velocities=datatuple(velocities), tracers=datatuple(tracers), diffusivities=nothing)
+    fill_halo_regions!(merge(velocities, tracers), arch, nothing, state)
 
     U, C = datatuples(velocities, tracers)
 

--- a/verification/stratified_couette_flow/stratified_couette_flow.jl
+++ b/verification/stratified_couette_flow/stratified_couette_flow.jl
@@ -47,7 +47,7 @@ end
 
 struct NusseltNumber{H, T}
     Tavg :: H
-    θ_wall :: T
+    Θ_wall :: T
 end
 
 """ Friction Reynolds number. See equation (20) of Vreugdenhil & Taylor (2018). """
@@ -58,15 +58,15 @@ function (Reτ::FrictionReynoldsNumber)(model)
 
     return h * uτ_top / ν, h * uτ_bottom / ν
 end
-
+ 
 """ Nusselt number. See equation (20) of Vreugdenhil & Taylor (2018). """
 function (Nu::NusseltNumber)(model)
     κ = model.closure.κ.T
     h = model.grid.Lz / 2
 
-    q_wall_top, q_wall_bottom = q_wall(model, Nu.Tavg, Nu.θ_wall)
+    q_wall_top, q_wall_bottom = q_wall(model, Nu.Tavg, Nu.Θ_wall)
 
-    return (q_wall_top * h)/(κ * Θ_wall), (q_wall_bottom * h)/(κ * Θ_wall)
+    return (q_wall_top * h)/(κ * Nu.Θ_wall), (q_wall_bottom * h)/(κ * Nu.Θ_wall)
 end
 
 """
@@ -214,7 +214,7 @@ function simulate_stratified_couette_flow(; Nxy, Nz, arch=GPU(), h=1, U_wall=1,
     #####
 
     Reτ = FrictionReynoldsNumber(Uavg, U_wall)
-     Nu = NusseltNumber(Tavg, θ_wall)
+     Nu = NusseltNumber(Tavg, Θ_wall)
 
     statistics = Dict(
         :Re_tau => model -> Reτ(model),


### PR DESCRIPTION
This PR simplifies the function signatures for boundary condition functions and forcing functions. 
It also nukes the `model.parameters` field in favor of more local "parameters" functionality, and adds `ParameterizedForcing` and `ParameterizedBoundaryCondition` convenience types and functions.

The new forcing function signature is

```julia
F(i, j, k, grid, clock, state)
```

while the new boundary condition function signature is

```julia
bc(i, j, grid, clock, state)
```

where `i, j` are indices along the boundary.

`state` is a `NamedTuple` with fields `:velocities`, `:tracers`, and `:diffusivities`, each corresponding to an `OffsetArray` that references the data associated with each field.

In the future, if we make substantial changes to `model`, the hope is that we can modify/extend `state` appropriately and thus leave user code unbroken.

We should probably release a new minor version when this is merged.

Resolves #682 .