### PR TITLE
Bump to 0.27.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Oceananigans"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.27.1"
+version = "0.27.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
A bug was fixed in the `zeros` function that's needed for the computation of HorizontalAverages on the GPU. Because this bug fix is very important, we should bump to 0.27.2.