### PR TITLE
Update and test benchmarks

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -15,6 +15,12 @@ version = "1.0.1"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
+git-tree-sha1 = "9e62e66db34540a0c919d72172cc2f642ac71260"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.5.0"
+
 [[BinDeps]]
 deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
 git-tree-sha1 = "66158ad56b4bf6cc8413b37d0b7bc52402682764"
@@ -87,9 +93,9 @@ version = "1.7.3"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
+git-tree-sha1 = "73eb18320fe3ba58790c8b8f6f89420f0a622773"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.10"
+version = "0.17.11"
 
 [[Dates]]
 deps = ["Printf"]
@@ -107,9 +113,9 @@ version = "1.2.0"
 
 [[FFTW_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "ddb57f4cf125243b4aa4908c94d73a805f3cbf2c"
+git-tree-sha1 = "6c975cd606128d45d1df432fb812d6eb10fee00b"
 uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.9+4"
+version = "3.3.9+5"
 
 [[FileIO]]
 deps = ["Pkg"]
@@ -214,12 +220,12 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "0c16b3179190d3046c073440d94172cfc3bb0553"
+git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.12"
+version = "1.0.1"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/Project.toml
+++ b/Project.toml
@@ -37,10 +37,11 @@ julia = "^1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [targets]
-test = ["BenchmarkTools", "Plots", "Test", "TimerOutputs", "TimesDates"]
+test = ["BenchmarkTools", "InteractiveUtils", "Plots", "Test", "TimerOutputs", "TimesDates"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Adapt = "^1"
@@ -37,9 +36,11 @@ OrderedCollections = "^1.1"
 julia = "^1.3"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TimesDates = "bdfc003b-8df8-5c39-adcd-3a9087f5df4a"
 
 [targets]
-test = ["Test", "Plots", "TimesDates"]
+test = ["BenchmarkTools", "Plots", "Test", "TimerOutputs", "TimesDates"]

--- a/benchmark/benchmark_channel.jl
+++ b/benchmark/benchmark_channel.jl
@@ -1,4 +1,5 @@
-using TimerOutputs, Printf
+using Printf
+using TimerOutputs
 using Oceananigans
 
 include("benchmark_utils.jl")
@@ -9,8 +10,7 @@ include("benchmark_utils.jl")
 
 const timer = TimerOutput()
 
-Ni = 2  # Number of iterations before benchmarking starts.
-Nt = 5  # Number of iterations to use for benchmarking time stepping.
+Nt = 10  # Number of iterations to use for benchmarking time stepping.
 
 # Model resolutions to benchmarks. Focusing on 3D models for GPU benchmarking.
             Ns = [(32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]
@@ -23,27 +23,16 @@ Nt = 5  # Number of iterations to use for benchmarking time stepping.
 #####
 
 for arch in archs, FT in float_types, N in Ns
-    Nx, Ny, Nz = N
-    Lx, Ly, Lz = 250e3, 250e3, 1000
+	topology = (Periodic, Bounded, Bounded)
+	grid = RegularCartesianGrid(topology=topology, size=N, length=(1, 1, 1))
+    model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid)
 
-    model = ChannelModel(architecture = arch, float_type = FT,
-			 grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Lx, Lz)),
-			 closure = ConstantIsotropicDiffusivity(ν=1e-2, κ=1e-2))
-
-    # Eddying channel model setup.
-    Ty = 4e-5  # Meridional temperature gradient [K/m].
-    Tz = 2e-3  # Vertical temperature gradient [K/m].
-
-    # Initial temperature field [°C].
-    T₀(x, y, z) = 10 + Ty*y + Tz*z + 1e-4*randn()
-    set!(model; T=T₀)
-
-    time_step!(model, Ni, 1)  # First 1~2 iterations are usually slower.
+    time_step!(model, 1)  # precompile
 
     bname =  benchmark_name(N, "", arch, FT)
-    @printf("Running eddying channel benchmark: %s...\n", bname)
+    @printf("Running channel benchmark: %s...\n", bname)
     for i in 1:Nt
-        @timeit timer bname time_step!(model, 1, 1)
+        @timeit timer bname time_step!(model, 1)
     end
 end
 

--- a/benchmark/benchmark_static_ocean.jl
+++ b/benchmark/benchmark_static_ocean.jl
@@ -23,12 +23,10 @@ Nt = 10  # Number of iterations to use for benchmarking time stepping.
 #####
 
 for arch in archs, float_type in float_types, N in Ns
-    Nx, Ny, Nz = N
-    Lx, Ly, Lz = 1, 1, 1
-
-    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    grid = RegularCartesianGrid(size=N, length=(1, 1, 1))
     model = IncompressibleModel(architecture=arch, float_type=float_type, grid=grid)
-    time_step!(model, 1)
+
+    time_step!(model, 1)  # precompile
 
     bname =  benchmark_name(N, "", arch, float_type)
     @printf("Running static ocean benchmark: %s...\n", bname)

--- a/benchmark/benchmark_static_ocean.jl
+++ b/benchmark/benchmark_static_ocean.jl
@@ -22,13 +22,13 @@ Nt = 10  # Number of iterations to use for benchmarking time stepping.
 ##### Run benchmarks
 #####
 
-for arch in archs, float_type in float_types, N in Ns
+for arch in archs, FT in float_types, N in Ns
     grid = RegularCartesianGrid(size=N, length=(1, 1, 1))
-    model = IncompressibleModel(architecture=arch, float_type=float_type, grid=grid)
+    model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid)
 
     time_step!(model, 1)  # precompile
 
-    bname =  benchmark_name(N, "", arch, float_type)
+    bname =  benchmark_name(N, "", arch, FT)
     @printf("Running static ocean benchmark: %s...\n", bname)
     for i in 1:Nt
         @timeit timer bname time_step!(model, 1)

--- a/benchmark/benchmark_static_ocean.jl
+++ b/benchmark/benchmark_static_ocean.jl
@@ -1,4 +1,5 @@
-using Printf, TimerOutputs
+using Printf
+using TimerOutputs
 using Oceananigans
 
 include("benchmark_utils.jl")
@@ -9,7 +10,6 @@ include("benchmark_utils.jl")
 
 const timer = TimerOutput()
 
-Ni = 2   # Number of iterations before benchmarking starts.
 Nt = 10  # Number of iterations to use for benchmarking time stepping.
 
 # Model resolutions to benchmarks. Focusing on 3D models for GPU benchmarking.
@@ -26,7 +26,8 @@ for arch in archs, float_type in float_types, N in Ns
     Nx, Ny, Nz = N
     Lx, Ly, Lz = 1, 1, 1
 
-    model = IncompressibleModel(architecture=arch, float_type=float_type, grid=RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)))
+    grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz))
+    model = IncompressibleModel(architecture=arch, float_type=float_type, grid=grid)
     time_step!(model, 1)
 
     bname =  benchmark_name(N, "", arch, float_type)

--- a/benchmark/benchmark_tracers.jl
+++ b/benchmark/benchmark_tracers.jl
@@ -9,7 +9,6 @@ include("benchmark_utils.jl")
 
 const timer = TimerOutput()
 
-Ni = 2   # Number of iterations before benchmarking starts.
 Nt = 10  # Number of iterations to use for benchmarking time stepping.
 
          archs = [CPU()]             # Architectures to benchmark on.
@@ -34,6 +33,7 @@ passive_tracers(n) = [Symbol("C" * string(n)) for n in 1:n]
 
 tracer_list(na, np) = Tuple(vcat(active_tracers(na), passive_tracers(np)))
 
+""" Number of active tracers to buoyancy """
 function na2buoyancy(n)
     n == 0 && return nothing
     n == 1 && return BuoyancyTracer()
@@ -45,28 +45,24 @@ end
 ##### Run benchmarks
 #####
 
+# Each test case specifies (number of active tracers, number of passive tracers)
 test_cases = [(0, 0), (0, 1), (0, 2), (1, 0), (2, 0), (2, 3), (2, 5), (2, 10)]
 
 for arch in archs, test_case in test_cases
     N = Nxyz(arch)
-    Nx, Ny, Nz = N
-    Lx, Ly, Lz = 1, 1, 1
-
     na, np = test_case
     tracers = tracer_list(na, np)
 
+    grid = RegularCartesianGrid(size=N, length=(1, 1, 1))
+    model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid,
+                                buoyancy=na2buoyancy(na), tracers=tracers)
+
+    time_step!(model, 1)  # precompile
+
     bname =  benchmark_name(N, "$na active + $(lpad(np, 2)) passive", arch, FT)
     @printf("Running benchmark: %s...\n", bname)
-
-    model = Model(architecture = arch,
-                    float_type = FT,
-                          grid = RegularCartesianGrid(size=(Nx, Ny, Nz), length=(Lx, Ly, Lz)),
-                      buoyancy = na2buoyancy(na),
-                       tracers = tracers)
-    time_step!(model, Ni, 1)
-
     for i in 1:Nt
-        @timeit timer bname time_step!(model, 1, 1)
+        @timeit timer bname time_step!(model, 1)
     end
 end
 

--- a/benchmark/benchmark_utils.jl
+++ b/benchmark/benchmark_utils.jl
@@ -1,11 +1,11 @@
-import Pkg
+using InteractiveUtils
 
 using Oceananigans: @hascuda, AbstractArchitecture
 
 @hascuda using CUDAdrv
 
 function print_benchmark_info()
-    versioninfo()
+    InteractiveUtils.versioninfo(verbose=true)
     @hascuda begin
         dev = device(CuCurrentContext()) |> string
         gpu_name = split(dev, ":")[end] |> strip

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,5 +141,6 @@ with_logger(ModelLogger()) do
         include("test_regression.jl")
         include("test_examples.jl")
         include("test_verification.jl")
+        include("test_benchmarks.jl")
     end
 end

--- a/test/test_benchmarks.jl
+++ b/test/test_benchmarks.jl
@@ -1,0 +1,77 @@
+using BenchmarkTools
+
+const BENCHMARKS_DIR = "../benchmark/"
+cp(joinpath(BENCHMARKS_DIR, "benchmark_utils.jl"), joinpath(@__DIR__, "benchmark_utils.jl"), force=true)
+
+function run_benchmark(replace_strings, benchmark_name, module_suffix="")
+    benchmark_filepath = joinpath(BENCHMARKS_DIR, "benchmark_" * benchmark_name * ".jl")
+    txt = read(benchmark_filepath, String)
+
+    for strs in replace_strings
+        txt = replace(txt, strs[1] => strs[2])
+    end
+
+    test_script_filepath = benchmark_name * "_benchmark_test.jl"
+
+    open(test_script_filepath, "w") do f
+        write(f, "module Test_$benchmark_name" * "_$module_suffix\n")
+        write(f, txt)
+        write(f, "\nend # module")
+    end
+
+    try
+        include(test_script_filepath)
+    catch err
+        @error sprint(showerror, err)
+        rm(test_script_filepath)
+        return false
+    end
+
+    rm(test_script_filepath)
+    return true
+end
+
+@testset "Performance benchmarks" begin
+    @info "Testing performance benchmarks..."
+
+    @testset "Performance benchmark scripts" begin
+        @info "  Testing performance benchmark scripts..."
+
+        @testset "Static ocean benchmark" begin
+            @info "    Running static ocean benchmarks..."
+
+            replace_strings = [
+                ("Ns = [(32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]",
+                 "Ns = [(32, 32, 32)]")
+            ]
+
+            @test run_benchmark(replace_strings, "static_ocean")
+        end
+    end
+
+    @testset "Selected performance benchmarks" begin
+        @info "  Running selected performance benchmarks..."
+
+        for arch in archs, FT in float_types
+            if arch isa CPU
+                sizes = [(32, 32, 32), (64, 64, 64)]
+            elseif arch isa GPU
+                sizes = [(128, 128, 128), (256, 256, 256)]
+            end
+
+            for sz in sizes
+                grid = RegularCartesianGrid(size=sz, length=(1, 1, 1))
+                model = IncompressibleModel(architecture=arch, float_type=FT, grid=grid)
+
+                @info "Benchmarking [$arch, $FT, $sz]"
+                b = @benchmark time_step!($model, 1)
+                display(b)
+                println()
+
+                @test model isa IncompressibleModel
+            end
+        end
+    end
+end
+
+rm(joinpath(@__DIR__, "benchmark_utils.jl"))

--- a/test/test_benchmarks.jl
+++ b/test/test_benchmarks.jl
@@ -47,6 +47,39 @@ end
 
             @test run_benchmark(replace_strings, "static_ocean")
         end
+
+        @testset "Channel benchmark" begin
+            @info "    Running channel benchmarks..."
+
+            replace_strings = [
+                ("Ns = [(32, 32, 32), (64, 64, 64), (128, 128, 128), (256, 256, 256)]",
+                 "Ns = [(32, 32, 32)]")
+            ]
+
+            @test run_benchmark(replace_strings, "channel")
+        end
+
+        @testset "Turbulence closures benchmark" begin
+            @info "    Running turbulence closures benchmark..."
+
+            replace_strings = [
+                ("Ns = [(32, 32, 32), (128, 128, 128)]",
+                 "Ns = [(32, 32, 32)]")
+            ]
+
+            @test run_benchmark(replace_strings, "turbulence_closures")
+        end
+
+        @testset "Tracers benchmark" begin
+            @info "    Running tracers benchmark..."
+
+            replace_strings = [
+                ("test_cases = [(0, 0), (0, 1), (0, 2), (1, 0), (2, 0), (2, 3), (2, 5), (2, 10)]",
+                 "test_cases = [(0, 0), (2, 0), (2, 3)]")
+            ]
+
+            @test run_benchmark(replace_strings, "tracers")
+        end
     end
 
     @testset "Selected performance benchmarks" begin

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,4 +1,4 @@
-EXAMPLES_DIR = "../examples/"
+const EXAMPLES_DIR = "../examples/"
 
 function run_example(replace_strings, example_name, module_suffix="")
     example_filepath = joinpath(EXAMPLES_DIR, example_name * ".jl")


### PR DESCRIPTION
This PR is an attempt to take performance benchmarking more seriously by keeping benchmark scripts up to date and tested.

This will be nice so we can get an idea of whether performance has regressed by looking at build logs. More useful for looking at memory allocations as runtimes will vary depending on the CI server.

We can still run the benchmark scripts from the terminal or REPL, and reduced versions are run as part of the test suite.

This PR is just a start, I'm sure we'll tune this stuff as time goes on.