### PR TITLE
Fix has_velocities

### DIFF
--- a/src/Fields/field_tuples.jl
+++ b/src/Fields/field_tuples.jl
@@ -99,6 +99,7 @@ TracerFields(arch, grid, empty_tracer_fields::NamedTuple{(),Tuple{}}, args...; k
 
 "Returns true if the first three elements of `names` are `(:u, :v, :w)`."
 has_velocities(names) = :u == names[1] && :v == names[2] && :w == names[3]
+has_velocities(::Tuple{}) = false
 
 tracernames(::Nothing) = ()
 tracernames(name::Symbol) = tuple(name)

--- a/test/test_fields.jl
+++ b/test/test_fields.jl
@@ -1,5 +1,5 @@
 """
-    test_init_field(N, L, ftf)
+    correct_field_size(N, L, ftf)
 
 Test that the field initialized by the field type function `ftf` on the grid g
 has the correct size.
@@ -7,7 +7,7 @@ has the correct size.
 correct_field_size(a, g, fieldtype, Tx, Ty, Tz) = size(parent(fieldtype(a, g)))  == (Tx, Ty, Tz)
     
 """
-    test_set_field(N, L, ftf, val)
+    correct_field_value_was_set(N, L, ftf, val)
 
 Test that the field initialized by the field type function `ftf` on the grid g
 can be correctly filled with the value `val` using the `set!(f::AbstractField, v)`
@@ -82,5 +82,11 @@ end
                 @test field.data[2, 4, 6] == A[2, 4, 6]
             end
         end
+    end
+
+    @testset "Miscellaneous field functionality" begin
+        @info "  Testing miscellaneous field functionality..."
+        @test Fields.has_velocities(()) == false
+        @test Fields.has_velocities((:u, :v, :w, :c)) == true
     end
 end


### PR DESCRIPTION
This PR adds a method that short circuits `has_velocities` when passed and empty tuple, which can happen for models with no tracers.

Resolves #700.